### PR TITLE
fix: Replace metadata grey box with collapsible "Article Metadata" de…

### DIFF
--- a/src/code_indexer/server/wiki/static/wiki.css
+++ b/src/code_indexer/server/wiki/static/wiki.css
@@ -362,65 +362,98 @@
 }
 
 /* -----------------------------------------------------------------------
-   Story #289: Article metadata panel
+   Story #289: Article metadata panel (collapsible)
    ----------------------------------------------------------------------- */
 .wiki-metadata-panel {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.4rem 0.75rem;
+    display: block;
     margin-bottom: 1rem;
-    background: var(--pico-secondary-background);
     border: 1px solid var(--pico-muted-border-color);
     border-radius: 4px;
+    background: var(--pico-secondary-background);
     font-size: 0.8rem;
     color: var(--pico-muted-color);
 }
 
-.metadata-field {
-    white-space: nowrap;
+.wiki-metadata-panel[open] > .metadata-summary {
+    border-bottom: 1px solid var(--pico-muted-border-color);
 }
 
-.metadata-badge {
-    display: inline-block;
-    padding: 0.15rem 0.5rem;
-    border-radius: 3px;
-    font-size: 0.75rem;
+.metadata-summary {
+    padding: 0.4rem 0.75rem;
+    cursor: pointer;
+    user-select: none;
     font-weight: 600;
-    text-transform: capitalize;
-    background: var(--pico-muted-border-color);
+    font-size: 0.8rem;
+    color: var(--pico-muted-color);
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+/* Custom triangle marker */
+.metadata-summary::before {
+    content: '';
+    display: inline-block;
+    width: 0;
+    height: 0;
+    border-left: 5px solid currentColor;
+    border-top: 4px solid transparent;
+    border-bottom: 4px solid transparent;
+    flex-shrink: 0;
+    transition: transform 0.15s ease;
+}
+
+.wiki-metadata-panel[open] > .metadata-summary::before {
+    transform: rotate(90deg);
+}
+
+/* Hide default browser marker */
+.metadata-summary::-webkit-details-marker {
+    display: none;
+}
+
+.metadata-summary::marker {
+    content: none;
+    display: none;
+}
+
+/* Override Pico's accordion chevron on summary::after */
+.metadata-summary::after {
+    display: none !important;
+    content: none !important;
+}
+
+.metadata-summary:hover {
     color: var(--pico-color);
 }
 
-.metadata-badge-published {
-    background: #d4edda;
-    color: #155724;
+.metadata-list {
+    margin: 0;
+    padding: 0.25rem 0.75rem 0.5rem;
 }
 
-.metadata-badge-internal {
-    background: #ffeeba;
-    color: #856404;
+.metadata-row {
+    display: flex;
+    align-items: center;
+    padding: 0.25rem 0;
 }
 
-.metadata-badge-draft {
-    background: #e2e3e5;
-    color: #383d41;
+.metadata-row + .metadata-row {
+    border-top: 1px solid color-mix(in srgb, var(--pico-muted-border-color) 50%, transparent);
 }
 
-[data-theme="dark"] .metadata-badge-published {
-    background: #1a3a24;
-    color: #75c98b;
+.metadata-row dt {
+    width: 12rem;
+    flex-shrink: 0;
+    font-weight: 600;
+    color: var(--pico-muted-color);
+    margin: 0;
 }
 
-[data-theme="dark"] .metadata-badge-internal {
-    background: #3d2e00;
-    color: #f0b429;
-}
-
-[data-theme="dark"] .metadata-badge-draft {
-    background: #2e2e2e;
-    color: #adb5bd;
+.metadata-row dd {
+    margin: 0;
+    color: var(--pico-color);
 }
 
 [data-theme="light"] .wiki-metadata-panel {
@@ -429,12 +462,11 @@
     border-color: #dee2e6;
 }
 
-[data-theme="light"] .metadata-field {
-    color: #495057;
+[data-theme="light"] .metadata-row dt {
+    color: #6c757d;
 }
 
-[data-theme="light"] .metadata-badge {
-    background: #dee2e6;
+[data-theme="light"] .metadata-row dd {
     color: #333;
 }
 

--- a/src/code_indexer/server/wiki/templates/article.html
+++ b/src/code_indexer/server/wiki/templates/article.html
@@ -83,29 +83,17 @@
         <div class="wiki-content">
             <h1>{{ title }}</h1>
             {% if metadata_panel %}
-            <div class="wiki-metadata-panel">
-                {% if metadata_panel.article_number %}
-                <span class="metadata-field">Article #{{ metadata_panel.article_number }}</span>
-                {% endif %}
-                {% if metadata_panel.publication_status %}
-                <span class="metadata-badge">{{ metadata_panel.publication_status }}</span>
-                {% endif %}
-                {% if metadata_panel.created %}
-                <span class="metadata-field">Created: {{ metadata_panel.created }}</span>
-                {% endif %}
-                {% if metadata_panel.modified %}
-                <span class="metadata-field">Modified: {{ metadata_panel.modified }}</span>
-                {% endif %}
-                {% if metadata_panel.real_views is defined %}
-                <span class="metadata-field">Views: {{ metadata_panel.real_views }}</span>
-                {% endif %}
-                {% if metadata_panel.visibility %}
-                <span class="metadata-badge {{ metadata_panel.visibility_class }}">{{ metadata_panel.visibility }}</span>
-                {% endif %}
-                {% if metadata_panel.category %}
-                <span class="metadata-field">Category: {{ metadata_panel.category }}</span>
-                {% endif %}
-            </div>
+            <details class="wiki-metadata-panel">
+                <summary class="metadata-summary">Article Metadata</summary>
+                <dl class="metadata-list">
+                    {% for label, value in metadata_panel %}
+                    <div class="metadata-row">
+                        <dt>{{ label }}</dt>
+                        <dd>{{ value }}</dd>
+                    </div>
+                    {% endfor %}
+                </dl>
+            </details>
             {% endif %}
             {{ content | safe }}
         </div>

--- a/src/code_indexer/server/wiki/wiki_service.py
+++ b/src/code_indexer/server/wiki/wiki_service.py
@@ -12,18 +12,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _visibility_badge_class(visibility: str) -> str:
-    """Return CSS class string for a visibility badge."""
-    v = visibility.lower().strip()
-    if v in ("public", "published"):
-        return "metadata-badge metadata-badge-published"
-    if v == "internal":
-        return "metadata-badge metadata-badge-internal"
-    if v == "draft":
-        return "metadata-badge metadata-badge-draft"
-    return "metadata-badge"
-
-
 class WikiService:
     """Renders markdown articles with front matter parsing and image path rewriting."""
 
@@ -48,9 +36,7 @@ class WikiService:
             logger.warning("Failed to parse front matter, treating as plain content")
             return {}, content
 
-    def _strip_header_block(
-        self, content: str, metadata: Dict[str, Any] = None
-    ) -> str:
+    def _strip_header_block(self, content: str, metadata: Dict[str, Any] = None) -> str:
         """Strip structured header block fields (Article Number/Title/Status) from body.
 
         Summary is preserved in the body. Extracted values are merged into metadata
@@ -182,8 +168,36 @@ class WikiService:
             parsed = datetime.strptime(date_part, "%Y-%m-%d")
             return parsed.strftime("%B %-d, %Y")
         except ValueError:
-            logger.warning("format_date_human_readable: cannot parse date %r", date_value)
+            logger.warning(
+                "format_date_human_readable: cannot parse date %r", date_value
+            )
             return None
+
+    # Keys to exclude from the metadata panel (internal / non-display fields)
+    _METADATA_SKIP_KEYS = frozenset(
+        {
+            "visibility_class",
+        }
+    )
+
+    # Human-friendly labels for well-known frontmatter keys
+    _METADATA_LABELS: Dict[str, str] = {
+        "original_article": "Salesforce Article",
+        "article_number": "Salesforce Article",
+        "publication_status": "Status",
+        "created": "Created",
+        "modified": "Modified",
+        "updated": "Modified",
+        "views": "Salesforce Views",
+        "real_views": "Views",
+        "visibility": "Visibility",
+        "category": "Category",
+        "draft": "Draft",
+        "title": "Title",
+        "author": "Author",
+        "tags": "Tags",
+        "description": "Description",
+    }
 
     def prepare_metadata_context(
         self,
@@ -191,59 +205,70 @@ class WikiService:
         repo_alias: str,
         article_path: str,
         wiki_cache: "WikiCache",
-    ) -> Dict[str, Any]:
-        """Prepare template context dict for the metadata panel (Story #289).
+    ) -> List[tuple]:
+        """Prepare template context for the metadata panel (Story #289).
 
-        Returns an empty dict when no displayable fields are available, which
-        signals to the template not to render the panel (AC5).
+        Returns a list of (label, value) tuples for display.  An empty list
+        signals to the template not to render the panel.
         """
-        ctx: Dict[str, Any] = {}
+        # Build a working dict of all displayable fields
+        fields: Dict[str, Any] = {}
 
-        # real_views from DB — always authoritative (AC2)
+        # Copy all frontmatter keys
+        for key, value in metadata.items():
+            if key in self._METADATA_SKIP_KEYS:
+                continue
+            fields[key] = value
+
+        # Normalise 'updated' → 'modified'
+        if "updated" in fields and "modified" not in fields:
+            fields["modified"] = fields.pop("updated")
+        elif "updated" in fields:
+            del fields["updated"]
+
+        # Normalise 'original_article' → 'article_number'
+        if "original_article" in fields and "article_number" not in fields:
+            fields["article_number"] = fields.pop("original_article")
+        elif "original_article" in fields:
+            del fields["original_article"]
+
+        # Draft flag → visibility
+        if fields.get("draft") is True:
+            fields["visibility"] = "draft"
+        fields.pop("draft", None)
+
+        # Format date fields
+        for date_key in ("created", "modified"):
+            if date_key in fields and fields[date_key] is not None:
+                formatted = self.format_date_human_readable(fields[date_key])
+                if formatted:
+                    fields[date_key] = formatted
+                else:
+                    del fields[date_key]
+
+        # Add view count from DB
         real_views = wiki_cache.get_view_count(repo_alias, article_path)
         if real_views > 0:
-            ctx["real_views"] = real_views
+            fields["real_views"] = real_views
 
-        # Created date (AC3)
-        created = metadata.get("created")
-        if created is not None:
-            formatted = self.format_date_human_readable(created)
-            if formatted:
-                ctx["created"] = formatted
+        # Build (label, value) list — strip empty values
+        # Article number always first
+        result: List[tuple] = []
+        if "article_number" in fields:
+            val = str(fields.pop("article_number")).strip()
+            if val:
+                result.append(
+                    (self._METADATA_LABELS.get("article_number", "Article"), val)
+                )
 
-        # Modified date — also accepts 'updated' as synonym (AC3)
-        modified_raw = metadata.get("modified") or metadata.get("updated")
-        if modified_raw is not None:
-            formatted = self.format_date_human_readable(modified_raw)
-            if formatted:
-                ctx["modified"] = formatted
+        for key, value in fields.items():
+            str_value = str(value).strip() if value is not None else ""
+            if not str_value:
+                continue
+            label = self._METADATA_LABELS.get(key, key.replace("_", " ").title())
+            result.append((label, str_value))
 
-        # Visibility / draft flags (AC4)
-        visibility: Optional[str] = metadata.get("visibility")  # type: ignore[assignment]
-        if metadata.get("draft") is True:
-            visibility = "draft"
-        if visibility:
-            ctx["visibility"] = str(visibility)
-            ctx["visibility_class"] = _visibility_badge_class(str(visibility))
-
-        # Category (AC4)
-        raw_category = metadata.get("category")
-        if raw_category is not None:
-            category = str(raw_category).strip()
-            if category:
-                ctx["category"] = category
-
-        # Article number (from YAML 'original_article' or legacy header 'article_number')
-        article_number = metadata.get("original_article") or metadata.get("article_number")
-        if article_number:
-            ctx["article_number"] = str(article_number).strip()
-
-        # Publication status (from legacy header extraction by _strip_header_block)
-        pub_status = metadata.get("publication_status")
-        if pub_status:
-            ctx["publication_status"] = str(pub_status).strip()
-
-        return ctx
+        return result
 
     # ------------------------------------------------------------------
     # Story #282: Sidebar navigation, link rewriting, breadcrumbs
@@ -343,7 +368,7 @@ class WikiService:
             return crumbs
         parts = article_path.split("/")
         for i, part in enumerate(parts[:-1]):
-            url = f"/wiki/{repo_alias}/{'/'.join(parts[:i + 1])}/"
+            url = f"/wiki/{repo_alias}/{'/'.join(parts[: i + 1])}/"
             crumbs.append({"label": part, "url": url})
         last = parts[-1].replace("-", " ").replace("_", " ").title()
         crumbs.append({"label": last, "url": None})

--- a/tests/unit/server/wiki/test_wiki_metadata_panel.py
+++ b/tests/unit/server/wiki/test_wiki_metadata_panel.py
@@ -7,6 +7,7 @@ Covers:
  - WikiCache metadata_json storage/retrieval
  - Route integration: metadata panel rendered in article.html
 """
+
 import json
 import os
 import sqlite3
@@ -59,6 +60,7 @@ def _make_user(username):
 def _make_app(actual_repo_path, db_path, authenticated_user=None):
     """Build a FastAPI test app with wiki router and minimal app state."""
     from code_indexer.server.wiki.routes import _reset_wiki_cache
+
     _reset_wiki_cache()
 
     app = FastAPI()
@@ -142,7 +144,10 @@ class TestFormatDateHumanReadable:
 
 
 class TestPrepareMetadataContext:
-    """Tests for WikiService.prepare_metadata_context()."""
+    """Tests for WikiService.prepare_metadata_context().
+
+    Returns a list of (label, value) tuples for template rendering.
+    """
 
     def setup_method(self):
         self.service = WikiService()
@@ -153,115 +158,151 @@ class TestPrepareMetadataContext:
         cache.get_view_count.return_value = view_count
         return cache
 
+    @staticmethod
+    def _as_dict(pairs):
+        """Convert list of (label, value) tuples to dict for easier assertion."""
+        return dict(pairs)
+
     def test_returns_real_views_when_greater_than_zero(self):
-        """real_views > 0 -> context includes 'real_views' key."""
+        """real_views > 0 -> result includes 'Views' label."""
         cache = self._make_cache(view_count=42)
-        ctx = self.service.prepare_metadata_context({}, "repo1", "article", cache)
-        assert ctx.get("real_views") == 42
+        result = self.service.prepare_metadata_context({}, "repo1", "article", cache)
+        d = self._as_dict(result)
+        assert d.get("Views") == "42"
 
     def test_omits_real_views_when_zero(self):
-        """real_views == 0 -> 'real_views' key not in context."""
+        """real_views == 0 -> 'Views' label not in result."""
         cache = self._make_cache(view_count=0)
-        ctx = self.service.prepare_metadata_context({}, "repo1", "article", cache)
-        assert "real_views" not in ctx
+        result = self.service.prepare_metadata_context({}, "repo1", "article", cache)
+        d = self._as_dict(result)
+        assert "Views" not in d
 
     def test_includes_created_date_when_present(self):
-        """metadata with 'created' field -> context has formatted 'created'."""
+        """metadata with 'created' field -> result has formatted 'Created'."""
         cache = self._make_cache(view_count=0)
         metadata = {"created": "2024-03-15"}
-        ctx = self.service.prepare_metadata_context(metadata, "repo1", "article", cache)
-        assert ctx.get("created") == "March 15, 2024"
+        result = self.service.prepare_metadata_context(
+            metadata, "repo1", "article", cache
+        )
+        d = self._as_dict(result)
+        assert d.get("Created") == "March 15, 2024"
 
     def test_omits_created_when_missing(self):
-        """metadata without 'created' -> 'created' not in context."""
+        """metadata without 'created' -> 'Created' not in result."""
         cache = self._make_cache(view_count=0)
-        ctx = self.service.prepare_metadata_context({}, "repo1", "article", cache)
-        assert "created" not in ctx
+        result = self.service.prepare_metadata_context({}, "repo1", "article", cache)
+        d = self._as_dict(result)
+        assert "Created" not in d
 
     def test_includes_modified_date_when_present(self):
-        """metadata with 'modified' -> context has formatted 'modified'."""
+        """metadata with 'modified' -> result has formatted 'Modified'."""
         cache = self._make_cache(view_count=0)
         metadata = {"modified": "2024-06-01"}
-        ctx = self.service.prepare_metadata_context(metadata, "repo1", "article", cache)
-        assert ctx.get("modified") == "June 1, 2024"
+        result = self.service.prepare_metadata_context(
+            metadata, "repo1", "article", cache
+        )
+        d = self._as_dict(result)
+        assert d.get("Modified") == "June 1, 2024"
 
     def test_modified_also_reads_updated_key(self):
-        """metadata with 'updated' (synonym for modified) -> context has 'modified'."""
+        """metadata with 'updated' (synonym for modified) -> result has 'Modified'."""
         cache = self._make_cache(view_count=0)
         metadata = {"updated": "2024-06-01"}
-        ctx = self.service.prepare_metadata_context(metadata, "repo1", "article", cache)
-        assert ctx.get("modified") == "June 1, 2024"
+        result = self.service.prepare_metadata_context(
+            metadata, "repo1", "article", cache
+        )
+        d = self._as_dict(result)
+        assert d.get("Modified") == "June 1, 2024"
 
     def test_omits_modified_when_missing(self):
-        """metadata without 'modified' or 'updated' -> 'modified' not in context."""
+        """metadata without 'modified' or 'updated' -> 'Modified' not in result."""
         cache = self._make_cache(view_count=0)
-        ctx = self.service.prepare_metadata_context({}, "repo1", "article", cache)
-        assert "modified" not in ctx
+        result = self.service.prepare_metadata_context({}, "repo1", "article", cache)
+        d = self._as_dict(result)
+        assert "Modified" not in d
 
     def test_includes_visibility_when_present(self):
-        """metadata with 'visibility' -> context has 'visibility' and 'visibility_class'."""
+        """metadata with 'visibility' -> result has 'Visibility' label."""
         cache = self._make_cache(view_count=0)
         metadata = {"visibility": "public"}
-        ctx = self.service.prepare_metadata_context(metadata, "repo1", "article", cache)
-        assert ctx.get("visibility") == "public"
-        assert "visibility_class" in ctx
+        result = self.service.prepare_metadata_context(
+            metadata, "repo1", "article", cache
+        )
+        d = self._as_dict(result)
+        assert d.get("Visibility") == "public"
 
     def test_draft_true_overrides_visibility(self):
-        """metadata with draft=True -> visibility becomes 'draft' regardless of visibility field."""
+        """metadata with draft=True -> visibility becomes 'draft'."""
         cache = self._make_cache(view_count=0)
         metadata = {"visibility": "public", "draft": True}
-        ctx = self.service.prepare_metadata_context(metadata, "repo1", "article", cache)
-        assert ctx.get("visibility") == "draft"
+        result = self.service.prepare_metadata_context(
+            metadata, "repo1", "article", cache
+        )
+        d = self._as_dict(result)
+        assert d.get("Visibility") == "draft"
 
     def test_omits_visibility_when_missing(self):
-        """metadata without visibility/draft/status -> 'visibility' not in context."""
+        """metadata without visibility/draft -> 'Visibility' not in result."""
         cache = self._make_cache(view_count=0)
-        ctx = self.service.prepare_metadata_context({}, "repo1", "article", cache)
-        assert "visibility" not in ctx
-        assert "visibility_class" not in ctx
+        result = self.service.prepare_metadata_context({}, "repo1", "article", cache)
+        d = self._as_dict(result)
+        assert "Visibility" not in d
 
-    def test_visibility_class_published_contains_published(self):
-        """visibility='published' -> visibility_class contains 'published'."""
+    def test_visibility_published_value(self):
+        """visibility='published' -> value is 'published'."""
         cache = self._make_cache(view_count=0)
         metadata = {"visibility": "published"}
-        ctx = self.service.prepare_metadata_context(metadata, "repo1", "article", cache)
-        assert "published" in ctx.get("visibility_class", "")
+        result = self.service.prepare_metadata_context(
+            metadata, "repo1", "article", cache
+        )
+        d = self._as_dict(result)
+        assert d.get("Visibility") == "published"
 
-    def test_visibility_class_internal_contains_internal(self):
-        """visibility='internal' -> visibility_class contains 'internal'."""
+    def test_visibility_internal_value(self):
+        """visibility='internal' -> value is 'internal'."""
         cache = self._make_cache(view_count=0)
         metadata = {"visibility": "internal"}
-        ctx = self.service.prepare_metadata_context(metadata, "repo1", "article", cache)
-        assert "internal" in ctx.get("visibility_class", "")
+        result = self.service.prepare_metadata_context(
+            metadata, "repo1", "article", cache
+        )
+        d = self._as_dict(result)
+        assert d.get("Visibility") == "internal"
 
-    def test_visibility_class_draft_contains_draft(self):
-        """draft=True -> visibility_class contains 'draft'."""
+    def test_draft_true_sets_visibility_draft(self):
+        """draft=True -> Visibility value is 'draft'."""
         cache = self._make_cache(view_count=0)
         metadata = {"draft": True}
-        ctx = self.service.prepare_metadata_context(metadata, "repo1", "article", cache)
-        assert "draft" in ctx.get("visibility_class", "")
+        result = self.service.prepare_metadata_context(
+            metadata, "repo1", "article", cache
+        )
+        d = self._as_dict(result)
+        assert d.get("Visibility") == "draft"
 
     def test_includes_category_when_present(self):
-        """metadata with 'category' -> context has 'category'."""
+        """metadata with 'category' -> result has 'Category' label."""
         cache = self._make_cache(view_count=0)
         metadata = {"category": "Operations"}
-        ctx = self.service.prepare_metadata_context(metadata, "repo1", "article", cache)
-        assert ctx.get("category") == "Operations"
+        result = self.service.prepare_metadata_context(
+            metadata, "repo1", "article", cache
+        )
+        d = self._as_dict(result)
+        assert d.get("Category") == "Operations"
 
     def test_omits_category_when_missing(self):
-        """metadata without 'category' -> 'category' not in context."""
+        """metadata without 'category' -> 'Category' not in result."""
         cache = self._make_cache(view_count=0)
-        ctx = self.service.prepare_metadata_context({}, "repo1", "article", cache)
-        assert "category" not in ctx
+        result = self.service.prepare_metadata_context({}, "repo1", "article", cache)
+        d = self._as_dict(result)
+        assert "Category" not in d
 
-    def test_empty_context_when_all_fields_missing_and_zero_views(self):
-        """No metadata and 0 views -> empty context dict."""
+    def test_empty_list_when_all_fields_missing_and_zero_views(self):
+        """No metadata and 0 views -> empty list."""
         cache = self._make_cache(view_count=0)
-        ctx = self.service.prepare_metadata_context({}, "repo1", "article", cache)
-        assert ctx == {}
+        result = self.service.prepare_metadata_context({}, "repo1", "article", cache)
+        assert result == []
 
     def test_full_metadata_produces_all_fields(self):
-        """All metadata fields present + views -> all context fields populated."""
+        """All metadata fields present + views -> all labels populated."""
         cache = self._make_cache(view_count=15)
         metadata = {
             "created": "2024-01-01",
@@ -269,13 +310,15 @@ class TestPrepareMetadataContext:
             "visibility": "public",
             "category": "Guides",
         }
-        ctx = self.service.prepare_metadata_context(metadata, "repo1", "article", cache)
-        assert "real_views" in ctx
-        assert "created" in ctx
-        assert "modified" in ctx
-        assert "visibility" in ctx
-        assert "visibility_class" in ctx
-        assert "category" in ctx
+        result = self.service.prepare_metadata_context(
+            metadata, "repo1", "article", cache
+        )
+        d = self._as_dict(result)
+        assert "Views" in d
+        assert "Created" in d
+        assert "Modified" in d
+        assert "Visibility" in d
+        assert "Category" in d
 
 
 # ---------------------------------------------------------------------------
@@ -290,10 +333,7 @@ class TestWikiCacheMetadataJson:
         """wiki_cache table must have a metadata_json column after ensure_tables()."""
         cache, db_path = cache_db
         conn = sqlite3.connect(db_path)
-        cols = {
-            r[1]
-            for r in conn.execute("PRAGMA table_info(wiki_cache)").fetchall()
-        }
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(wiki_cache)").fetchall()}
         conn.close()
         assert "metadata_json" in cols
 
@@ -304,7 +344,9 @@ class TestWikiCacheMetadataJson:
         md_file.write_text("# Article\nContent")
         metadata = {"created": "2024-01-01", "visibility": "public"}
 
-        cache.put_article("repo1", "article", "<p>Content</p>", "Article", md_file, metadata=metadata)
+        cache.put_article(
+            "repo1", "article", "<p>Content</p>", "Article", md_file, metadata=metadata
+        )
 
         conn = sqlite3.connect(db_path)
         row = conn.execute(
@@ -318,7 +360,9 @@ class TestWikiCacheMetadataJson:
         assert stored.get("created") == "2024-01-01"
         assert stored.get("visibility") == "public"
 
-    def test_put_article_stores_null_metadata_when_not_provided(self, cache_db, repo_dir):
+    def test_put_article_stores_null_metadata_when_not_provided(
+        self, cache_db, repo_dir
+    ):
         """put_article() without metadata arg stores NULL metadata_json."""
         cache, db_path = cache_db
         md_file = repo_dir / "article.md"
@@ -342,14 +386,18 @@ class TestWikiCacheMetadataJson:
         md_file.write_text("# Article\nContent")
         metadata = {"created": "2024-03-15"}
 
-        cache.put_article("repo1", "article", "<p>Content</p>", "Article", md_file, metadata=metadata)
+        cache.put_article(
+            "repo1", "article", "<p>Content</p>", "Article", md_file, metadata=metadata
+        )
         result = cache.get_article("repo1", "article", md_file)
 
         assert result is not None
         assert "metadata" in result
         assert result["metadata"].get("created") == "2024-03-15"
 
-    def test_get_article_returns_none_metadata_when_not_stored(self, cache_db, repo_dir):
+    def test_get_article_returns_none_metadata_when_not_stored(
+        self, cache_db, repo_dir
+    ):
         """get_article() returns dict with metadata=None when no metadata was stored."""
         cache, _ = cache_db
         md_file = repo_dir / "article.md"
@@ -387,7 +435,9 @@ class TestMetadataPanelRouteIntegration:
                     "Content here."
                 )
                 (repo_dir / "article.md").write_text(md_content)
-                app = _make_app(str(repo_dir), db_path, authenticated_user=_make_user("alice"))
+                app = _make_app(
+                    str(repo_dir), db_path, authenticated_user=_make_user("alice")
+                )
                 client = TestClient(app)
 
                 resp = client.get("/wiki/test-repo/article")
@@ -407,13 +457,7 @@ class TestMetadataPanelRouteIntegration:
             try:
                 repo_dir = Path(tmpdir)
                 # front matter has views=999 but DB will have the real count
-                md_content = (
-                    "---\n"
-                    "title: Popular\n"
-                    "views: 999\n"
-                    "---\n"
-                    "# Popular\nContent."
-                )
+                md_content = "---\ntitle: Popular\nviews: 999\n---\n# Popular\nContent."
                 (repo_dir / "popular.md").write_text(md_content)
 
                 # Pre-seed DB with 7 real views
@@ -422,15 +466,17 @@ class TestMetadataPanelRouteIntegration:
                 for _ in range(7):
                     cache.increment_view("test-repo", "popular")
 
-                app = _make_app(str(repo_dir), db_path, authenticated_user=_make_user("alice"))
+                app = _make_app(
+                    str(repo_dir), db_path, authenticated_user=_make_user("alice")
+                )
                 client = TestClient(app)
 
                 resp = client.get("/wiki/test-repo/popular")
                 assert resp.status_code == 200
-                # The metadata panel must show "Views:" (DB-driven)
-                assert "Views:" in resp.text
+                # The metadata panel must show Views (DB-driven)
+                assert ">Views<" in resp.text
                 # The front matter raw value 999 must NOT appear as the view count
-                assert "Views: 999" not in resp.text
+                assert ">999<" not in resp.text
             finally:
                 try:
                     os.unlink(db_path)
@@ -438,25 +484,26 @@ class TestMetadataPanelRouteIntegration:
                     pass
 
     def test_article_page_shows_views_only_when_no_front_matter(self):
-        """Article with no front matter -> metadata panel shows Views: 1 (route increments view before render)."""
+        """Article with no front matter -> metadata panel shows Views (route increments view before render)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             fd, db_path = tempfile.mkstemp(suffix=".db")
             os.close(fd)
             try:
                 repo_dir = Path(tmpdir)
                 (repo_dir / "plain.md").write_text("# Plain\nNo front matter.")
-                app = _make_app(str(repo_dir), db_path, authenticated_user=_make_user("alice"))
+                app = _make_app(
+                    str(repo_dir), db_path, authenticated_user=_make_user("alice")
+                )
                 client = TestClient(app)
 
                 resp = client.get("/wiki/test-repo/plain")
                 assert resp.status_code == 200
                 # Route increments view before rendering, so real_views >= 1 -> panel is shown
                 assert "wiki-metadata-panel" in resp.text
-                assert "Views: 1" in resp.text
+                assert ">Views<" in resp.text
                 # No front matter fields should be present
-                assert "Created:" not in resp.text
-                assert "Modified:" not in resp.text
-                assert "metadata-badge" not in resp.text
+                assert "Created" not in resp.text
+                assert "Modified" not in resp.text
             finally:
                 try:
                     os.unlink(db_path)
@@ -471,14 +518,12 @@ class TestMetadataPanelRouteIntegration:
             try:
                 repo_dir = Path(tmpdir)
                 md_content = (
-                    "---\n"
-                    "title: Cached\n"
-                    "created: '2024-05-10'\n"
-                    "---\n"
-                    "# Cached\nContent."
+                    "---\ntitle: Cached\ncreated: '2024-05-10'\n---\n# Cached\nContent."
                 )
                 (repo_dir / "cached.md").write_text(md_content)
-                app = _make_app(str(repo_dir), db_path, authenticated_user=_make_user("alice"))
+                app = _make_app(
+                    str(repo_dir), db_path, authenticated_user=_make_user("alice")
+                )
                 client = TestClient(app)
 
                 # First request populates cache
@@ -503,14 +548,12 @@ class TestMetadataPanelRouteIntegration:
             try:
                 repo_dir = Path(tmpdir)
                 md_content = (
-                    "---\n"
-                    "title: Dated\n"
-                    "created: '2024-03-15'\n"
-                    "---\n"
-                    "# Dated\nContent."
+                    "---\ntitle: Dated\ncreated: '2024-03-15'\n---\n# Dated\nContent."
                 )
                 (repo_dir / "dated.md").write_text(md_content)
-                app = _make_app(str(repo_dir), db_path, authenticated_user=_make_user("alice"))
+                app = _make_app(
+                    str(repo_dir), db_path, authenticated_user=_make_user("alice")
+                )
                 client = TestClient(app)
 
                 resp = client.get("/wiki/test-repo/dated")
@@ -522,8 +565,8 @@ class TestMetadataPanelRouteIntegration:
                 except OSError:
                     pass
 
-    def test_article_page_shows_visibility_badge(self):
-        """Article with visibility='public' -> badge with 'public' class visible in HTML."""
+    def test_article_page_shows_visibility_value(self):
+        """Article with visibility='public' -> 'public' visible in HTML."""
         with tempfile.TemporaryDirectory() as tmpdir:
             fd, db_path = tempfile.mkstemp(suffix=".db")
             os.close(fd)
@@ -537,12 +580,13 @@ class TestMetadataPanelRouteIntegration:
                     "# Public\nContent."
                 )
                 (repo_dir / "pub.md").write_text(md_content)
-                app = _make_app(str(repo_dir), db_path, authenticated_user=_make_user("alice"))
+                app = _make_app(
+                    str(repo_dir), db_path, authenticated_user=_make_user("alice")
+                )
                 client = TestClient(app)
 
                 resp = client.get("/wiki/test-repo/pub")
                 assert resp.status_code == 200
-                assert "metadata-badge" in resp.text
                 assert "public" in resp.text
             finally:
                 try:


### PR DESCRIPTION
…tails panel

Frontmatter metadata now renders as a collapsible <details> section with a disclosure triangle instead of a flat grey box. All frontmatter keys are displayed as Key: Value pairs without per-field conditionals. Salesforce-origin fields use dedicated labels (Salesforce Article, Salesforce Views). Article number is always shown first.