### PR TITLE
fix: prevent UnboundLocalError on refresh_interval in scheduler thread (#729)

### DIFF
--- a/src/code_indexer/global_repos/refresh_scheduler.py
+++ b/src/code_indexer/global_repos/refresh_scheduler.py
@@ -801,6 +801,7 @@ class RefreshScheduler:
         logger.debug("Refresh scheduler loop started")
 
         while self._running:
+            refresh_interval = 300  # Defensive init prevents UnboundLocalError if try block fails early
             try:
                 # Bug #240: Periodically evict orphaned write mode markers from
                 # clients that disconnected without calling exit_write_mode.


### PR DESCRIPTION
## Fix: UnboundLocalError on `refresh_interval` in scheduler thread

**Issue:** #729

### Root Cause
`refresh_interval` is assigned conditionally inside the `try` block at line 810 (`self.get_refresh_interval()`). If an exception occurs before this assignment (e.g., in `cleanup_stale_write_mode_markers()` or `list_global_repos()`), execution jumps to the `except` block at line 885, then falls through to line 891 where `refresh_interval` is referenced in `self._calculate_poll_interval(refresh_interval)`. 

On the first iteration, this raises `UnboundLocalError: local variable 'refresh_interval' referenced before assignment`, silently crashing the background scheduler thread and stopping all periodic global repo refreshes.

### Fix
Add a defensive initialization `refresh_interval = 300` at the top of the `while` loop body, before the `try` block. This ensures the variable always has a safe default value regardless of control flow.

```python
while self._running:
    refresh_interval = 300  # Defensive init prevents UnboundLocalError
    try:
        ...
```

### Why this works
- Guarantees `refresh_interval` always has a value regardless of control flow
- Minimal change — one line added
- No behavioral change on happy path (the try block still assigns the configured value)
- Prevents silent scheduler thread death
- 300s (5min) is a reasonable fallback if `get_refresh_interval()` itself fails
