### PR TITLE
v10.0.4: bug sweep + TOTP modal UX

### DIFF
--- a/src/code_indexer/global_repos/refresh_scheduler.py
+++ b/src/code_indexer/global_repos/refresh_scheduler.py
@@ -38,6 +38,7 @@ from code_indexer.server.utils.config_manager import ScipConfig, ServerResourceC
 
 if TYPE_CHECKING:
     from code_indexer.server.repositories.background_jobs import BackgroundJobManager
+    from code_indexer.server.services.job_tracker import JobTracker
 
 logger = logging.getLogger(__name__)
 
@@ -137,6 +138,7 @@ class RefreshScheduler:
         resource_config: Optional["ServerResourceConfig"] = None,
         background_job_manager: Optional["BackgroundJobManager"] = None,
         registry: Optional["GlobalRegistry"] = None,  # type: ignore[name-defined]  # noqa: F821
+        job_tracker: Optional["JobTracker"] = None,
     ):
         """
         Initialize the refresh scheduler.
@@ -149,6 +151,9 @@ class RefreshScheduler:
             resource_config: Optional resource configuration for timeouts (server mode)
             background_job_manager: Optional job manager for dashboard visibility (server mode)
             registry: Optional registry instance (for testing); if None, creates SQLite backend (production)
+            job_tracker: Optional JobTracker for drain-status visibility (Bug #935). When provided,
+                each in-flight _execute_refresh call registers itself so drain-status sees it.
+                When None (CLI mode), no registration occurs.
         """
         self.golden_repos_dir = Path(golden_repos_dir)
         self.config_source = config_source
@@ -156,6 +161,7 @@ class RefreshScheduler:
         self.cleanup_manager = cleanup_manager
         self.resource_config = resource_config
         self.background_job_manager = background_job_manager
+        self._job_tracker = job_tracker
 
         # Initialize managers
         self.alias_manager = AliasManager(str(self.golden_repos_dir / "aliases"))
@@ -1028,376 +1034,175 @@ class RefreshScheduler:
         # Acquire per-repo lock to serialize concurrent refresh attempts
         repo_lock = self._get_repo_lock(alias_name)
 
-        with repo_lock:
-            try:
-                logger.info(f"Starting refresh for {alias_name}")
+        # Bug #935: Register in-flight refresh with JobTracker so drain-status
+        # sees it and the auto-updater waits before restarting.
+        # Guard with is not None — CLI mode has no tracker.
+        _tracker_job_id = f"refresh-{alias_name}"
+        if self._job_tracker is not None:
+            self._job_tracker.register_job(
+                _tracker_job_id,
+                operation_type="global_repo_refresh",
+                username="system",
+                repo_alias=alias_name,
+            )
+            self._job_tracker.update_status(_tracker_job_id, status="running")
 
-                # Get current alias target
-                current_target = self.alias_manager.read_alias(alias_name)
-                if not current_target:
-                    logger.warning(f"Alias {alias_name} not found, skipping refresh")
-                    return {
-                        "success": True,
-                        "alias": alias_name,
-                        "message": "Alias not found, skipped",
-                    }
+        # Bug #935: track whether the refresh raised so the finally block can
+        # call fail_job (raised) vs complete_job (all normal exits incl. early returns).
+        _tracker_raised = False
+        try:
+            with repo_lock:
+                try:
+                    logger.info(f"Starting refresh for {alias_name}")
 
-                # Get repo info from registry
-                repo_info = self.registry.get_global_repo(alias_name)
-                if not repo_info:
-                    logger.warning(
-                        f"Repo {alias_name} not in registry, skipping refresh"
+                    # Get current alias target
+                    current_target = self.alias_manager.read_alias(alias_name)
+                    if not current_target:
+                        logger.warning(f"Alias {alias_name} not found, skipping refresh")
+                        return {
+                            "success": True,
+                            "alias": alias_name,
+                            "message": "Alias not found, skipped",
+                        }
+
+                    # Get repo info from registry
+                    repo_info = self.registry.get_global_repo(alias_name)
+                    if not repo_info:
+                        logger.warning(
+                            f"Repo {alias_name} not in registry, skipping refresh"
+                        )
+                        return {
+                            "success": True,
+                            "alias": alias_name,
+                            "message": "Repo not in registry, skipped",
+                        }
+
+                    # Determine repo type from repo_url.
+                    # repo_url=None  → meta-directory (cidx-meta), uses MetaDirectoryUpdater
+                    # repo_url starts with "local://" → local filesystem repo
+                    # anything else → remote git repo, uses GitPullUpdater
+                    repo_url = repo_info.get("repo_url", "")
+                    is_meta_repo = repo_url is None
+                    is_local_repo = repo_url.startswith("local://") if repo_url else False
+
+                    # Story #236 Fix 2: Always derive master path from golden_repos_dir / repo_name.
+                    # current_target from alias JSON may point to a .versioned/ snapshot after first
+                    # refresh — using it for git pull or as snapshot source would be wrong.
+                    repo_name = alias_name.removesuffix("-global")
+                    master_path = str(self.golden_repos_dir / repo_name)
+
+                    # AC6: Reconcile registry with filesystem at START of refresh
+                    # This ensures registry flags reflect actual index state before refresh begins
+                    detected_indexes = self._detect_existing_indexes(Path(current_target))
+                    self._reconcile_registry_with_filesystem(alias_name, detected_indexes)
+                    logger.info(
+                        f"Reconciled registry with filesystem at START for {alias_name}: {detected_indexes}"
                     )
-                    return {
-                        "success": True,
-                        "alias": alias_name,
-                        "message": "Repo not in registry, skipped",
-                    }
+                    sync_failure: Optional[str] = None
 
-                # Determine repo type from repo_url.
-                # repo_url=None  → meta-directory (cidx-meta), uses MetaDirectoryUpdater
-                # repo_url starts with "local://" → local filesystem repo
-                # anything else → remote git repo, uses GitPullUpdater
-                repo_url = repo_info.get("repo_url", "")
-                is_meta_repo = repo_url is None
-                is_local_repo = repo_url.startswith("local://") if repo_url else False
-
-                # Story #236 Fix 2: Always derive master path from golden_repos_dir / repo_name.
-                # current_target from alias JSON may point to a .versioned/ snapshot after first
-                # refresh — using it for git pull or as snapshot source would be wrong.
-                repo_name = alias_name.removesuffix("-global")
-                master_path = str(self.golden_repos_dir / repo_name)
-
-                # AC6: Reconcile registry with filesystem at START of refresh
-                # This ensures registry flags reflect actual index state before refresh begins
-                detected_indexes = self._detect_existing_indexes(Path(current_target))
-                self._reconcile_registry_with_filesystem(alias_name, detected_indexes)
-                logger.info(
-                    f"Reconciled registry with filesystem at START for {alias_name}: {detected_indexes}"
-                )
-                sync_failure: Optional[str] = None
-
-                if is_local_repo:
-                    # C3: For local repos, source_path is the LIVE directory (where writers put files),
-                    # NOT the current alias target which may point to a versioned snapshot.
-                    source_path = master_path
-
-                    # Bug #268: Skip uninitialized local repos gracefully.
-                    # Per-user Langfuse repos may not have .code-indexer/ yet when the
-                    # scheduler fires before LangfuseTraceSyncService has written any traces.
-                    # Attempting cidx index on an uninitialized dir fails with:
-                    #   "Command 'index' is not available in no configuration found"
-                    # These repos are only refreshed via explicit trigger from their writers.
-                    code_indexer_dir = Path(source_path) / ".code-indexer"
-                    if not code_indexer_dir.exists():
-                        logger.info(
-                            f"Skipping scheduled refresh for local repo {alias_name}: "
-                            f"not yet initialized (no .code-indexer/ in {source_path}). "
-                            f"Will be refreshed via explicit trigger when writers populate it."
-                        )
-                        return {
-                            "success": True,
-                            "alias": alias_name,
-                            "message": "Not yet initialized, skipped",
-                        }
-
-                    # Story #227: Skip CoW clone if an external writer holds the write lock.
-                    # Writers (DependencyMapService, LangfuseTraceSyncService) acquire the lock
-                    # before writing and trigger an explicit refresh when done.
-                    # Non-blocking check — never wait, just skip this cycle.
-                    if self.is_write_locked(repo_name):
-                        logger.info(
-                            f"Skipping refresh for {alias_name}, write lock held by external writer"
-                        )
-                        return {
-                            "success": True,
-                            "alias": alias_name,
-                            "message": "Skipped, write lock held",
-                        }
-
-                    # Story #926: After migrate_legacy_cidx_meta() runs at server startup,
-                    # cidx-meta-global gets repo_url="local://cidx-meta", making is_local_repo=True
-                    # and is_meta_repo=False.  The backup gate must fire here (before mtime-based
-                    # change detection) so that remote drift and idempotent bootstrap are always
-                    # handled regardless of whether local files have changed.
-                    # _handled_by_backup=True means the backup path ran; the mtime block below
-                    # is skipped so that the existing single mtime path is not duplicated.
-                    _handled_by_backup = False
-                    if alias_name == "cidx-meta-global":
-                        _backup_cfg_local = None
-                        try:
-                            _backup_cfg_local = (
-                                get_config_service()
-                                .get_config()
-                                .cidx_meta_backup_config
-                            )
-                        except Exception as _cfg_err:
-                            logger.warning(
-                                "Could not load cidx_meta_backup_config for %s, "
-                                "falling back to mtime-based detection: %s",
-                                alias_name,
-                                _cfg_err,
-                            )
-
-                        if _backup_cfg_local is not None and _backup_cfg_local.enabled:
-                            _handled_by_backup = True
-
-                            # MED-3: MetaDirectoryUpdater first so description files are
-                            # in place before CidxMetaBackupSync runs `git add -A`.
-                            try:
-                                MetaDirectoryUpdater(
-                                    master_path, self.registry
-                                ).update()
-                            except Exception as _meta_err:
-                                logger.warning(
-                                    "MetaDirectoryUpdater failed for %s before backup sync: %s",
-                                    alias_name,
-                                    _meta_err,
-                                )
-
-                            # MED-2: Idempotent bootstrap — cheap when remote URL unchanged.
-                            if _backup_cfg_local.remote_url:
-                                try:
-                                    CidxMetaBackupBootstrap().bootstrap(
-                                        master_path, _backup_cfg_local.remote_url
-                                    )
-                                except Exception as _bootstrap_err:
-                                    logger.warning(
-                                        "cidx-meta backup bootstrap failed for %s: %s",
-                                        alias_name,
-                                        _bootstrap_err,
-                                    )
-
-                            _branch = detect_default_branch(master_path) or "master"
-                            _sync_result = CidxMetaBackupSync(
-                                master_path,
-                                _branch,
-                                ClaudeConflictResolver(),
-                            ).sync()
-
-                            if _sync_result.skipped and not force_reset:
-                                logger.info(
-                                    "No cidx-meta backup changes detected for %s, "
-                                    "skipping refresh",
-                                    alias_name,
-                                )
-                                return {
-                                    "success": True,
-                                    "alias": alias_name,
-                                    "message": "No changes detected",
-                                }
-
-                            sync_failure = _sync_result.sync_failure
-                            logger.info(
-                                f"Changes detected in local repo {alias_name}, creating new index"
-                            )
-                            # Fall through to the shared indexing pipeline below.
-
-                    # C2: Use mtime-based change detection for local repos.
-                    # Skipped when the backup-aware path already handled cidx-meta-global.
-                    if not _handled_by_backup:
-                        has_changes = self._has_local_changes(source_path, alias_name)
-
-                        if not has_changes:
-                            logger.info(
-                                f"No changes detected for local repo {alias_name}, skipping refresh"
-                            )
-                            return {
-                                "success": True,
-                                "alias": alias_name,
-                                "message": "No changes detected",
-                            }
-
-                        logger.info(
-                            f"Changes detected in local repo {alias_name}, creating new index"
-                        )
-                else:
-                    # Bug #239: Check write lock for git repos too. Protects against
-                    # reconciliation restoring a master while refresh tries to snapshot it.
-                    if self.is_write_locked(repo_name):
-                        logger.info(
-                            f"Skipping refresh for {alias_name}, write lock held by external writer"
-                        )
-                        return {
-                            "success": True,
-                            "alias": alias_name,
-                            "message": "Skipped, write lock held",
-                        }
-
-                    backup_cfg = None
-                    if is_meta_repo and alias_name == "cidx-meta-global":
-                        try:
-                            backup_cfg = (
-                                get_config_service()
-                                .get_config()
-                                .cidx_meta_backup_config
-                            )
-                        except Exception:
-                            backup_cfg = None
-
-                    if (
-                        is_meta_repo
-                        and alias_name == "cidx-meta-global"
-                        and backup_cfg is not None
-                        and backup_cfg.enabled
-                    ):
-                        # MED-3: Run MetaDirectoryUpdater before sync so description
-                        # files are created/removed on disk before CidxMetaBackupSync
-                        # runs `git add -A`.  git add -A is a superset of
-                        # MetaDirectoryUpdater's filesystem writes once it has run.
-                        # Wrapped in try/except so a MetaDirectoryUpdater failure
-                        # does not block backup sync (matching the defensive pattern
-                        # used for backup_cfg fetch and bootstrap errors in this block).
-                        try:
-                            MetaDirectoryUpdater(master_path, self.registry).update()
-                        except Exception as meta_err:
-                            logger.warning(
-                                "MetaDirectoryUpdater failed for %s before backup sync: %s",
-                                alias_name,
-                                meta_err,
-                            )
-
-                        # MED-2: Idempotent bootstrap call ensures URL changes applied
-                        # via DB-only paths (not through the Save route) are applied
-                        # on the next refresh cycle.  CidxMetaBackupBootstrap.bootstrap()
-                        # is cheap when the remote URL has not changed (reads
-                        # `git remote get-url origin` and returns immediately on match).
-                        if backup_cfg.remote_url:
-                            try:
-                                CidxMetaBackupBootstrap().bootstrap(
-                                    master_path, backup_cfg.remote_url
-                                )
-                            except Exception as bootstrap_err:
-                                logger.warning(
-                                    "cidx-meta backup bootstrap failed for %s: %s",
-                                    alias_name,
-                                    bootstrap_err,
-                                )
-                        branch = detect_default_branch(master_path) or "master"
-                        sync_result = CidxMetaBackupSync(
-                            master_path,
-                            branch,
-                            ClaudeConflictResolver(),
-                        ).sync()
-                        if sync_result.skipped and not force_reset:
-                            logger.info(
-                                "No cidx-meta backup changes detected for %s, skipping refresh",
-                                alias_name,
-                            )
-                            return {
-                                "success": True,
-                                "alias": alias_name,
-                                "message": "No changes detected",
-                            }
-                        sync_failure = sync_result.sync_failure
+                    if is_local_repo:
+                        # C3: For local repos, source_path is the LIVE directory (where writers put files),
+                        # NOT the current alias target which may point to a versioned snapshot.
                         source_path = master_path
-                    else:
-                        # Meta-directories (repo_url=None) use MetaDirectoryUpdater instead of
-                        # GitPullUpdater — they sync description files, not git history.
-                        updater: UpdateStrategy
-                        if is_meta_repo:
-                            updater = MetaDirectoryUpdater(master_path, self.registry)
-                        else:
-                            # Story #236 Fix 2: Always git pull into the master golden repo, never into
-                            # a versioned snapshot. current_target may be a .versioned/ path after first
-                            # refresh, but git pull must always operate on the canonical master.
-                            updater = GitPullUpdater(master_path)
 
-                        # Bug #469 Fix 1: Verify base clone is on expected default_branch before
-                        # pulling.  If the clone was switched to a wrong branch by any previous
-                        # operation, reset it now so we don't perpetuate the contamination.
-                        try:
-                            branch_result = subprocess.run(
-                                ["git", "branch", "--show-current"],
-                                cwd=master_path,
-                                capture_output=True,
-                                text=True,
-                                timeout=10,
-                            )
-                            current_branch = branch_result.stdout.strip()
-                            default_branch = repo_info.get("default_branch")
-                            try:
-                                db_path = str(
-                                    self.golden_repos_dir.parent / "cidx_server.db"
-                                )
-                                _meta_backend = GoldenRepoMetadataSqliteBackend(db_path)
-                                base_alias = alias_name.removesuffix("-global")
-                                meta = _meta_backend.get_repo(base_alias)
-                                if meta and meta.get("default_branch"):
-                                    default_branch = meta["default_branch"]
-                            except Exception as e:
-                                logger.debug(
-                                    "Could not read default_branch from golden_repos_metadata"
-                                    " for %s: %s",
-                                    alias_name,
-                                    e,
-                                )
-
-                            if not default_branch:
-                                try:
-                                    symref_result = subprocess.run(
-                                        [
-                                            "git",
-                                            "symbolic-ref",
-                                            "--short",
-                                            "refs/remotes/origin/HEAD",
-                                        ],
-                                        cwd=master_path,
-                                        capture_output=True,
-                                        text=True,
-                                        timeout=10,
-                                    )
-                                    if symref_result.returncode == 0:
-                                        ref = symref_result.stdout.strip()
-                                        if ref.startswith("origin/"):
-                                            default_branch = ref[len("origin/") :]
-                                except Exception as e:
-                                    logger.debug(
-                                        "git symbolic-ref fallback failed for %s: %s",
-                                        alias_name,
-                                        e,
-                                    )
-
-                            if (
-                                default_branch
-                                and current_branch
-                                and current_branch != default_branch
-                            ):
-                                logger.warning(
-                                    f"Base clone for {alias_name} on '{current_branch}' instead of "
-                                    f"'{default_branch}', resetting to default branch"
-                                )
-                                checkout_result = subprocess.run(
-                                    ["git", "checkout", default_branch],
-                                    cwd=master_path,
-                                    capture_output=True,
-                                    text=True,
-                                    timeout=30,
-                                )
-                                if checkout_result.returncode != 0:
-                                    logger.error(
-                                        f"Failed to reset {alias_name} to {default_branch}: "
-                                        f"{checkout_result.stderr}"
-                                    )
-                        except Exception as e:
-                            logger.warning(
-                                f"Branch verification failed for {alias_name}: {e}"
-                            )
-
-                        if force_reset:
+                        # Bug #268: Skip uninitialized local repos gracefully.
+                        # Per-user Langfuse repos may not have .code-indexer/ yet when the
+                        # scheduler fires before LangfuseTraceSyncService has written any traces.
+                        # Attempting cidx index on an uninitialized dir fails with:
+                        #   "Command 'index' is not available in no configuration found"
+                        # These repos are only refreshed via explicit trigger from their writers.
+                        code_indexer_dir = Path(source_path) / ".code-indexer"
+                        if not code_indexer_dir.exists():
                             logger.info(
-                                f"Force reset requested for {alias_name}, "
-                                "skipping change detection and resetting to remote branch"
+                                f"Skipping scheduled refresh for local repo {alias_name}: "
+                                f"not yet initialized (no .code-indexer/ in {source_path}). "
+                                f"Will be refreshed via explicit trigger when writers populate it."
                             )
-                            updater.update(force_reset=True)
-                        else:
-                            try:
-                                has_changes = updater.has_changes()
-                                self._reset_fetch_failures(alias_name)
+                            return {
+                                "success": True,
+                                "alias": alias_name,
+                                "message": "Not yet initialized, skipped",
+                            }
 
-                                if not has_changes:
+                        # Story #227: Skip CoW clone if an external writer holds the write lock.
+                        # Writers (DependencyMapService, LangfuseTraceSyncService) acquire the lock
+                        # before writing and trigger an explicit refresh when done.
+                        # Non-blocking check — never wait, just skip this cycle.
+                        if self.is_write_locked(repo_name):
+                            logger.info(
+                                f"Skipping refresh for {alias_name}, write lock held by external writer"
+                            )
+                            return {
+                                "success": True,
+                                "alias": alias_name,
+                                "message": "Skipped, write lock held",
+                            }
+
+                        # Story #926: After migrate_legacy_cidx_meta() runs at server startup,
+                        # cidx-meta-global gets repo_url="local://cidx-meta", making is_local_repo=True
+                        # and is_meta_repo=False.  The backup gate must fire here (before mtime-based
+                        # change detection) so that remote drift and idempotent bootstrap are always
+                        # handled regardless of whether local files have changed.
+                        # _handled_by_backup=True means the backup path ran; the mtime block below
+                        # is skipped so that the existing single mtime path is not duplicated.
+                        _handled_by_backup = False
+                        if alias_name == "cidx-meta-global":
+                            _backup_cfg_local = None
+                            try:
+                                _backup_cfg_local = (
+                                    get_config_service()
+                                    .get_config()
+                                    .cidx_meta_backup_config
+                                )
+                            except Exception as _cfg_err:
+                                logger.warning(
+                                    "Could not load cidx_meta_backup_config for %s, "
+                                    "falling back to mtime-based detection: %s",
+                                    alias_name,
+                                    _cfg_err,
+                                )
+
+                            if _backup_cfg_local is not None and _backup_cfg_local.enabled:
+                                _handled_by_backup = True
+
+                                # MED-3: MetaDirectoryUpdater first so description files are
+                                # in place before CidxMetaBackupSync runs `git add -A`.
+                                try:
+                                    MetaDirectoryUpdater(
+                                        master_path, self.registry
+                                    ).update()
+                                except Exception as _meta_err:
+                                    logger.warning(
+                                        "MetaDirectoryUpdater failed for %s before backup sync: %s",
+                                        alias_name,
+                                        _meta_err,
+                                    )
+
+                                # MED-2: Idempotent bootstrap — cheap when remote URL unchanged.
+                                if _backup_cfg_local.remote_url:
+                                    try:
+                                        CidxMetaBackupBootstrap().bootstrap(
+                                            master_path, _backup_cfg_local.remote_url
+                                        )
+                                    except Exception as _bootstrap_err:
+                                        logger.warning(
+                                            "cidx-meta backup bootstrap failed for %s: %s",
+                                            alias_name,
+                                            _bootstrap_err,
+                                        )
+
+                                _branch = detect_default_branch(master_path) or "master"
+                                _sync_result = CidxMetaBackupSync(
+                                    master_path,
+                                    _branch,
+                                    ClaudeConflictResolver(),
+                                ).sync()
+
+                                if _sync_result.skipped and not force_reset:
                                     logger.info(
-                                        f"No changes detected for {alias_name}, skipping refresh"
+                                        "No cidx-meta backup changes detected for %s, "
+                                        "skipping refresh",
+                                        alias_name,
                                     )
                                     return {
                                         "success": True,
@@ -1405,126 +1210,356 @@ class RefreshScheduler:
                                         "message": "No changes detected",
                                     }
 
+                                sync_failure = _sync_result.sync_failure
                                 logger.info(
-                                    f"Pulling latest changes for {alias_name} into master: {master_path}"
+                                    f"Changes detected in local repo {alias_name}, creating new index"
                                 )
-                                updater.update()
-                            except GitFetchError as e:
-                                self._handle_fetch_error(
-                                    alias_name, repo_url, master_path, e
+                                # Fall through to the shared indexing pipeline below.
+
+                        # C2: Use mtime-based change detection for local repos.
+                        # Skipped when the backup-aware path already handled cidx-meta-global.
+                        if not _handled_by_backup:
+                            has_changes = self._has_local_changes(source_path, alias_name)
+
+                            if not has_changes:
+                                logger.info(
+                                    f"No changes detected for local repo {alias_name}, skipping refresh"
                                 )
-                                raise
+                                return {
+                                    "success": True,
+                                    "alias": alias_name,
+                                    "message": "No changes detected",
+                                }
 
-                        source_path = master_path
+                            logger.info(
+                                f"Changes detected in local repo {alias_name}, creating new index"
+                            )
+                    else:
+                        # Bug #239: Check write lock for git repos too. Protects against
+                        # reconciliation restoring a master while refresh tries to snapshot it.
+                        if self.is_write_locked(repo_name):
+                            logger.info(
+                                f"Skipping refresh for {alias_name}, write lock held by external writer"
+                            )
+                            return {
+                                "success": True,
+                                "alias": alias_name,
+                                "message": "Skipped, write lock held",
+                            }
 
-                # Story #223 AC7: Sync file extensions from server config before indexing
-                try:
-                    config_service = get_config_service()
-                    config_service.sync_repo_extensions_if_drifted(source_path)
-                except Exception as e:
-                    logger.warning(
-                        "Could not sync extensions before index for %s: %s",
-                        alias_name,
-                        e,
-                    )
+                        backup_cfg = None
+                        if is_meta_repo and alias_name == "cidx-meta-global":
+                            try:
+                                backup_cfg = (
+                                    get_config_service()
+                                    .get_config()
+                                    .cidx_meta_backup_config
+                                )
+                            except Exception:
+                                backup_cfg = None
 
-                # Index source first, then create versioned snapshot (Story #229)
-                # Story #482 PATH C: Forward progress_callback into _index_source
-                self._index_source(
-                    alias_name=alias_name,
-                    source_path=source_path,
-                    progress_callback=progress_callback,
-                )
-                new_index_path = self._create_snapshot(
-                    alias_name=alias_name, source_path=source_path
-                )
+                        if (
+                            is_meta_repo
+                            and alias_name == "cidx-meta-global"
+                            and backup_cfg is not None
+                            and backup_cfg.enabled
+                        ):
+                            # MED-3: Run MetaDirectoryUpdater before sync so description
+                            # files are created/removed on disk before CidxMetaBackupSync
+                            # runs `git add -A`.  git add -A is a superset of
+                            # MetaDirectoryUpdater's filesystem writes once it has run.
+                            # Wrapped in try/except so a MetaDirectoryUpdater failure
+                            # does not block backup sync (matching the defensive pattern
+                            # used for backup_cfg fetch and bootstrap errors in this block).
+                            try:
+                                MetaDirectoryUpdater(master_path, self.registry).update()
+                            except Exception as meta_err:
+                                logger.warning(
+                                    "MetaDirectoryUpdater failed for %s before backup sync: %s",
+                                    alias_name,
+                                    meta_err,
+                                )
 
-                # Swap alias to new index
-                logger.info(f"Swapping alias {alias_name} to new index")
-                self.alias_manager.swap_alias(
-                    alias_name=alias_name,
-                    new_target=new_index_path,
-                    old_target=current_target,
-                )
+                            # MED-2: Idempotent bootstrap call ensures URL changes applied
+                            # via DB-only paths (not through the Save route) are applied
+                            # on the next refresh cycle.  CidxMetaBackupBootstrap.bootstrap()
+                            # is cheap when the remote URL has not changed (reads
+                            # `git remote get-url origin` and returns immediately on match).
+                            if backup_cfg.remote_url:
+                                try:
+                                    CidxMetaBackupBootstrap().bootstrap(
+                                        master_path, backup_cfg.remote_url
+                                    )
+                                except Exception as bootstrap_err:
+                                    logger.warning(
+                                        "cidx-meta backup bootstrap failed for %s: %s",
+                                        alias_name,
+                                        bootstrap_err,
+                                    )
+                            branch = detect_default_branch(master_path) or "master"
+                            sync_result = CidxMetaBackupSync(
+                                master_path,
+                                branch,
+                                ClaudeConflictResolver(),
+                            ).sync()
+                            if sync_result.skipped and not force_reset:
+                                logger.info(
+                                    "No cidx-meta backup changes detected for %s, skipping refresh",
+                                    alias_name,
+                                )
+                                return {
+                                    "success": True,
+                                    "alias": alias_name,
+                                    "message": "No changes detected",
+                                }
+                            sync_failure = sync_result.sync_failure
+                            source_path = master_path
+                        else:
+                            # Meta-directories (repo_url=None) use MetaDirectoryUpdater instead of
+                            # GitPullUpdater — they sync description files, not git history.
+                            updater: UpdateStrategy
+                            if is_meta_repo:
+                                updater = MetaDirectoryUpdater(master_path, self.registry)
+                            else:
+                                # Story #236 Fix 2: Always git pull into the master golden repo, never into
+                                # a versioned snapshot. current_target may be a .versioned/ path after first
+                                # refresh, but git pull must always operate on the canonical master.
+                                updater = GitPullUpdater(master_path)
 
-                # Bug #881 Phase 2: Evict stale HNSW cache entries for the old snapshot
-                # immediately after swap, rather than waiting for 10-minute TTL.
-                # format_error_log imported before try so it is always bound in except.
-                # get_global_cache and get_correlation_id imported inside try because they
-                # are only available in server context; the except guard covers import failures.
-                from code_indexer.server.logging_utils import (
-                    format_error_log as _fmt_err,
-                )
+                            # Bug #469 Fix 1: Verify base clone is on expected default_branch before
+                            # pulling.  If the clone was switched to a wrong branch by any previous
+                            # operation, reset it now so we don't perpetuate the contamination.
+                            try:
+                                branch_result = subprocess.run(
+                                    ["git", "branch", "--show-current"],
+                                    cwd=master_path,
+                                    capture_output=True,
+                                    text=True,
+                                    timeout=10,
+                                )
+                                current_branch = branch_result.stdout.strip()
+                                default_branch = repo_info.get("default_branch")
+                                try:
+                                    db_path = str(
+                                        self.golden_repos_dir.parent / "cidx_server.db"
+                                    )
+                                    _meta_backend = GoldenRepoMetadataSqliteBackend(db_path)
+                                    base_alias = alias_name.removesuffix("-global")
+                                    meta = _meta_backend.get_repo(base_alias)
+                                    if meta and meta.get("default_branch"):
+                                        default_branch = meta["default_branch"]
+                                except Exception as e:
+                                    logger.debug(
+                                        "Could not read default_branch from golden_repos_metadata"
+                                        " for %s: %s",
+                                        alias_name,
+                                        e,
+                                    )
 
-                try:
-                    from code_indexer.server.cache import get_global_cache
-                    from code_indexer.server.middleware.correlation import (
-                        get_correlation_id as _get_corr_id,
-                    )
+                                if not default_branch:
+                                    try:
+                                        symref_result = subprocess.run(
+                                            [
+                                                "git",
+                                                "symbolic-ref",
+                                                "--short",
+                                                "refs/remotes/origin/HEAD",
+                                            ],
+                                            cwd=master_path,
+                                            capture_output=True,
+                                            text=True,
+                                            timeout=10,
+                                        )
+                                        if symref_result.returncode == 0:
+                                            ref = symref_result.stdout.strip()
+                                            if ref.startswith("origin/"):
+                                                default_branch = ref[len("origin/") :]
+                                    except Exception as e:
+                                        logger.debug(
+                                            "git symbolic-ref fallback failed for %s: %s",
+                                            alias_name,
+                                            e,
+                                        )
 
-                    _evicted = get_global_cache().invalidate_prefix(current_target)
-                    logger.info(
-                        f"[REFRESH-{alias_name}] Evicted {_evicted} HNSW cache entries "
-                        f"for old snapshot {current_target}",
-                        extra={"correlation_id": _get_corr_id()},
-                    )
-                except Exception as _cache_evict_err:
-                    logger.warning(
-                        _fmt_err(
-                            "REPO-GENERAL-055",
-                            f"Failed to evict HNSW cache for old snapshot "
-                            f"{current_target}: {_cache_evict_err}",
+                                if (
+                                    default_branch
+                                    and current_branch
+                                    and current_branch != default_branch
+                                ):
+                                    logger.warning(
+                                        f"Base clone for {alias_name} on '{current_branch}' instead of "
+                                        f"'{default_branch}', resetting to default branch"
+                                    )
+                                    checkout_result = subprocess.run(
+                                        ["git", "checkout", default_branch],
+                                        cwd=master_path,
+                                        capture_output=True,
+                                        text=True,
+                                        timeout=30,
+                                    )
+                                    if checkout_result.returncode != 0:
+                                        logger.error(
+                                            f"Failed to reset {alias_name} to {default_branch}: "
+                                            f"{checkout_result.stderr}"
+                                        )
+                            except Exception as e:
+                                logger.warning(
+                                    f"Branch verification failed for {alias_name}: {e}"
+                                )
+
+                            if force_reset:
+                                logger.info(
+                                    f"Force reset requested for {alias_name}, "
+                                    "skipping change detection and resetting to remote branch"
+                                )
+                                updater.update(force_reset=True)
+                            else:
+                                try:
+                                    has_changes = updater.has_changes()
+                                    self._reset_fetch_failures(alias_name)
+
+                                    if not has_changes:
+                                        logger.info(
+                                            f"No changes detected for {alias_name}, skipping refresh"
+                                        )
+                                        return {
+                                            "success": True,
+                                            "alias": alias_name,
+                                            "message": "No changes detected",
+                                        }
+
+                                    logger.info(
+                                        f"Pulling latest changes for {alias_name} into master: {master_path}"
+                                    )
+                                    updater.update()
+                                except GitFetchError as e:
+                                    self._handle_fetch_error(
+                                        alias_name, repo_url, master_path, e
+                                    )
+                                    raise
+
+                            source_path = master_path
+
+                    # Story #223 AC7: Sync file extensions from server config before indexing
+                    try:
+                        config_service = get_config_service()
+                        config_service.sync_repo_extensions_if_drifted(source_path)
+                    except Exception as e:
+                        logger.warning(
+                            "Could not sync extensions before index for %s: %s",
+                            alias_name,
+                            e,
                         )
+
+                    # Index source first, then create versioned snapshot (Story #229)
+                    # Story #482 PATH C: Forward progress_callback into _index_source
+                    self._index_source(
+                        alias_name=alias_name,
+                        source_path=source_path,
+                        progress_callback=progress_callback,
+                    )
+                    new_index_path = self._create_snapshot(
+                        alias_name=alias_name, source_path=source_path
                     )
 
-                # Story #236 Fix 1: Only schedule cleanup for versioned snapshots.
-                # Never schedule cleanup for the master golden repo (golden-repos/{alias}/).
-                # On first refresh, current_target IS the master golden repo — scheduling it
-                # for cleanup would permanently destroy the master.
-                if ".versioned" in current_target:
+                    # Swap alias to new index
+                    logger.info(f"Swapping alias {alias_name} to new index")
+                    self.alias_manager.swap_alias(
+                        alias_name=alias_name,
+                        new_target=new_index_path,
+                        old_target=current_target,
+                    )
+
+                    # Bug #881 Phase 2: Evict stale HNSW cache entries for the old snapshot
+                    # immediately after swap, rather than waiting for 10-minute TTL.
+                    # format_error_log imported before try so it is always bound in except.
+                    # get_global_cache and get_correlation_id imported inside try because they
+                    # are only available in server context; the except guard covers import failures.
+                    from code_indexer.server.logging_utils import (
+                        format_error_log as _fmt_err,
+                    )
+
+                    try:
+                        from code_indexer.server.cache import get_global_cache
+                        from code_indexer.server.middleware.correlation import (
+                            get_correlation_id as _get_corr_id,
+                        )
+
+                        _evicted = get_global_cache().invalidate_prefix(current_target)
+                        logger.info(
+                            f"[REFRESH-{alias_name}] Evicted {_evicted} HNSW cache entries "
+                            f"for old snapshot {current_target}",
+                            extra={"correlation_id": _get_corr_id()},
+                        )
+                    except Exception as _cache_evict_err:
+                        logger.warning(
+                            _fmt_err(
+                                "REPO-GENERAL-055",
+                                f"Failed to evict HNSW cache for old snapshot "
+                                f"{current_target}: {_cache_evict_err}",
+                            )
+                        )
+
+                    # Story #236 Fix 1: Only schedule cleanup for versioned snapshots.
+                    # Never schedule cleanup for the master golden repo (golden-repos/{alias}/).
+                    # On first refresh, current_target IS the master golden repo — scheduling it
+                    # for cleanup would permanently destroy the master.
+                    if ".versioned" in current_target:
+                        logger.info(
+                            f"Scheduling cleanup of old versioned snapshot: {current_target}"
+                        )
+                        self.cleanup_manager.schedule_cleanup(current_target)
+                    else:
+                        logger.info(
+                            f"Preserving master golden repo (not scheduling cleanup): {current_target}"
+                        )
+
+                    # Update registry timestamp
+                    self.registry.update_refresh_timestamp(alias_name)
+
+                    # AC6: Reconcile registry with filesystem at END of refresh
+                    # This captures any new indexes created during refresh (semantic, FTS, temporal, SCIP)
+                    detected_indexes = self._detect_existing_indexes(Path(new_index_path))
+                    self._reconcile_registry_with_filesystem(alias_name, detected_indexes)
                     logger.info(
-                        f"Scheduling cleanup of old versioned snapshot: {current_target}"
-                    )
-                    self.cleanup_manager.schedule_cleanup(current_target)
-                else:
-                    logger.info(
-                        f"Preserving master golden repo (not scheduling cleanup): {current_target}"
+                        f"Reconciled registry with filesystem at END for {alias_name}: {detected_indexes}"
                     )
 
-                # Update registry timestamp
-                self.registry.update_refresh_timestamp(alias_name)
+                    if sync_failure:
+                        raise RuntimeError(
+                            "refresh complete, indexing succeeded, but backup "
+                            + sync_failure
+                        )
 
-                # AC6: Reconcile registry with filesystem at END of refresh
-                # This captures any new indexes created during refresh (semantic, FTS, temporal, SCIP)
-                detected_indexes = self._detect_existing_indexes(Path(new_index_path))
-                self._reconcile_registry_with_filesystem(alias_name, detected_indexes)
-                logger.info(
-                    f"Reconciled registry with filesystem at END for {alias_name}: {detected_indexes}"
-                )
+                    logger.info(f"Refresh complete for {alias_name}")
+                    return {
+                        "success": True,
+                        "alias": alias_name,
+                        "message": "Refresh complete",
+                    }
 
-                if sync_failure:
+                except Exception as e:
+                    logger.error(
+                        f"Refresh failed for {alias_name}: {type(e).__name__}: {e}",
+                        exc_info=True,
+                    )
+                    # Bug #84 fix: Raise exception instead of returning error dict
+                    # BackgroundJobManager marks jobs as FAILED only when exceptions are raised
+                    _tracker_raised = True
                     raise RuntimeError(
-                        "refresh complete, indexing succeeded, but backup "
-                        + sync_failure
+                        f"Refresh failed for {alias_name}: {type(e).__name__}: {e}"
                     )
 
-                logger.info(f"Refresh complete for {alias_name}")
-                return {
-                    "success": True,
-                    "alias": alias_name,
-                    "message": "Refresh complete",
-                }
-
-            except Exception as e:
-                logger.error(
-                    f"Refresh failed for {alias_name}: {type(e).__name__}: {e}",
-                    exc_info=True,
-                )
-                # Bug #84 fix: Raise exception instead of returning error dict
-                # BackgroundJobManager marks jobs as FAILED only when exceptions are raised
-                raise RuntimeError(
-                    f"Refresh failed for {alias_name}: {type(e).__name__}: {e}"
-                )
+        finally:
+            # Bug #935: always unregister from JobTracker (finally runs on return AND raise).
+            if self._job_tracker is not None:
+                if _tracker_raised:
+                    self._job_tracker.fail_job(
+                        _tracker_job_id,
+                        error=f"refresh failed for {alias_name}",
+                    )
+                else:
+                    self._job_tracker.complete_job(_tracker_job_id)
 
     def _index_source(
         self, alias_name: str, source_path: str, progress_callback=None

--- a/src/code_indexer/server/auth/dependencies.py
+++ b/src/code_indexer/server/auth/dependencies.py
@@ -648,6 +648,7 @@ def _hybrid_auth_impl(
             logger.info(
                 f"Hybrid auth ({auth_type}): Session auth SUCCESS for {session.username}"
             )
+            request.state.user_jti = session_cookie_value  # enables elevation session key resolution
             return user
         else:
             logger.debug(f"Hybrid auth ({auth_type}): Session invalid")

--- a/src/code_indexer/server/repositories/golden_repo_manager.py
+++ b/src/code_indexer/server/repositories/golden_repo_manager.py
@@ -3007,11 +3007,26 @@ class GoldenRepoManager:
 
                     elif index_type == "temporal":
                         # Story #480: Use Popen + line reader for real-time progress
+                        # Bug #945: Only use --clear when no vector_*.json files exist.
+                        # Vectors are expensive (embedding API). HNSW is cheap to rebuild.
+                        # If vectors exist, omit --clear so rebuild_from_vectors is used.
+                        _index_dir = (
+                            Path(repo_path)
+                            / ".code-indexer"
+                            / "index"
+                        )
+                        _temporal_vectors_exist = any(
+                            True
+                            for _coll_dir in _index_dir.glob("code-indexer-temporal*")
+                            if _coll_dir.is_dir()
+                            for _ in _coll_dir.glob("vector_*.json")
+                        )
+                        _clear_flags = [] if _temporal_vectors_exist else ["--clear"]
                         command = [
                             "cidx",
                             "index",
                             "--index-commits",
-                            "--clear",
+                            *_clear_flags,
                             "--progress-json",
                         ]
 

--- a/src/code_indexer/server/self_monitoring/service.py
+++ b/src/code_indexer/server/self_monitoring/service.py
@@ -10,7 +10,7 @@ create bug reports, and maintain operational excellence.
 import logging
 import sqlite3
 import threading
-from typing import Optional, TYPE_CHECKING
+from typing import Callable, Optional, TYPE_CHECKING
 
 from code_indexer.server.self_monitoring.prompts import get_default_prompt
 
@@ -50,6 +50,7 @@ class SelfMonitoringService:
         github_token: Optional[str] = None,
         server_name: Optional[str] = None,
         storage_backend: Optional["SelfMonitoringBackend"] = None,
+        token_fetcher: Optional[Callable[[], Optional[str]]] = None,
     ):
         """
         Initialize the self-monitoring service.
@@ -66,6 +67,10 @@ class SelfMonitoringService:
             github_token: GitHub token for authentication (optional, Bug #87)
             server_name: Server display name for issue identification (optional, Bug #87)
             storage_backend: Optional SelfMonitoringBackend for DB delegation
+            token_fetcher: Optional callable that returns a fresh GitHub token on
+                each invocation. When provided, _execute_scan calls this instead of
+                reading self._github_token, enabling token rotation without restart
+                (Bug #957).
 
         Note (Story #566): The analysis prompt is no longer configurable at runtime.
         It is always loaded from default_analysis_prompt.md at scan execution time.
@@ -81,6 +86,7 @@ class SelfMonitoringService:
         self._github_token = github_token
         self._server_name = server_name
         self._backend = storage_backend
+        self._token_fetcher = token_fetcher
         self._running = False
         self._thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
@@ -462,6 +468,13 @@ class SelfMonitoringService:
             )
             return {"status": "FAILURE", "error": error_msg}
 
+        # Bug #957: Resolve token fresh on each scan tick so that a rotated
+        # token is picked up without restarting the service.
+        if self._token_fetcher is not None:
+            github_token = self._token_fetcher()
+        else:
+            github_token = self._github_token
+
         logger.debug(
             f"[SELF-MON-DEBUG] _execute_scan: Config validated - model={self._model}, repo_root={self._repo_root}, server_name={self._server_name}"
         )
@@ -490,7 +503,7 @@ class SelfMonitoringService:
             prompt_template=prompt,
             model=self._model,
             repo_root=self._repo_root,
-            github_token=self._github_token,
+            github_token=github_token,
             server_name=self._server_name,
         )
 

--- a/src/code_indexer/server/services/dep_map_parser_graph.py
+++ b/src/code_indexer/server/services/dep_map_parser_graph.py
@@ -9,6 +9,7 @@ final graph edge assembly.
 from __future__ import annotations
 
 import logging
+import threading
 from pathlib import Path
 from typing import Any, Dict, List, Set, Tuple, Union
 
@@ -27,6 +28,12 @@ from code_indexer.server.services.dep_map_parser_tables import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Per-path dedup set: once a missing domain file has been warned about, subsequent
+# calls log at DEBUG level only (Bug #960 — suppress repeated missing-file noise).
+# Lock ensures thread-safe access in the multi-threaded FastAPI server.
+_warned_missing_domains: set = set()
+_warned_missing_domains_lock: threading.Lock = threading.Lock()
 
 # Column indices (mirrors dep_map_parser_tables constants; re-declared locally
 # to avoid cross-module constant coupling for these graph-specific usages).
@@ -250,6 +257,31 @@ def parse_domain_file_for_graph(
     try:
         content = md_file.read_text(encoding="utf-8")
         parse_frontmatter_strict(content)
+    except FileNotFoundError as exc:
+        domain_path_str = str(md_file)
+        with _warned_missing_domains_lock:
+            already_warned = domain_path_str in _warned_missing_domains
+            if not already_warned:
+                _warned_missing_domains.add(domain_path_str)
+        if not already_warned:
+            logger.warning(
+                "parse_domain_file_for_graph: missing domain file %s (suppressing future repeats)",
+                domain_path_str,
+            )
+        else:
+            logger.debug(
+                "parse_domain_file_for_graph: still missing %s",
+                domain_path_str,
+            )
+        anomalies.append(
+            AnomalyEntry(
+                type=AnomalyType.MALFORMED_YAML,
+                file=str(md_file),
+                message=str(exc),
+                channel="parser",
+            )
+        )
+        return
     except Exception as exc:
         logger.warning(
             "parse_domain_file_for_graph: failed to read/parse %s",

--- a/src/code_indexer/server/services/dependency_latency_tracker.py
+++ b/src/code_indexer/server/services/dependency_latency_tracker.py
@@ -9,6 +9,7 @@ Provides:
 """
 
 import logging
+import sqlite3
 import threading
 import time
 from collections import deque
@@ -56,6 +57,14 @@ _EXCEPTION_STATUS_CODE = -1
 
 # Node ID placeholder: resolved from environment / config if available
 _DEFAULT_NODE_ID = "local"
+
+# Substring present in sqlite3.ProgrammingError when the database connection is
+# closed — used to detect a terminal condition in the writer thread.
+_CLOSED_DB_SUBSTRING = "closed database"
+
+# Number of consecutive flush/prune failures (any error type) before the writer
+# thread gives up and terminates — prevents infinite loops on persistent errors.
+_MAX_CONSECUTIVE_FAILURES = 5
 
 
 def _validate_positive_float(value: Any, name: str) -> None:
@@ -208,29 +217,56 @@ class DependencyLatencyTracker:
         """
         Background daemon loop: flush buffer to storage, delete stale samples.
 
-        Termination: exits when ``_stop_event`` is set by ``shutdown()``.
-        Each iteration is guarded by a top-level try/except so that unexpected
-        errors in flush/prune do not kill the thread.
+        Termination paths:
+        1. Normal shutdown: ``_stop_event`` set by ``shutdown()`` — final flush runs.
+        2. Closed-database terminal: ``_flush_buffer`` / ``_prune_stale`` set
+           ``_stop_event`` and re-raise; the loop detects the set event and breaks
+           without additional logging. Final flush is skipped.
+        3. Max consecutive failures: after ``_MAX_CONSECUTIVE_FAILURES`` consecutive
+           exceptions (that did NOT already set ``_stop_event``), the loop sets
+           ``_stop_event`` and logs exactly ONE error, then breaks. Final flush is
+           skipped.
+
+        A successful iteration resets the consecutive-failures counter to zero.
         """
+        consecutive_failures = 0
+        terminal_failure = False
         # Daemon-service pattern: loop is bounded by stop_event (set by shutdown).
         # Event.wait(timeout) ensures the thread wakes at most every flush_interval_s
         # and exits immediately when the event fires — termination is event-driven.
         while not self._stop_event.is_set():
             self._stop_event.wait(timeout=self._flush_interval_s)
+            if self._stop_event.is_set():
+                break
+            try:
+                self._flush_and_prune()
+                consecutive_failures = 0
+            except Exception:
+                # If _flush_buffer/_prune_stale already set _stop_event (closed-db),
+                # exit immediately — they already logged the terminal warning.
+                if self._stop_event.is_set():
+                    terminal_failure = True
+                    break
+                consecutive_failures += 1
+                if consecutive_failures >= _MAX_CONSECUTIVE_FAILURES:
+                    self._stop_event.set()
+                    terminal_failure = True
+                    logger.error(
+                        "DependencyLatencyTracker: %d consecutive failures — "
+                        "writer thread terminating",
+                        consecutive_failures,
+                    )
+                    break
+
+        # Final flush on normal shutdown only — skip when a terminal failure ended
+        # the loop to avoid triggering additional log noise on a broken backend.
+        if not terminal_failure:
             try:
                 self._flush_and_prune()
             except Exception as exc:
                 logger.warning(
-                    "DependencyLatencyTracker: writer iteration failed: %s", exc
+                    "DependencyLatencyTracker: final flush on shutdown failed: %s", exc
                 )
-
-        # Final flush on shutdown — also guarded
-        try:
-            self._flush_and_prune()
-        except Exception as exc:
-            logger.warning(
-                "DependencyLatencyTracker: final flush on shutdown failed: %s", exc
-            )
 
     def _flush_and_prune(self) -> None:
         """Drain the buffer into storage and delete samples outside the retention window."""
@@ -238,7 +274,12 @@ class DependencyLatencyTracker:
         self._prune_stale()
 
     def _flush_buffer(self) -> None:
-        """Drain all samples currently in the buffer into the storage backend."""
+        """Drain all samples currently in the buffer into the storage backend.
+
+        Raises:
+            sqlite3.ProgrammingError: re-raised when the database is closed so
+                the caller (_writer_loop) can treat it as a terminal condition.
+        """
         with self._buffer_lock:
             if not self._buffer:
                 return
@@ -247,13 +288,32 @@ class DependencyLatencyTracker:
 
         try:
             self._backend.insert_batch(samples)
-        except Exception as exc:
-            logger.warning("DependencyLatencyTracker: flush failed: %s", exc)
+        except sqlite3.ProgrammingError as exc:
+            if _CLOSED_DB_SUBSTRING in str(exc).lower():
+                self._stop_event.set()
+                logger.warning(
+                    "DependencyLatencyTracker: database closed — writer thread terminating"
+                )
+            raise
+        except Exception:
+            raise
 
     def _prune_stale(self) -> None:
-        """Delete samples older than retention_s from the storage backend."""
+        """Delete samples older than retention_s from the storage backend.
+
+        Raises:
+            sqlite3.ProgrammingError: re-raised when the database is closed so
+                the caller (_writer_loop) can treat it as a terminal condition.
+        """
         cutoff = time.time() - self._retention_s
         try:
             self._backend.delete_older_than(cutoff)
-        except Exception as exc:
-            logger.warning("DependencyLatencyTracker: prune failed: %s", exc)
+        except sqlite3.ProgrammingError as exc:
+            if _CLOSED_DB_SUBSTRING in str(exc).lower():
+                self._stop_event.set()
+                logger.warning(
+                    "DependencyLatencyTracker: database closed — writer thread terminating"
+                )
+            raise
+        except Exception:
+            raise

--- a/src/code_indexer/server/services/description_refresh_scheduler.py
+++ b/src/code_indexer/server/services/description_refresh_scheduler.py
@@ -12,6 +12,7 @@ import logging
 import random
 import re
 import threading
+from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, cast
@@ -36,6 +37,11 @@ logger = logging.getLogger(__name__)
 # required for Claude CLI in non-interactive environments.
 _CLAUDE_CLI_SOFT_TIMEOUT_SECONDS = 90  # inner shell ``timeout`` budget
 _CLAUDE_CLI_HARD_TIMEOUT_SECONDS = 120  # Python subprocess.run cap
+
+# Bug #953: circuit-breaker threshold for consecutive prompt-generation failures.
+# After this many consecutive None-prompt results for the same repo, the scheduler
+# stops rescheduling (quarantines) and logs one ERROR.  Reset to 0 on success.
+PROMPT_FAILURE_QUARANTINE_THRESHOLD = 3
 
 
 def _build_claude_env() -> dict:
@@ -188,6 +194,12 @@ class DescriptionRefreshScheduler:
             self._golden_backend = GoldenRepoMetadataSqliteBackend(db_path)
         self._shutdown_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
+        # Bug #953: per-repo consecutive prompt-failure counter.
+        # Incremented each time _get_refresh_prompt() returns None.
+        # Reset to 0 by on_refresh_complete(success=True).
+        # When the count reaches PROMPT_FAILURE_QUARANTINE_THRESHOLD the repo is
+        # quarantined (not rescheduled) and one ERROR log is emitted.
+        self._prompt_failure_counts: Dict[str, int] = defaultdict(int)
 
         # Story #728 AC5: Bounded thread pool sized by max_concurrent_claude_cli config.
         # Prevents mass backfill from spawning N unbounded concurrent Claude CLI processes.
@@ -658,6 +670,8 @@ class DescriptionRefreshScheduler:
 
         # Update tracking record
         if success:
+            # Bug #953: reset circuit-breaker counter on any successful refresh.
+            self._prompt_failure_counts[repo_alias] = 0
             self._tracking_backend.upsert_tracking(
                 repo_alias=repo_alias,
                 status="completed",
@@ -744,8 +758,29 @@ class DescriptionRefreshScheduler:
                 # Get refresh prompt using RepoAnalyzer
                 prompt = self._get_refresh_prompt(alias, clone_path)
                 if prompt is None:
+                    # Bug #953: circuit-breaker — count consecutive prompt failures.
+                    self._prompt_failure_counts[alias] += 1
+                    failure_count = self._prompt_failure_counts[alias]
+                    if failure_count >= PROMPT_FAILURE_QUARANTINE_THRESHOLD:
+                        # Log exactly once at the quarantine boundary; subsequent
+                        # passes are silently skipped to avoid log spam.
+                        if failure_count == PROMPT_FAILURE_QUARANTINE_THRESHOLD:
+                            logger.error(
+                                "Repo %s entered quarantine after %d consecutive "
+                                "prompt-generation failures — will not reschedule until "
+                                "a successful refresh resets the counter.",
+                                alias,
+                                failure_count,
+                            )
+                        # Do NOT call upsert_tracking — leave next_run stale so the
+                        # repo stays quarantined until the counter is reset externally.
+                        continue
                     logger.warning(
-                        f"Cannot refresh {alias}: failed to generate prompt, rescheduling"
+                        "Cannot refresh %s: failed to generate prompt, rescheduling"
+                        " (failure %d/%d)",
+                        alias,
+                        failure_count,
+                        PROMPT_FAILURE_QUARANTINE_THRESHOLD,
                     )
                     # Reschedule to next cycle to avoid infinite retry loop (Finding N3)
                     now = datetime.now(timezone.utc).isoformat()

--- a/src/code_indexer/server/services/job_tracker.py
+++ b/src/code_indexer/server/services/job_tracker.py
@@ -436,7 +436,7 @@ class JobTracker:
         with self._lock:
             job = self._active_jobs.get(job_id)
             if job is None:
-                logger.warning(f"JobTracker.update_status: job {job_id} not in memory")
+                logger.debug(f"JobTracker.update_status: job {job_id} not in memory")
                 return
 
             if status is not None:

--- a/src/code_indexer/server/services/job_tracker.py
+++ b/src/code_indexer/server/services/job_tracker.py
@@ -945,6 +945,22 @@ class JobTracker:
         with self._lock:
             return sum(1 for j in self._active_jobs.values() if j.status == "pending")
 
+    def get_running_jobs_count(self) -> int:
+        """Return the count of running jobs.
+
+        Alias for get_active_job_count() using the plural-form name expected by
+        MaintenanceState.register_job_tracker() interface (drain-status monitoring).
+        """
+        return self.get_active_job_count()
+
+    def get_queued_jobs_count(self) -> int:
+        """Return the count of pending (queued) jobs.
+
+        Alias for get_pending_job_count() using the plural-form name expected by
+        MaintenanceState.register_job_tracker() interface (drain-status monitoring).
+        """
+        return self.get_pending_job_count()
+
     # ------------------------------------------------------------------
     # Private SQLite helpers
     # ------------------------------------------------------------------

--- a/src/code_indexer/server/web/elevation_web_routes.py
+++ b/src/code_indexer/server/web/elevation_web_routes.py
@@ -3,6 +3,7 @@
 Provides:
 - GET /admin/elevate?next=... -- render elevation form
 - POST /auth/elevate-form -- process form submission, redirect to next on success
+- POST /auth/elevate-ajax -- AJAX modal elevation, returns JSON (Bug #955)
 
 First-run guidance: when user lacks TOTP, GET redirects to /admin/mfa/setup?next=...
 so the admin can complete TOTP setup and bounce back.
@@ -10,11 +11,12 @@ so the admin can complete TOTP setup and bounce back.
 
 import logging
 import os
-from typing import Optional
+from enum import Enum, auto
+from typing import Optional, Tuple
 from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, Form, Request, status
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 from code_indexer.server.auth.dependencies import (
@@ -40,6 +42,15 @@ _HTTP_BAD_REQUEST = status.HTTP_400_BAD_REQUEST
 _HTTP_UNAUTHORIZED = status.HTTP_401_UNAUTHORIZED
 _HTTP_FORBIDDEN = status.HTTP_403_FORBIDDEN
 _HTTP_SERVICE_UNAVAILABLE = status.HTTP_503_SERVICE_UNAVAILABLE
+
+
+class _ElevResult(Enum):
+    SUCCESS = auto()
+    KILL_SWITCH_OFF = auto()
+    NO_CODE = auto()
+    NO_MFA = auto()
+    NO_SESSION = auto()
+    INVALID_CODE = auto()
 
 
 def _sanitize_next(next_value: str) -> str:
@@ -123,6 +134,86 @@ def _verify_credentials(
     return None
 
 
+def _attempt_elevation(
+    request: Request,
+    username: str,
+    totp_code: Optional[str],
+    recovery_code: Optional[str],
+    client_ip: str,
+) -> Tuple[_ElevResult, Optional[str]]:
+    """Run the shared elevation decision pipeline.
+
+    Executes all validation steps (kill-switch, code presence, MFA config,
+    session key, credential verification) and — on success — creates the
+    elevated session.  All audit log entries are emitted here so both the
+    form and AJAX callers share identical observability.
+
+    Args:
+        request: Current FastAPI request (used for session key resolution).
+        username: Authenticated admin username.
+        totp_code: TOTP code supplied by the caller (may be None).
+        recovery_code: Recovery code supplied by the caller (may be None).
+        client_ip: Client IP address for audit logging.
+
+    Returns:
+        A tuple of (_ElevResult, scope_or_None).  scope is only set on
+        SUCCESS; all other results carry None as the second element.
+    """
+    if not _is_elevation_enforcement_enabled():
+        logger.warning(
+            "Elevation attempt by %s from %s rejected — kill switch is OFF",
+            username,
+            client_ip,
+        )
+        return _ElevResult.KILL_SWITCH_OFF, None
+
+    if not totp_code and not recovery_code:
+        logger.warning(
+            "Elevation attempt by %s from %s rejected — no code provided",
+            username,
+            client_ip,
+        )
+        return _ElevResult.NO_CODE, None
+
+    totp_service = get_totp_service()
+    if totp_service is None or not totp_service.is_mfa_enabled(username):
+        logger.warning(
+            "Elevation attempt by %s from %s rejected — no MFA configured",
+            username,
+            client_ip,
+        )
+        return _ElevResult.NO_MFA, None
+
+    session_key = _resolve_session_key(request)
+    if not session_key:
+        logger.warning(
+            "Elevation attempt by %s from %s rejected — no session key resolved",
+            username,
+            client_ip,
+        )
+        return _ElevResult.NO_SESSION, None
+
+    scope = _verify_credentials(totp_service, username, totp_code, recovery_code, client_ip)
+    if scope is None:
+        code_type = "recovery code" if recovery_code else "TOTP code"
+        logger.warning(
+            "Elevation attempt by %s from %s rejected — invalid %s",
+            username,
+            client_ip,
+            code_type,
+        )
+        return _ElevResult.INVALID_CODE, None
+
+    elevated_session_manager.create(
+        session_key=session_key,
+        username=username,
+        elevated_from_ip=client_ip,
+        scope=scope,
+    )
+    logger.info("Elevation granted for %s from %s (scope=%s)", username, client_ip, scope)
+    return _ElevResult.SUCCESS, scope
+
+
 @router.get("/admin/elevate", response_class=HTMLResponse)
 def elevate_page(
     request: Request,
@@ -157,63 +248,67 @@ def elevate_form(
     safe_next = _sanitize_next(next)
     client_ip = request.client.host if request.client else "unknown"
 
-    if not _is_elevation_enforcement_enabled():
-        logger.warning(
-            "Elevation attempt by %s from %s rejected — kill switch is OFF",
-            user.username,
-            client_ip,
-        )
+    result, _scope = _attempt_elevation(
+        request, user.username, totp_code, recovery_code, client_ip
+    )
+
+    if result == _ElevResult.SUCCESS:
+        return RedirectResponse(url=safe_next, status_code=_HTTP_SEE_OTHER)
+    if result == _ElevResult.KILL_SWITCH_OFF:
         return _elev_error(
-            request,
-            safe_next,
-            "Step-up elevation is currently disabled.",
+            request, safe_next, "Step-up elevation is currently disabled.",
             _HTTP_SERVICE_UNAVAILABLE,
         )
-
-    if not totp_code and not recovery_code:
-        logger.warning(
-            "Elevation attempt by %s from %s rejected — no code provided",
-            user.username,
-            client_ip,
-        )
+    if result == _ElevResult.NO_CODE:
         return _elev_error(request, safe_next, "Provide a code.", _HTTP_BAD_REQUEST)
-
-    totp_service = get_totp_service()
-    if totp_service is None or not totp_service.is_mfa_enabled(user.username):
-        logger.warning(
-            "User %s from %s has no MFA configured — redirecting to setup",
-            user.username,
-            client_ip,
-        )
+    if result == _ElevResult.NO_MFA:
         return _redirect_to_setup(safe_next)
-
-    session_key = _resolve_session_key(request)
-    if not session_key:
-        logger.warning(
-            "Elevation attempt by %s from %s rejected — no session key resolved",
-            user.username,
-            client_ip,
-        )
+    if result == _ElevResult.NO_SESSION:
         return _elev_error(request, safe_next, "No session.", _HTTP_FORBIDDEN)
+    # INVALID_CODE
+    error_msg = "Invalid recovery code." if recovery_code else "Invalid code."
+    return _elev_error(request, safe_next, error_msg, _HTTP_UNAUTHORIZED)
 
-    scope = _verify_credentials(
-        totp_service, user.username, totp_code, recovery_code, client_ip
+
+@router.post("/auth/elevate-ajax")
+def elevate_ajax(
+    request: Request,
+    totp_code: Optional[str] = Form(None),
+    recovery_code: Optional[str] = Form(None),
+    user: User = Depends(get_current_admin_user_hybrid),
+):
+    """AJAX endpoint for inline modal elevation — returns JSON, never redirects."""
+    client_ip = request.client.host if request.client else "unknown"
+
+    result, _scope = _attempt_elevation(
+        request, user.username, totp_code, recovery_code, client_ip
     )
-    if scope is None:
-        code_type = "recovery code" if recovery_code else "TOTP code"
-        logger.warning(
-            "Elevation attempt by %s from %s rejected — invalid %s",
-            user.username,
-            client_ip,
-            code_type,
+
+    if result == _ElevResult.SUCCESS:
+        return JSONResponse({"success": True})
+    if result == _ElevResult.KILL_SWITCH_OFF:
+        return JSONResponse(
+            {"success": False, "error": "Step-up elevation is currently disabled."},
+            status_code=_HTTP_SERVICE_UNAVAILABLE,
         )
-        error_msg = "Invalid recovery code." if recovery_code else "Invalid code."
-        return _elev_error(request, safe_next, error_msg, _HTTP_UNAUTHORIZED)
-
-    elevated_session_manager.create(
-        session_key=session_key,
-        username=user.username,
-        elevated_from_ip=client_ip,
-        scope=scope,
+    if result == _ElevResult.NO_CODE:
+        return JSONResponse(
+            {"success": False, "error": "Provide a code."},
+            status_code=_HTTP_BAD_REQUEST,
+        )
+    if result == _ElevResult.NO_MFA:
+        return JSONResponse(
+            {"success": False, "error": "No MFA configured. Please set up TOTP first."},
+            status_code=_HTTP_BAD_REQUEST,
+        )
+    if result == _ElevResult.NO_SESSION:
+        return JSONResponse(
+            {"success": False, "error": "No session."},
+            status_code=_HTTP_FORBIDDEN,
+        )
+    # INVALID_CODE
+    error_msg = "Invalid recovery code." if recovery_code else "Invalid code."
+    return JSONResponse(
+        {"success": False, "error": error_msg},
+        status_code=_HTTP_UNAUTHORIZED,
     )
-    return RedirectResponse(url=safe_next, status_code=_HTTP_SEE_OTHER)

--- a/src/code_indexer/server/web/templates/base.html
+++ b/src/code_indexer/server/web/templates/base.html
@@ -10,12 +10,13 @@
     <script src="/admin/static/htmx.min.js?v={{ static_version }}"></script>
     <script>
         // Bug #206: Redirect to login on session expiry instead of injecting 401 HTML into dashboard.
-        // Bug #955 (Story #923 AC7): Redirect to TOTP setup or elevation entry on 403 elevation errors
-        // so admins are driven into the elevation flow instead of seeing a silent failure in DevTools.
+        // Bug #955 (Story #923 AC7): Show inline TOTP modal on 403 elevation errors (no page redirect).
+        window._cidxElevationPending = null;
+        window._cidxRedirecting = false;
+
         document.addEventListener('htmx:beforeSwap', function(evt) {
             var xhr = evt.detail.xhr;
 
-            // 403 with elevation error envelope: drive the browser into the elevation flow.
             if (xhr.status === 403) {
                 try {
                     var body = JSON.parse(xhr.responseText);
@@ -31,29 +32,109 @@
                     }
                     if (err === 'elevation_required') {
                         evt.detail.shouldSwap = false;
-                        if (!window._cidxRedirecting) {
-                            window._cidxRedirecting = true;
-                            window.location.href = '/admin/elevate?next=' + encodeURIComponent(window.location.pathname + window.location.search);
-                            setTimeout(function() { window._cidxRedirecting = false; }, 3000);
-                        }
+                        window._cidxElevationPending = {
+                            verb: evt.detail.requestConfig && evt.detail.requestConfig.verb,
+                            path: evt.detail.requestConfig && evt.detail.requestConfig.path,
+                            target: evt.detail.target,
+                            parameters: evt.detail.requestConfig && evt.detail.requestConfig.parameters,
+                        };
+                        _cidxOpenElevationModal();
                         return;
                     }
                 } catch (e) {
-                    // Not a JSON body or no detail.error — fall through to default HTMX handling.
+                    // Not a JSON body — fall through to default HTMX handling.
                 }
             }
 
-            // 401 (session expiry) → /login
             if (xhr.status === 401 ||
                 (xhr.responseURL && xhr.responseURL.indexOf('/login') !== -1)) {
                 evt.detail.shouldSwap = false;
                 if (!window._cidxRedirecting) {
                     window._cidxRedirecting = true;
                     window.location.href = '/login';
-                    // Reset flag after timeout to prevent permanent blocking
                     setTimeout(function() { window._cidxRedirecting = false; }, 3000);
                 }
             }
+        });
+
+        function _cidxOpenElevationModal() {
+            var modal = document.getElementById('elevationModal');
+            if (!modal) return;
+            document.getElementById('elevationTotpCode').value = '';
+            var recEl = document.getElementById('elevationRecoveryCode');
+            if (recEl) recEl.value = '';
+            var errEl = document.getElementById('elevationError');
+            errEl.style.display = 'none';
+            errEl.textContent = '';
+            modal.showModal();
+            setTimeout(function() { document.getElementById('elevationTotpCode').focus(); }, 50);
+        }
+
+        function _cidxCloseElevationModal() {
+            var modal = document.getElementById('elevationModal');
+            if (modal && modal.open) modal.close();
+            window._cidxElevationPending = null;
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            var modal = document.getElementById('elevationModal');
+            if (!modal) return;
+
+            document.getElementById('elevationCancelBtn').addEventListener('click', function() {
+                _cidxCloseElevationModal();
+            });
+
+            function _doElevateAjax() {
+                var totpCode = document.getElementById('elevationTotpCode').value.trim();
+                var recEl = document.getElementById('elevationRecoveryCode');
+                var recoveryCode = recEl ? recEl.value.trim() : '';
+                var btn = document.getElementById('elevationVerifyBtn');
+                btn.setAttribute('aria-busy', 'true');
+                btn.disabled = true;
+                var params = new URLSearchParams();
+                if (totpCode) params.append('totp_code', totpCode);
+                if (recoveryCode) params.append('recovery_code', recoveryCode);
+                fetch('/auth/elevate-ajax', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                    body: params.toString(),
+                })
+                .then(function(resp) {
+                    return resp.json().then(function(data) { return {status: resp.status, data: data}; });
+                })
+                .then(function(result) {
+                    btn.removeAttribute('aria-busy');
+                    btn.disabled = false;
+                    if (result.data && result.data.success) {
+                        var pending = window._cidxElevationPending;
+                        _cidxCloseElevationModal();
+                        if (pending && pending.verb && pending.path) {
+                            htmx.ajax(pending.verb.toUpperCase(), pending.path, {
+                                target: pending.target,
+                                values: pending.parameters || {},
+                            });
+                        }
+                    } else {
+                        var errEl = document.getElementById('elevationError');
+                        errEl.textContent = (result.data && result.data.error) || 'Invalid code.';
+                        errEl.style.display = '';
+                        document.getElementById('elevationTotpCode').value = '';
+                        document.getElementById('elevationTotpCode').focus();
+                    }
+                })
+                .catch(function() {
+                    btn.removeAttribute('aria-busy');
+                    btn.disabled = false;
+                    var errEl = document.getElementById('elevationError');
+                    errEl.textContent = 'Network error. Please try again.';
+                    errEl.style.display = '';
+                });
+            }
+
+            document.getElementById('elevationVerifyBtn').addEventListener('click', _doElevateAjax);
+            document.getElementById('elevationTotpCode').addEventListener('keydown', function(e) {
+                if (e.key === 'Enter') { _doElevateAjax(); }
+            });
         });
     </script>
     <script src="/admin/static/js/server_clock.js?v={{ static_version }}" defer></script>
@@ -93,6 +174,36 @@
         {% endif %}
 
         {% block content %}{% endblock %}
+
+        <!-- TOTP Elevation Modal: inline dialog replaces full-page redirect -->
+        <dialog id="elevationModal" aria-modal="true" aria-labelledby="elevationModalTitle">
+            <article>
+                <header>
+                    <h2 id="elevationModalTitle">Verify your identity</h2>
+                </header>
+                <p>Enter your authenticator code to continue.</p>
+                <div id="elevationError" role="alert" class="error-message" style="display:none"></div>
+                <label for="elevationTotpCode">
+                    Authenticator code
+                    <input type="text" id="elevationTotpCode"
+                           autocomplete="one-time-code"
+                           inputmode="numeric" pattern="[0-9]{6}" maxlength="6"
+                           placeholder="6-digit code">
+                </label>
+                <details>
+                    <summary>Use a recovery code instead</summary>
+                    <label for="elevationRecoveryCode">
+                        Recovery code
+                        <input type="text" id="elevationRecoveryCode"
+                               pattern="[A-Z0-9-]+" placeholder="XXXX-XXXX-XXXX-XXXX">
+                    </label>
+                </details>
+                <footer>
+                    <button id="elevationVerifyBtn" type="button">Verify</button>
+                    <button id="elevationCancelBtn" type="button" class="secondary outline">Cancel</button>
+                </footer>
+            </article>
+        </dialog>
     </main>
 </body>
 </html>

--- a/src/code_indexer/services/progress_subprocess_runner.py
+++ b/src/code_indexer/services/progress_subprocess_runner.py
@@ -278,9 +278,19 @@ def run_with_popen_progress(
 
     if process.returncode != 0:
         stdout_output = "".join(all_stdout)
-        error_details = (
-            stderr_output or stdout_output or f"Exit code {process.returncode}"
-        )
+        if process.returncode < 0:
+            # Signal-terminated process: always lead with the signal code so that
+            # callers such as refresh_scheduler.py can match "Exit code -15" for
+            # SIGTERM routing.  The banner/stderr text is appended as context.
+            signal_str = f"Exit code {process.returncode}"
+            detail = stderr_output or stdout_output or ""
+            error_details = (
+                f"{signal_str}. {detail}".rstrip(". ") if detail else signal_str
+            )
+        else:
+            error_details = (
+                stderr_output or stdout_output or f"Exit code {process.returncode}"
+            )
         raise IndexingSubprocessError(f"Failed to {error_label}: {error_details}")
 
     return high_water

--- a/src/code_indexer/services/progressive_metadata.py
+++ b/src/code_indexer/services/progressive_metadata.py
@@ -60,12 +60,38 @@ class ProgressiveMetadata:
         return default_metadata
 
     def _save_metadata(self):
-        """Save metadata to disk."""
+        """Save metadata to disk atomically — temp file + rename prevents corruption on crash."""
+        import os
+        import tempfile
+
         # Ensure parent directory exists
         self.metadata_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(self.metadata_path, "w") as f:
-            json.dump(self.metadata, f, indent=2)
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            dir=str(self.metadata_path.parent), suffix=".tmp"
+        )
+        fd_owned = False
+        try:
+            try:
+                tmp_f = os.fdopen(tmp_fd, "w")
+                fd_owned = True
+                with tmp_f:
+                    json.dump(self.metadata, tmp_f, indent=2)
+                os.replace(tmp_path, str(self.metadata_path))
+            finally:
+                if not fd_owned:
+                    try:
+                        os.close(tmp_fd)
+                    except OSError:
+                        pass  # Already closed or invalid — discard
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                # Best-effort cleanup — temp file may already be gone.
+                # Discard silently; the original exception propagates unmodified.
+                pass
+            raise
 
     def start_indexing(
         self, provider_name: str, model_name: str, git_status: Dict[str, Any]

--- a/src/code_indexer/services/provider_health_monitor.py
+++ b/src/code_indexer/services/provider_health_monitor.py
@@ -105,6 +105,8 @@ class ProviderHealthMonitor:
         self._sinbin_failure_deque: Dict[
             str, deque
         ] = {}  # provider -> recent failure timestamps
+        # Bug #959: transition-gate health status logging to suppress repeated spam
+        self._last_logged_status: Dict[str, str] = {}
         # Story #691: optional file-backed persistence of sin-bin state
         self._persistence_path: Optional[Path] = persistence_path
         if persistence_path is not None:
@@ -592,12 +594,12 @@ class ProviderHealthMonitor:
                 if provider not in self._metrics:
                     return {provider: self._empty_status(provider)}
                 self._prune_old_metrics(provider)
-                return {provider: self._compute_status(provider)}
+                return {provider: self._compute_status(provider, _log_transitions=True)}
 
             result = {}
             for pname in list(self._metrics.keys()):
                 self._prune_old_metrics(pname)
-                result[pname] = self._compute_status(pname)
+                result[pname] = self._compute_status(pname, _log_transitions=True)
             return result
 
     def get_best_provider(self, providers: List[str]) -> Optional[str]:
@@ -622,8 +624,17 @@ class ProviderHealthMonitor:
             while metrics and metrics[0].timestamp < cutoff:
                 metrics.popleft()
 
-    def _compute_status(self, provider: str) -> ProviderHealthStatus:
-        """Compute health status from current metrics. Must hold _data_lock."""
+    def _compute_status(
+        self, provider: str, _log_transitions: bool = False
+    ) -> ProviderHealthStatus:
+        """Compute health status from current metrics. Must hold _data_lock.
+
+        _log_transitions: when True, emit transition-gate log messages (WARNING
+        on status entry, DEBUG on repeat, INFO on healthy recovery).  Callers
+        that invoke _compute_status purely for internal state tracking (e.g.
+        record_call) pass False (the default) so they do not consume the
+        transition before get_health() reports it to the caller.
+        """
         metrics = self._metrics.get(provider)
         if not metrics:
             return self._empty_status(provider)
@@ -662,15 +673,41 @@ class ProviderHealthMonitor:
         else:
             status = "healthy"
 
-        if status in ("degraded", "down"):
-            logger.warning(
-                "Provider %s health: %s (error_rate=%.2f, p95=%.0fms, availability=%.2f)",
-                provider,
-                status,
-                error_rate,
-                p95,
-                availability,
-            )
+        # Bug #959: transition-gate logging — warn once on status entry, debug on repeat.
+        # Only fires when _log_transitions=True so record_call's internal call does not
+        # consume the transition before get_health() can report it.
+        if _log_transitions:
+            _prev_logged = self._last_logged_status.get(provider, "")
+            if status in ("degraded", "down"):
+                if status != _prev_logged:
+                    logger.warning(
+                        "Provider %s health: %s (error_rate=%.2f, p95=%.0fms, availability=%.2f)",
+                        provider,
+                        status,
+                        error_rate,
+                        p95,
+                        availability,
+                    )
+                    self._last_logged_status[provider] = status
+                else:
+                    logger.debug(
+                        "Provider %s health still %s (error_rate=%.2f, p95=%.0fms, availability=%.2f)",
+                        provider,
+                        status,
+                        error_rate,
+                        p95,
+                        availability,
+                    )
+            elif status == "healthy" and _prev_logged in ("degraded", "down"):
+                logger.info(
+                    "Provider %s health recovered to %s (error_rate=%.2f, p95=%.0fms, availability=%.2f)",
+                    provider,
+                    status,
+                    error_rate,
+                    p95,
+                    availability,
+                )
+                self._last_logged_status.pop(provider, None)
 
         # Bug #678: check sin-bin state without re-acquiring _data_lock (already held)
         is_sb = time.monotonic() < self._sinbin_until.get(provider, _SINBIN_NOT_ACTIVE)

--- a/src/code_indexer/storage/hnsw_index_manager.py
+++ b/src/code_indexer/storage/hnsw_index_manager.py
@@ -62,6 +62,10 @@ class HNSWIndexManager:
         self.vector_dim = vector_dim
         self.space = space
 
+    def _save_hnsw_index(self, index: Any, path: str) -> None:
+        # Any: hnswlib.Index is a C extension with no Python type stubs
+        index.save_index(path)
+
     def build_index(
         self,
         collection_path: Path,
@@ -130,9 +134,30 @@ class HNSWIndexManager:
         if progress_callback:
             progress_callback(0, 0, Path(""), info="🔧 HNSW index built ✓")
 
-        # Save index to disk
+        # Save index to disk atomically — temp file + rename prevents corruption on crash
         index_file = collection_path / self.INDEX_FILENAME
-        index.save_index(str(index_file))
+        tmp_hnsw_fd, tmp_hnsw_path = tempfile.mkstemp(
+            dir=str(collection_path),
+            prefix=".tmp_hnsw_",
+            suffix=".tmp",
+        )
+        os.close(tmp_hnsw_fd)  # hnswlib opens by path, not fd
+        try:
+            index.save_index(tmp_hnsw_path)
+            os.replace(tmp_hnsw_path, str(index_file))
+        except Exception:
+            try:
+                os.unlink(tmp_hnsw_path)
+            except OSError as cleanup_err:
+                # Best-effort cleanup — temp file may already be gone or unlink may
+                # fail on a read-only filesystem. Log and discard so the original
+                # exception propagates unmodified.
+                logger.warning(
+                    "Failed to clean up temp HNSW file %s after write error: %s",
+                    tmp_hnsw_path,
+                    cleanup_err,
+                )
+            raise
 
         # Update metadata
         self._update_metadata(
@@ -526,9 +551,35 @@ class HNSWIndexManager:
                     timezone.utc
                 ).isoformat()
 
-                # Save metadata
-                with open(meta_file, "w") as f:
-                    json.dump(metadata, f, indent=2)
+                # Save metadata atomically — temp file + rename prevents corruption on crash
+                tmp_fd, tmp_path = tempfile.mkstemp(
+                    dir=str(collection_path), suffix=".tmp"
+                )
+                fd_owned = False
+                try:
+                    try:
+                        tmp_f = os.fdopen(tmp_fd, "w")
+                        fd_owned = True
+                        with tmp_f:
+                            json.dump(metadata, tmp_f, indent=2)
+                        os.replace(tmp_path, str(meta_file))
+                    finally:
+                        if not fd_owned:
+                            try:
+                                os.close(tmp_fd)
+                            except OSError:
+                                pass  # Already closed or invalid — discard
+                except Exception:
+                    try:
+                        os.unlink(tmp_path)
+                    except OSError as cleanup_err:
+                        # Best-effort cleanup — log and discard so original exception propagates
+                        logger.warning(
+                            "Failed to clean up temp metadata file %s: %s",
+                            tmp_path,
+                            cleanup_err,
+                        )
+                    raise
             finally:
                 # Release lock
                 fcntl.flock(lock_f.fileno(), fcntl.LOCK_UN)
@@ -684,9 +735,35 @@ class HNSWIndexManager:
 
                 metadata["hnsw_index"] = hnsw_meta
 
-                # Save metadata
-                with open(meta_file, "w") as f:
-                    json.dump(metadata, f, indent=2)
+                # Save metadata atomically — temp file + rename prevents corruption on crash
+                tmp_fd, tmp_path = tempfile.mkstemp(
+                    dir=str(collection_path), suffix=".tmp"
+                )
+                fd_owned = False
+                try:
+                    try:
+                        tmp_f = os.fdopen(tmp_fd, "w")
+                        fd_owned = True
+                        with tmp_f:
+                            json.dump(metadata, tmp_f, indent=2)
+                        os.replace(tmp_path, str(meta_file))
+                    finally:
+                        if not fd_owned:
+                            try:
+                                os.close(tmp_fd)
+                            except OSError:
+                                pass  # Already closed or invalid — discard
+                except Exception:
+                    try:
+                        os.unlink(tmp_path)
+                    except OSError as cleanup_err:
+                        # Best-effort cleanup — log and discard so original exception propagates
+                        logger.warning(
+                            "Failed to clean up temp metadata file %s: %s",
+                            tmp_path,
+                            cleanup_err,
+                        )
+                    raise
             finally:
                 # Release lock
                 fcntl.flock(lock_f.fileno(), fcntl.LOCK_UN)
@@ -896,9 +973,30 @@ class HNSWIndexManager:
             f"⚡ INCREMENTAL HNSW UPDATE: Adding/updating {num_new_vectors} vectors (total index size: {current_index_size})"
         )
 
-        # Save index to disk
+        # Save index to disk atomically — temp file + rename prevents corruption on crash
         index_file = collection_path / self.INDEX_FILENAME
-        index.save_index(str(index_file))
+        tmp_hnsw_fd, tmp_hnsw_path = tempfile.mkstemp(
+            dir=str(collection_path),
+            prefix=".tmp_hnsw_",
+            suffix=".tmp",
+        )
+        os.close(tmp_hnsw_fd)  # hnswlib opens by path, not fd
+        try:
+            self._save_hnsw_index(index, tmp_hnsw_path)
+            os.replace(tmp_hnsw_path, str(index_file))
+        except Exception:
+            try:
+                os.unlink(tmp_hnsw_path)
+            except OSError as cleanup_err:
+                # Best-effort cleanup — temp file may already be gone or unlink may
+                # fail on a read-only filesystem.  Log and discard so the original
+                # exception propagates unmodified.
+                logger.warning(
+                    "Failed to clean up temp HNSW file %s after write error: %s",
+                    tmp_hnsw_path,
+                    cleanup_err,
+                )
+            raise
 
         # Update metadata with new mappings
         meta_file = collection_path / "collection_meta.json"

--- a/src/code_indexer/storage/hnsw_index_manager.py
+++ b/src/code_indexer/storage/hnsw_index_manager.py
@@ -227,8 +227,36 @@ class HNSWIndexManager:
         # Set ef parameter for query-time accuracy (must be set after k_actual is known)
         index.set_ef(ef_actual)
 
-        # Query index (returns labels and distances)
-        labels, distances = index.knn_query(query_vector, k=k_actual)
+        # Query index (returns labels and distances).
+        # Bug #954/#948: hnswlib can still raise "contiguous 2D array" even after
+        # the ef>=k guard above (e.g. index M parameter too small, corrupted index).
+        # Retry with progressively smaller k so callers get partial results rather
+        # than a hard failure.  A WARNING is emitted when entering the first retry
+        # so operators see the degraded-index signal regardless of retry outcome.
+        # Unrelated RuntimeErrors propagate immediately without retry.
+        first_exc: RuntimeError | None = None
+        labels = distances = None
+        for attempt_idx, attempt_k in enumerate(
+            [k_actual, max(1, k_actual // 2), max(1, k_actual // 4), 1]
+        ):
+            if attempt_idx == 1 and first_exc is not None:
+                # Entering first retry — warn once so operators see degraded index.
+                logger.warning(
+                    "knn_query failed with contiguous-2D-array error at k=%d; "
+                    "retrying with k=%d (degraded index — ef or M may be too small)",
+                    k_actual,
+                    attempt_k,
+                )
+            try:
+                labels, distances = index.knn_query(query_vector, k=attempt_k)
+                break
+            except RuntimeError as exc:
+                if "contiguous 2D array" not in str(exc):
+                    raise
+                if first_exc is None:
+                    first_exc = exc
+        if first_exc is not None and labels is None:
+            raise first_exc
 
         # Convert labels to IDs
         result_ids = [id_mapping.get(int(label), f"vec_{label}") for label in labels[0]]

--- a/tests/unit/global_repos/test_refresh_scheduler_job_tracker_935.py
+++ b/tests/unit/global_repos/test_refresh_scheduler_job_tracker_935.py
@@ -1,0 +1,360 @@
+"""
+Unit tests for Bug #935 fix: RefreshScheduler registers in-flight refresh jobs
+with JobTracker so the drain endpoint knows they exist.
+
+Tests verify:
+1. RefreshScheduler accepts and stores job_tracker parameter (defaults to None in CLI mode).
+2. When a refresh starts, register_job is called BEFORE update_status(running) — verified via
+   mock_calls ordering so the sequence cannot silently reverse.
+3. When a refresh ends (success), complete_job is called and fail_job is not.
+4. When a refresh ends with an exception, fail_job is called in try/finally.
+5. When no job_tracker is configured (CLI mode), _execute_refresh works unchanged.
+6. JobTracker exposes get_running_jobs_count() / get_queued_jobs_count() for
+   compatibility with the MaintenanceState tracker interface.
+"""
+
+import sqlite3
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from code_indexer.global_repos.refresh_scheduler import RefreshScheduler
+from code_indexer.global_repos.query_tracker import QueryTracker
+from code_indexer.global_repos.cleanup_manager import CleanupManager
+from code_indexer.config import ConfigManager
+
+
+# ---------------------------------------------------------------------------
+# Shared scheduler fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def golden_repos_dir(tmp_path):
+    d = tmp_path / ".code-indexer" / "golden_repos"
+    d.mkdir(parents=True)
+    return d
+
+
+@pytest.fixture
+def config_mgr(tmp_path):
+    return ConfigManager(tmp_path / ".code-indexer" / "config.json")
+
+
+@pytest.fixture
+def query_tracker():
+    return QueryTracker()
+
+
+@pytest.fixture
+def cleanup_manager(query_tracker):
+    return CleanupManager(query_tracker)
+
+
+@pytest.fixture
+def mock_job_tracker():
+    """Minimal mock of JobTracker with the methods called by RefreshScheduler."""
+    tracker = MagicMock()
+    tracker.register_job = MagicMock(return_value=MagicMock())
+    tracker.update_status = MagicMock()
+    tracker.complete_job = MagicMock()
+    tracker.fail_job = MagicMock()
+    return tracker
+
+
+def _make_scheduler(
+    golden_repos_dir,
+    config_mgr,
+    query_tracker,
+    cleanup_manager,
+    job_tracker=None,
+    registry=None,
+):
+    """Helper: build a RefreshScheduler with an optional job_tracker."""
+    return RefreshScheduler(
+        golden_repos_dir=str(golden_repos_dir),
+        config_source=config_mgr,
+        query_tracker=query_tracker,
+        cleanup_manager=cleanup_manager,
+        job_tracker=job_tracker,
+        registry=registry,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared JobTracker DB fixture
+# ---------------------------------------------------------------------------
+
+_BACKGROUND_JOBS_DDL = """
+    CREATE TABLE IF NOT EXISTS background_jobs (
+        job_id TEXT PRIMARY KEY,
+        operation_type TEXT,
+        status TEXT,
+        created_at TEXT,
+        started_at TEXT,
+        completed_at TEXT,
+        result TEXT,
+        error TEXT,
+        progress INTEGER DEFAULT 0,
+        username TEXT,
+        is_admin INTEGER DEFAULT 0,
+        cancelled INTEGER DEFAULT 0,
+        repo_alias TEXT,
+        resolution_attempts INTEGER DEFAULT 0,
+        progress_info TEXT,
+        metadata TEXT
+    )
+"""
+
+
+@pytest.fixture
+def job_tracker_db(tmp_path):
+    """Create an initialized JobTracker backed by a real SQLite DB."""
+    db_path = str(tmp_path / "tracker.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute(_BACKGROUND_JOBS_DDL)
+    conn.commit()
+    conn.close()
+
+    from code_indexer.server.services.job_tracker import JobTracker
+
+    return JobTracker(db_path)
+
+
+# ---------------------------------------------------------------------------
+# AC1: RefreshScheduler accepts and stores job_tracker parameter
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshSchedulerAcceptsJobTracker:
+    def test_accepts_job_tracker_parameter(
+        self,
+        golden_repos_dir,
+        config_mgr,
+        query_tracker,
+        cleanup_manager,
+        mock_job_tracker,
+    ):
+        """RefreshScheduler.__init__ must accept job_tracker and store it."""
+        scheduler = _make_scheduler(
+            golden_repos_dir,
+            config_mgr,
+            query_tracker,
+            cleanup_manager,
+            job_tracker=mock_job_tracker,
+        )
+        assert scheduler._job_tracker is mock_job_tracker
+
+    def test_job_tracker_defaults_to_none(
+        self, golden_repos_dir, config_mgr, query_tracker, cleanup_manager
+    ):
+        """job_tracker must default to None (CLI mode, no DB required)."""
+        scheduler = _make_scheduler(
+            golden_repos_dir, config_mgr, query_tracker, cleanup_manager
+        )
+        assert scheduler._job_tracker is None
+
+
+# ---------------------------------------------------------------------------
+# AC2: Job registered with running status at refresh start (ordered sequence)
+# ---------------------------------------------------------------------------
+
+
+class TestJobRegisteredAtRefreshStart:
+    def test_register_then_running_sequence_is_ordered(
+        self,
+        golden_repos_dir,
+        config_mgr,
+        query_tracker,
+        cleanup_manager,
+        mock_job_tracker,
+    ):
+        """register_job must be called BEFORE update_status(status='running').
+
+        Verified via mock_calls ordering so a reversed sequence is caught.
+        """
+        scheduler = _make_scheduler(
+            golden_repos_dir,
+            config_mgr,
+            query_tracker,
+            cleanup_manager,
+            job_tracker=mock_job_tracker,
+        )
+
+        with patch.object(
+            scheduler.alias_manager, "read_alias", return_value=None
+        ):
+            scheduler._execute_refresh("my-repo-global")
+
+        # Extract the names of all calls made on mock_job_tracker in order.
+        call_names = [c[0] for c in mock_job_tracker.mock_calls]
+
+        # register_job must appear before update_status.
+        assert "register_job" in call_names, "register_job was never called"
+        assert "update_status" in call_names, "update_status was never called"
+        register_idx = call_names.index("register_job")
+        update_idx = call_names.index("update_status")
+        assert register_idx < update_idx, (
+            f"register_job (pos {register_idx}) must precede "
+            f"update_status (pos {update_idx})"
+        )
+
+        # The same job_id must flow through both calls.
+        registered_job_id = mock_job_tracker.register_job.call_args[0][0]
+        assert registered_job_id == "refresh-my-repo-global"
+
+        update_args = mock_job_tracker.update_status.call_args
+        assert update_args[0][0] == "refresh-my-repo-global"
+        assert update_args[1].get("status") == "running"
+
+
+# ---------------------------------------------------------------------------
+# AC3: Job unregistered at refresh end (success)
+# ---------------------------------------------------------------------------
+
+
+class TestJobUnregisteredOnSuccess:
+    def test_complete_job_called_on_success(
+        self,
+        golden_repos_dir,
+        config_mgr,
+        query_tracker,
+        cleanup_manager,
+        mock_job_tracker,
+    ):
+        """complete_job must be called when _execute_refresh exits successfully."""
+        scheduler = _make_scheduler(
+            golden_repos_dir,
+            config_mgr,
+            query_tracker,
+            cleanup_manager,
+            job_tracker=mock_job_tracker,
+        )
+
+        with patch.object(
+            scheduler.alias_manager, "read_alias", return_value=None
+        ):
+            result = scheduler._execute_refresh("ok-repo-global")
+
+        assert result["success"] is True
+        mock_job_tracker.complete_job.assert_called_once_with("refresh-ok-repo-global")
+        mock_job_tracker.fail_job.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AC4: Job unregistered on failure (try/finally guarantee)
+# ---------------------------------------------------------------------------
+
+
+class TestJobUnregisteredOnFailure:
+    def test_fail_job_called_when_refresh_raises(
+        self,
+        golden_repos_dir,
+        config_mgr,
+        query_tracker,
+        cleanup_manager,
+        mock_job_tracker,
+    ):
+        """fail_job must be called even when _execute_refresh raises an exception."""
+        scheduler = _make_scheduler(
+            golden_repos_dir,
+            config_mgr,
+            query_tracker,
+            cleanup_manager,
+            job_tracker=mock_job_tracker,
+        )
+
+        with patch.object(
+            scheduler.alias_manager,
+            "read_alias",
+            side_effect=RuntimeError("disk read error"),
+        ):
+            with pytest.raises(RuntimeError, match="disk read error"):
+                scheduler._execute_refresh("failing-repo-global")
+
+        mock_job_tracker.fail_job.assert_called_once()
+        job_id_arg = mock_job_tracker.fail_job.call_args[0][0]
+        assert job_id_arg == "refresh-failing-repo-global"
+        mock_job_tracker.complete_job.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AC5: CLI mode — no job_tracker means no registration calls
+# ---------------------------------------------------------------------------
+
+
+class TestNoJobTrackerInCliMode:
+    def test_no_job_tracker_no_registration(
+        self, golden_repos_dir, config_mgr, query_tracker, cleanup_manager
+    ):
+        """When job_tracker is None, _execute_refresh must run without touching any tracker."""
+        scheduler = _make_scheduler(
+            golden_repos_dir,
+            config_mgr,
+            query_tracker,
+            cleanup_manager,
+            job_tracker=None,
+        )
+
+        with patch.object(
+            scheduler.alias_manager, "read_alias", return_value=None
+        ):
+            result = scheduler._execute_refresh("cli-repo-global")
+
+        assert result["success"] is True  # normal early return
+
+
+# ---------------------------------------------------------------------------
+# AC6: JobTracker exposes drain interface methods
+# ---------------------------------------------------------------------------
+
+
+class TestJobTrackerDrainInterface:
+    """JobTracker must expose get_running_jobs_count() and get_queued_jobs_count()
+    so it can be registered with MaintenanceState as a drain tracker."""
+
+    def test_get_running_jobs_count_method_exists(self):
+        from code_indexer.server.services.job_tracker import JobTracker
+
+        assert hasattr(JobTracker, "get_running_jobs_count"), (
+            "JobTracker must have get_running_jobs_count() for MaintenanceState interface"
+        )
+
+    def test_get_queued_jobs_count_method_exists(self):
+        from code_indexer.server.services.job_tracker import JobTracker
+
+        assert hasattr(JobTracker, "get_queued_jobs_count"), (
+            "JobTracker must have get_queued_jobs_count() for MaintenanceState interface"
+        )
+
+    def test_get_running_jobs_count_returns_zero_when_empty(self, job_tracker_db):
+        """get_running_jobs_count() returns 0 when no jobs are registered."""
+        assert job_tracker_db.get_running_jobs_count() == 0
+
+    def test_get_queued_jobs_count_returns_zero_when_empty(self, job_tracker_db):
+        """get_queued_jobs_count() returns 0 when no jobs are pending."""
+        assert job_tracker_db.get_queued_jobs_count() == 0
+
+    def test_get_running_and_queued_counts_reflect_in_memory_jobs(self, job_tracker_db):
+        """Both methods reflect the in-memory _active_jobs dict correctly."""
+        from code_indexer.server.services.job_tracker import TrackedJob
+
+        running_job = TrackedJob(
+            job_id="job-run-1",
+            operation_type="global_repo_refresh",
+            status="running",
+            username="system",
+        )
+        pending_job = TrackedJob(
+            job_id="job-pend-1",
+            operation_type="global_repo_refresh",
+            status="pending",
+            username="system",
+        )
+
+        with job_tracker_db._lock:
+            job_tracker_db._active_jobs["job-run-1"] = running_job
+            job_tracker_db._active_jobs["job-pend-1"] = pending_job
+
+        assert job_tracker_db.get_running_jobs_count() == 1
+        assert job_tracker_db.get_queued_jobs_count() == 1

--- a/tests/unit/golden_repos/test_add_index_commands.py
+++ b/tests/unit/golden_repos/test_add_index_commands.py
@@ -571,6 +571,149 @@ class TestTemporalIndexOptionsModel:
 
 
 # ---------------------------------------------------------------------------
+# Bug #945: Temporal add-index must not use --clear when vector files exist
+# ---------------------------------------------------------------------------
+
+
+class TestTemporalVectorExistenceCheck:
+    """
+    Bug #945: --clear flag destroys expensive vector_*.json files.
+
+    When vector_*.json files already exist in any temporal collection directory
+    under <repo_path>/.code-indexer/index/, the add-index temporal command must
+    omit --clear so the HNSW index can be rebuilt from existing vectors at zero
+    embedding API cost.
+
+    When no vector_*.json files exist (fresh index), --clear is kept so the
+    intent is explicit and the directory is cleaned before indexing starts.
+    """
+
+    def _capture_temporal_commands(
+        self,
+        registered_manager,
+        repo_path,
+        temporal_options=None,
+    ):
+        """Call add_index_to_golden_repo with temporal index_type and capture commands."""
+        registered_manager.golden_repos["test-repo"].temporal_options = temporal_options
+        captured_cmds = []
+
+        def fake_submit_job(operation_type, func, **kwargs):
+            collected = []
+
+            def recording_run(cmd, **kw):
+                collected.append(list(cmd))
+                r = MagicMock()
+                r.returncode = 0
+                r.stdout = "ok"
+                r.stderr = ""
+                return r
+
+            with (
+                patch("subprocess.run", side_effect=recording_run),
+                patch("subprocess.Popen", side_effect=_make_success_popen(collected)),
+                patch.object(
+                    registered_manager,
+                    "get_actual_repo_path",
+                    return_value=str(repo_path),
+                ),
+            ):
+                func()
+            captured_cmds.extend(collected)
+            return "fake-job-id"
+
+        with patch.object(
+            registered_manager.background_job_manager,
+            "submit_job",
+            side_effect=fake_submit_job,
+        ):
+            registered_manager.add_index_to_golden_repo(
+                alias="test-repo",
+                index_type="temporal",
+            )
+
+        return [c for c in captured_cmds if c[:2] == ["cidx", "index"]]
+
+    def test_temporal_omits_clear_when_vectors_exist(
+        self, registered_manager, repo_path
+    ):
+        """
+        Bug #945: when vector_*.json files already exist in the temporal collection
+        directory, --clear must NOT appear in the cidx index command.
+
+        Vectors are expensive (embedding API calls). The HNSW index is cheap to
+        rebuild from them. Omitting --clear triggers rebuild_from_vectors path.
+        """
+        # Create a temporal collection directory with a vector file
+        temporal_dir = (
+            repo_path / ".code-indexer" / "index" / "code-indexer-temporal"
+        )
+        temporal_dir.mkdir(parents=True)
+        (temporal_dir / "vector_abc123.json").write_text('{"id": "test"}')
+
+        cmds = self._capture_temporal_commands(registered_manager, repo_path)
+
+        assert cmds, "No 'cidx index' command issued for temporal index type."
+        temporal_cmd = cmds[0]
+        assert "--clear" not in temporal_cmd, (
+            f"Bug #945: when vector files exist, '--clear' must be omitted to "
+            f"preserve expensive embedding results. Got command: {temporal_cmd}"
+        )
+        assert "--index-commits" in temporal_cmd, (
+            f"--index-commits must still be present. Got: {temporal_cmd}"
+        )
+
+    def test_temporal_includes_clear_when_no_vectors_exist(
+        self, registered_manager, repo_path
+    ):
+        """
+        Bug #945: when NO vector_*.json files exist (fresh index), --clear must
+        still be included in the cidx index command.
+
+        For a fresh temporal index, --clear is harmless and keeps intent explicit.
+        """
+        # Do NOT create any vector files — fresh index scenario
+        # The .code-indexer/index directory may not even exist
+        cmds = self._capture_temporal_commands(registered_manager, repo_path)
+
+        assert cmds, "No 'cidx index' command issued for temporal index type."
+        temporal_cmd = cmds[0]
+        assert "--clear" in temporal_cmd, (
+            f"Bug #945: when no vector files exist, '--clear' must be present "
+            f"for a fresh temporal index. Got command: {temporal_cmd}"
+        )
+        assert "--index-commits" in temporal_cmd, (
+            f"--index-commits must be present. Got: {temporal_cmd}"
+        )
+
+    def test_temporal_omits_clear_with_provider_aware_collection(
+        self, registered_manager, repo_path
+    ):
+        """
+        Bug #945: vector existence check works for provider-aware collection names
+        (code-indexer-temporal-voyage_code_3) as well as the legacy name.
+        """
+        # Create a provider-aware temporal collection directory with a vector file
+        temporal_dir = (
+            repo_path
+            / ".code-indexer"
+            / "index"
+            / "code-indexer-temporal-voyage_code_3"
+        )
+        temporal_dir.mkdir(parents=True)
+        (temporal_dir / "vector_def456.json").write_text('{"id": "test2"}')
+
+        cmds = self._capture_temporal_commands(registered_manager, repo_path)
+
+        assert cmds, "No 'cidx index' command issued for temporal index type."
+        temporal_cmd = cmds[0]
+        assert "--clear" not in temporal_cmd, (
+            f"Bug #945: provider-aware collection with vector files must omit "
+            f"'--clear'. Got command: {temporal_cmd}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Story #478: SQLite persistence of temporal_options per golden repo
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/server/auth/test_elevate_ajax.py
+++ b/tests/unit/server/auth/test_elevate_ajax.py
@@ -1,0 +1,223 @@
+"""
+TestClient-based unit tests for POST /auth/elevate-ajax (inline modal elevation).
+
+The endpoint returns JSON (never redirects), enabling the in-page TOTP modal
+introduced in Bug #955 UX improvement. All external dependencies are patched
+with MagicMock — no real DB, no live server.
+"""
+
+import contextlib
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from code_indexer.server.web.elevation_web_routes import router as elevation_web_router
+
+# ---------------------------------------------------------------------------
+# Patch targets — must match the module where the names are looked up
+# ---------------------------------------------------------------------------
+_ENFORCEMENT_PATH = (
+    "code_indexer.server.web.elevation_web_routes._is_elevation_enforcement_enabled"
+)
+_TOTP_SERVICE_PATH = (
+    "code_indexer.server.web.elevation_web_routes.get_totp_service"
+)
+_ESM_PATH = (
+    "code_indexer.server.web.elevation_web_routes.elevated_session_manager"
+)
+_RESOLVE_SESSION_PATH = (
+    "code_indexer.server.web.elevation_web_routes._resolve_session_key"
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+_SESSION_JTI = "test-jti-ajax-xyz"
+_USERNAME = "admin"
+# Dummy bcrypt-format string — not a real credential; avoids hash computation.
+_DUMMY_HASH = "$2b$12$dummyhashfortest000000000000000000000000000000000000000"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin_user():
+    """Minimal admin User with a dummy (non-functional) password hash."""
+    from code_indexer.server.auth.user_manager import User
+
+    return User(
+        username=_USERNAME,
+        role="admin",
+        password_hash=_DUMMY_HASH,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.fixture
+def app(admin_user):
+    """Minimal FastAPI app with only the elevation web router; admin auth overridden."""
+    _app = FastAPI()
+    _app.include_router(elevation_web_router)
+    from code_indexer.server.auth import dependencies as _deps
+
+    _app.dependency_overrides[_deps.get_current_admin_user_hybrid] = (
+        lambda: admin_user
+    )
+    return _app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_totp(
+    mfa_enabled: bool = True,
+    totp_ok: bool = True,
+    recovery_ok: bool = True,
+) -> MagicMock:
+    svc = MagicMock()
+    svc.is_mfa_enabled.return_value = mfa_enabled
+    svc.verify_enabled_code.return_value = totp_ok
+    svc.verify_recovery_code.return_value = recovery_ok
+    return svc
+
+
+def _fake_esm() -> MagicMock:
+    esm = MagicMock()
+    esm.create.return_value = None
+    return esm
+
+
+@contextlib.contextmanager
+def _ajax_ctx(
+    enforcement: bool = True,
+    totp_svc=None,
+    esm=None,
+    session_key: str = _SESSION_JTI,
+):
+    """Patch all four dependencies for elevate-ajax tests and yield the esm mock."""
+    if totp_svc is None:
+        totp_svc = _fake_totp()
+    if esm is None:
+        esm = _fake_esm()
+    with (
+        patch(_ENFORCEMENT_PATH, return_value=enforcement),
+        patch(_TOTP_SERVICE_PATH, return_value=totp_svc),
+        patch(_ESM_PATH, esm),
+        patch(_RESOLVE_SESSION_PATH, return_value=session_key),
+    ):
+        yield esm
+
+
+def _post_ajax(client, *, totp_code=None, recovery_code=None, cookie=None):
+    """POST form data to /auth/elevate-ajax with an optional session cookie."""
+    data = {}
+    if totp_code is not None:
+        data["totp_code"] = totp_code
+    if recovery_code is not None:
+        data["recovery_code"] = recovery_code
+    cookies = {"cidx_session": cookie} if cookie else {}
+    return client.post("/auth/elevate-ajax", data=data, cookies=cookies)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_success_returns_json_success_true(client):
+    """Valid TOTP code with active session → 200 {"success": true}."""
+    totp_svc = _fake_totp(mfa_enabled=True, totp_ok=True)
+    esm = _fake_esm()
+    with _ajax_ctx(totp_svc=totp_svc, esm=esm):
+        resp = _post_ajax(client, totp_code="123456", cookie=_SESSION_JTI)
+
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+    esm.create.assert_called_once()
+
+
+def test_invalid_code_returns_json_success_false_401(client):
+    """Wrong TOTP code → 401 {"success": false, "error": "Invalid code."}."""
+    totp_svc = _fake_totp(mfa_enabled=True, totp_ok=False)
+    esm = _fake_esm()
+    with _ajax_ctx(totp_svc=totp_svc, esm=esm):
+        resp = _post_ajax(client, totp_code="000000", cookie=_SESSION_JTI)
+
+    assert resp.status_code == 401
+    body = resp.json()
+    assert body["success"] is False
+    assert body["error"] == "Invalid code."
+    esm.create.assert_not_called()
+
+
+def test_no_code_provided_returns_400(client):
+    """Neither totp_code nor recovery_code → 400 {"success": false}."""
+    with _ajax_ctx():
+        resp = _post_ajax(client, cookie=_SESSION_JTI)
+
+    assert resp.status_code == 400
+    assert resp.json()["success"] is False
+
+
+def test_kill_switch_off_returns_503(client):
+    """Elevation enforcement disabled → 503 {"success": false}."""
+    esm = _fake_esm()
+    with _ajax_ctx(enforcement=False, esm=esm):
+        resp = _post_ajax(client, totp_code="123456", cookie=_SESSION_JTI)
+
+    assert resp.status_code == 503
+    assert resp.json()["success"] is False
+    esm.create.assert_not_called()
+
+
+def test_no_session_returns_403(client):
+    """Session key resolves to None → 403 {"success": false, "error": "No session."}."""
+    totp_svc = _fake_totp(mfa_enabled=True)
+    esm = _fake_esm()
+    with _ajax_ctx(totp_svc=totp_svc, esm=esm, session_key=None):
+        resp = _post_ajax(client, totp_code="123456")
+
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["success"] is False
+    assert body["error"] == "No session."
+    esm.create.assert_not_called()
+
+
+def test_no_mfa_configured_returns_400(client):
+    """TOTP not enabled for user → 400 {"success": false}."""
+    totp_svc = _fake_totp(mfa_enabled=False)
+    esm = _fake_esm()
+    with _ajax_ctx(totp_svc=totp_svc, esm=esm):
+        resp = _post_ajax(client, totp_code="123456", cookie=_SESSION_JTI)
+
+    assert resp.status_code == 400
+    assert resp.json()["success"] is False
+    esm.create.assert_not_called()
+
+
+def test_recovery_code_success(client):
+    """Valid recovery code → 200 {"success": true}, elevation session created."""
+    totp_svc = _fake_totp(mfa_enabled=True, recovery_ok=True)
+    esm = _fake_esm()
+    with _ajax_ctx(totp_svc=totp_svc, esm=esm):
+        resp = _post_ajax(
+            client, recovery_code="AAAA-BBBB-CCCC-DDDD", cookie=_SESSION_JTI
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+    esm.create.assert_called_once()

--- a/tests/unit/server/self_monitoring/test_service.py
+++ b/tests/unit/server/self_monitoring/test_service.py
@@ -1005,3 +1005,80 @@ class TestOrphanedScanCleanup:
         assert call_order.index("cleanup") < call_order.index("submit"), (
             f"Expected cleanup before submit, got order: {call_order}"
         )
+
+
+class TestTokenRotation:
+    """Test suite for Bug #957 - token_fetcher refreshes token on each scheduled scan."""
+
+    @pytest.fixture()
+    def tmp_db(self, tmp_path):
+        """Provide a guaranteed-cleanup temp SQLite DB path via tmp_path."""
+        import sqlite3
+
+        db_file = tmp_path / "test_monitor.db"
+        conn = sqlite3.connect(str(db_file))
+        conn.close()
+        return str(db_file)
+
+    def _run_scan_and_capture_tokens(self, service, scan_count=1):
+        """Run _execute_scan() scan_count times; return list of github_token values passed to LogScanner."""
+        from unittest.mock import patch, MagicMock
+
+        tokens_passed = []
+
+        def capture_scanner(**kwargs):
+            tokens_passed.append(kwargs.get("github_token"))
+            mock_inst = MagicMock()
+            mock_inst.execute_scan.return_value = {"status": "SUCCESS"}
+            return mock_inst
+
+        with patch(
+            "code_indexer.server.self_monitoring.scanner.LogScanner",
+            side_effect=capture_scanner,
+        ):
+            for _ in range(scan_count):
+                service._execute_scan()
+
+        return tokens_passed
+
+    def _make_service(self, tmp_db, github_token=None, token_fetcher=None):
+        """Construct SelfMonitoringService wired to tmp_db with configurable token params."""
+        from code_indexer.server.self_monitoring.service import SelfMonitoringService
+        from unittest.mock import MagicMock
+
+        return SelfMonitoringService(
+            enabled=True,
+            cadence_minutes=60,
+            job_manager=MagicMock(),
+            db_path=tmp_db,
+            log_db_path=tmp_db,
+            github_repo="owner/repo",
+            github_token=github_token,
+            token_fetcher=token_fetcher,
+        )
+
+    def test_scheduled_scan_uses_fresh_token_after_rotation(self, tmp_db):
+        """
+        Bug #957: Second scan must pick up the rotated token, not the boot-time token.
+
+        token_fetcher returns 'old_token' on first call and 'new_token' on second,
+        simulating a token rotation between two scheduled scan ticks.
+        """
+        tokens = ["old_token", "new_token"]
+        call_index = {"n": 0}
+
+        def rotating_fetcher():
+            idx = call_index["n"]
+            call_index["n"] += 1
+            return tokens[min(idx, len(tokens) - 1)]
+
+        service = self._make_service(tmp_db, github_token=None, token_fetcher=rotating_fetcher)
+        captured = self._run_scan_and_capture_tokens(service, scan_count=2)
+
+        assert len(captured) == 2
+        assert captured[0] == "old_token", (
+            f"First scan should use 'old_token', got '{captured[0]}'"
+        )
+        assert captured[1] == "new_token", (
+            f"Second scan should use 'new_token' after rotation, got '{captured[1]}'"
+        )

--- a/tests/unit/server/services/test_dep_map_960.py
+++ b/tests/unit/server/services/test_dep_map_960.py
@@ -1,0 +1,218 @@
+"""
+Tests for Bug #960 — suppress repeated missing-domain-file warnings.
+
+parse_domain_file_for_graph() must log WARNING once per missing file path,
+then switch to DEBUG for subsequent occurrences. No exc_info=True on the warning.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Set, Tuple
+
+import pytest
+
+import code_indexer.server.services.dep_map_parser_graph as dep_map_parser_graph
+from code_indexer.server.services.dep_map_parser_graph import parse_domain_file_for_graph
+from code_indexer.server.services.dep_map_parser_hygiene import AnomalyEntry
+
+
+@pytest.fixture(autouse=True)
+def clear_warned_set():
+    """Clear the module-level dedup set before each test."""
+    dep_map_parser_graph._warned_missing_domains.clear()
+    yield
+    dep_map_parser_graph._warned_missing_domains.clear()
+
+
+def _call_parse_for_missing(
+    output_dir: Path, domain_name: str, times: int
+) -> Tuple[List[AnomalyEntry], List[Tuple[str, bool]]]:
+    """
+    Call parse_domain_file_for_graph() *times* times for a domain whose .md file
+    does not exist.  Returns (anomalies, log_records) where log_records is a list
+    of (levelname, exc_info_present) tuples captured from the logger.
+    """
+    base_dir = output_dir.resolve()
+    edge_data: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    incoming_claims: Set[frozenset] = set()
+    anomalies: List[AnomalyEntry] = []
+
+    captured: List[Tuple[str, bool]] = []
+
+    class _Handler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append((record.levelname, record.exc_info is not None))
+
+    logger = logging.getLogger("code_indexer.server.services.dep_map_parser_graph")
+    handler = _Handler()
+    logger.addHandler(handler)
+    old_level = logger.level
+    logger.setLevel(logging.DEBUG)
+
+    try:
+        for _ in range(times):
+            parse_domain_file_for_graph(
+                output_dir,
+                base_dir,
+                domain_name,
+                edge_data,
+                incoming_claims,
+                anomalies,
+            )
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(old_level)
+
+    return anomalies, captured
+
+
+class TestMissingFileWarningOnce:
+    """WARNING must be logged exactly once for a missing domain file."""
+
+    def test_missing_file_logs_warning_once(self, tmp_path: Path) -> None:
+        """Calling parse_domain_file_for_graph 5 times with same missing path
+        must produce exactly 1 WARNING and 4 DEBUG records."""
+        output_dir = tmp_path / "dep-map"
+        output_dir.mkdir()
+
+        anomalies, records = _call_parse_for_missing(output_dir, "missing-domain", 5)
+
+        warnings = [r for r in records if r[0] == "WARNING"]
+        debugs = [r for r in records if r[0] == "DEBUG"]
+
+        assert len(warnings) == 1, (
+            f"Expected exactly 1 WARNING for repeated missing file, got {len(warnings)}"
+        )
+        assert len(debugs) == 4, (
+            f"Expected exactly 4 DEBUG records for subsequent calls, got {len(debugs)}"
+        )
+
+    def test_missing_file_no_stack_trace_in_warning(self, tmp_path: Path) -> None:
+        """The WARNING for a missing domain file must not carry exc_info (no stack trace)."""
+        output_dir = tmp_path / "dep-map"
+        output_dir.mkdir()
+
+        _anomalies, records = _call_parse_for_missing(output_dir, "missing-domain", 1)
+
+        warnings = [r for r in records if r[0] == "WARNING"]
+        assert len(warnings) == 1, "Expected 1 WARNING"
+        _levelname, exc_info_present = warnings[0]
+        assert not exc_info_present, (
+            "WARNING for missing domain file must NOT carry exc_info "
+            "(no stack trace needed for a simple FileNotFoundError)"
+        )
+
+    def test_second_different_missing_file_also_warns_once(
+        self, tmp_path: Path
+    ) -> None:
+        """Two different missing file paths must each get exactly 1 WARNING."""
+        output_dir = tmp_path / "dep-map"
+        output_dir.mkdir()
+
+        base_dir = output_dir.resolve()
+        captured: List[Tuple[str, bool]] = []
+
+        class _Handler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append((record.levelname, record.message if hasattr(record, "message") else record.getMessage()))
+
+        logger = logging.getLogger("code_indexer.server.services.dep_map_parser_graph")
+        handler = _Handler()
+        logger.addHandler(handler)
+        old_level = logger.level
+        logger.setLevel(logging.DEBUG)
+
+        try:
+            for _ in range(3):
+                parse_domain_file_for_graph(
+                    output_dir, base_dir, "domain-alpha",
+                    {}, set(), [],
+                )
+            for _ in range(3):
+                parse_domain_file_for_graph(
+                    output_dir, base_dir, "domain-beta",
+                    {}, set(), [],
+                )
+        finally:
+            logger.removeHandler(handler)
+            logger.setLevel(old_level)
+
+        warnings = [r for r in captured if r[0] == "WARNING"]
+        assert len(warnings) == 2, (
+            f"Expected exactly 2 WARNINGs (one per unique missing path), "
+            f"got {len(warnings)}: {warnings}"
+        )
+
+
+class TestExistingFileStillParsesNormally:
+    """A valid domain file must still parse successfully after Bug #960 fix."""
+
+    def test_existing_file_still_parses_normally(self, tmp_path: Path) -> None:
+        """A valid domain .md file must be read and populate edge_data without warning."""
+        output_dir = tmp_path / "dep-map"
+        output_dir.mkdir()
+
+        # Write minimal _domains.json (not strictly needed for this call, but realistic)
+        (output_dir / "_domains.json").write_text(
+            json.dumps([{"name": "my-domain", "participating_repos": []}]),
+            encoding="utf-8",
+        )
+
+        # Write a valid domain file with outgoing + incoming sections
+        content = (
+            "---\nname: my-domain\n---\n"
+            "## Cross-Domain Connections\n\n"
+            "### Outgoing Dependencies\n\n"
+            "| This Repo | Depends On | Target Domain | Type | Why | Evidence |\n"
+            "|---|---|---|---|---|---|\n"
+            "| repo-a | lib-b | other-domain | Code-level | for X | ev |\n\n"
+            "### Incoming Dependencies\n\n"
+            "| External Repo | Depends On | Source Domain | Type | Why | Evidence |\n"
+            "|---|---|---|---|---|---|\n"
+        )
+        (output_dir / "my-domain.md").write_text(content, encoding="utf-8")
+
+        base_dir = output_dir.resolve()
+        edge_data: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        incoming_claims: Set[frozenset] = set()
+        anomalies: List[AnomalyEntry] = []
+
+        warned_before = set(dep_map_parser_graph._warned_missing_domains)
+
+        captured_levels: List[str] = []
+
+        class _Handler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured_levels.append(record.levelname)
+
+        logger = logging.getLogger("code_indexer.server.services.dep_map_parser_graph")
+        handler = _Handler()
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+
+        try:
+            parse_domain_file_for_graph(
+                output_dir,
+                base_dir,
+                "my-domain",
+                edge_data,
+                incoming_claims,
+                anomalies,
+            )
+        finally:
+            logger.removeHandler(handler)
+
+        # The edge ("my-domain", "other-domain") must be populated
+        assert ("my-domain", "other-domain") in edge_data, (
+            "Existing valid file must populate edge_data; bug #960 fix must not break normal parsing"
+        )
+        # No WARNING emitted for an existing, readable file
+        warnings = [lvl for lvl in captured_levels if lvl == "WARNING"]
+        assert len(warnings) == 0, (
+            f"No WARNING expected for a valid, readable domain file; got {warnings}"
+        )
+        # Module-level set must not have grown (no missing path was logged)
+        assert dep_map_parser_graph._warned_missing_domains == warned_before

--- a/tests/unit/server/services/test_dependency_latency_tracker.py
+++ b/tests/unit/server/services/test_dependency_latency_tracker.py
@@ -7,6 +7,7 @@ Tests written FIRST following TDD methodology.
 """
 
 import queue
+import sqlite3
 import threading
 import time
 from pathlib import Path
@@ -435,3 +436,162 @@ class TestDependencyLatencyTrackerSingleton:
         set_instance(tracker)
         set_instance(second)
         assert get_instance() is second
+
+
+# ── Constants for Bug #951 tests ───────────────────────────────────────────────
+
+CLOSED_DB_ERROR_MSG = "Cannot operate on a closed database"
+BUG951_FLUSH_INTERVAL_S = 0.05
+BUG951_LOOP_TERMINATE_TIMEOUT_S = 5.0
+BUG951_POLL_INTERVAL_S = 0.05
+MAX_CONSECUTIVE_FAILURES = 5
+
+
+# ── Bug #951 module-level backend stubs ───────────────────────────────────────
+
+
+class _ClosedDbBackend:
+    """Backend stub that always raises sqlite3.ProgrammingError (closed database)."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def insert_batch(self, samples) -> None:
+        self.call_count += 1
+        raise sqlite3.ProgrammingError(CLOSED_DB_ERROR_MSG)
+
+    def delete_older_than(self, cutoff) -> None:
+        self.call_count += 1
+        raise sqlite3.ProgrammingError(CLOSED_DB_ERROR_MSG)
+
+
+class _PersistentFailureBackend:
+    """Backend stub that always raises a generic RuntimeError."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def insert_batch(self, samples) -> None:
+        self.call_count += 1
+        raise RuntimeError("persistent backend failure")
+
+    def delete_older_than(self, cutoff) -> None:
+        self.call_count += 1
+        raise RuntimeError("persistent backend failure")
+
+
+# ── Bug #951 shared helpers ────────────────────────────────────────────────────
+
+_TRACKER_LOGGER_NAME = "code_indexer.server.services.dependency_latency_tracker"
+
+
+def _wait_for_stop_event(stop_event: threading.Event, timeout_s: float) -> bool:
+    """Poll until stop_event is set or timeout elapses. Returns True if set."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if stop_event.is_set():
+            return True
+        time.sleep(BUG951_POLL_INTERVAL_S)
+    return stop_event.is_set()
+
+
+class _LogCapture:
+    """Context manager that captures log records at a given level from the tracker logger."""
+
+    def __init__(self, level: int) -> None:
+        import logging
+
+        self.messages: List[str] = []
+        self._level = level
+        self._logger = logging.getLogger(_TRACKER_LOGGER_NAME)
+        self._original_level = self._logger.level
+        capture = self
+
+        class _Handler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                if record.levelno == capture._level:
+                    capture.messages.append(record.getMessage())
+
+        self._handler = _Handler()
+
+    def __enter__(self) -> "_LogCapture":
+        import logging
+
+        effective = min(self._level, self._logger.level) if self._logger.level > 0 else self._level
+        self._logger.setLevel(effective)
+        self._logger.addHandler(self._handler)
+        return self
+
+    def __exit__(self, *_) -> None:
+        self._logger.removeHandler(self._handler)
+        self._logger.setLevel(self._original_level)
+
+
+def _make_bug951_tracker(backend):
+    """Create and start a DependencyLatencyTracker with a fast flush interval."""
+    from code_indexer.server.services.dependency_latency_tracker import (
+        DependencyLatencyTracker,
+    )
+
+    t = DependencyLatencyTracker(
+        backend=backend,
+        flush_interval_s=BUG951_FLUSH_INTERVAL_S,
+        retention_s=STANDARD_RETENTION_S,
+    )
+    t.start()
+    return t
+
+
+# ── Bug #951 test class ────────────────────────────────────────────────────────
+
+
+class TestDependencyLatencyTrackerBug951:
+    """Tests for Bug #951: writer loop must not flood logs on persistent backend errors."""
+
+    def test_closed_database_terminates_loop(self) -> None:
+        """
+        sqlite3.ProgrammingError('Cannot operate on a closed database') must set
+        stop_event and terminate the thread with at most 1 warning logged.
+        """
+        import logging
+
+        backend = _ClosedDbBackend()
+        t = _make_bug951_tracker(backend)
+        with _LogCapture(logging.WARNING) as cap:
+            terminated = _wait_for_stop_event(t._stop_event, BUG951_LOOP_TERMINATE_TIMEOUT_S)
+        t._stop_event.set()
+        t._writer_thread.join(timeout=2.0)
+
+        assert terminated, "stop_event must be set when backend signals closed database"
+        assert not t._writer_thread.is_alive(), "writer thread must exit after closed-database"
+        assert backend.call_count >= 1, "backend must have been called at least once"
+        assert len(cap.messages) <= 1, (
+            f"Expected at most 1 warning (terminal), got {len(cap.messages)}: {cap.messages}"
+        )
+
+    def test_max_consecutive_failures_terminates_loop(self) -> None:
+        """
+        MAX_CONSECUTIVE_FAILURES consecutive non-closed-database errors must set
+        stop_event and log exactly 1 ERROR (not one per iteration).
+        """
+        import logging
+
+        backend = _PersistentFailureBackend()
+        t = _make_bug951_tracker(backend)
+        with _LogCapture(logging.ERROR) as cap:
+            terminated = _wait_for_stop_event(t._stop_event, BUG951_LOOP_TERMINATE_TIMEOUT_S)
+        t._stop_event.set()
+        t._writer_thread.join(timeout=2.0)
+
+        assert terminated, "stop_event must be set after max consecutive failures"
+        assert not t._writer_thread.is_alive(), "writer thread must exit after max failures"
+        assert backend.call_count >= MAX_CONSECUTIVE_FAILURES, (
+            f"Backend must be called at least {MAX_CONSECUTIVE_FAILURES} times"
+        )
+        assert backend.call_count <= MAX_CONSECUTIVE_FAILURES + 2, (
+            f"Backend must not be called more than {MAX_CONSECUTIVE_FAILURES + 2} times, "
+            f"got {backend.call_count}"
+        )
+        assert len(cap.messages) == 1, (
+            f"Expected exactly 1 error log at termination, got {len(cap.messages)}: {cap.messages}"
+        )

--- a/tests/unit/server/services/test_description_refresh_scheduler_bug953.py
+++ b/tests/unit/server/services/test_description_refresh_scheduler_bug953.py
@@ -1,0 +1,289 @@
+"""
+Unit tests for Bug #953: circuit-breaker for infinite reschedule loop.
+
+When a golden repo's descriptor file lacks YAML frontmatter or is missing
+description/last_analyzed fields, _get_refresh_prompt() returns None and
+_run_loop_single_pass() reschedules the repo -- but the missing fields are
+never populated, so the cycle never terminates.
+
+Fix: per-repo consecutive-failure counter (defaultdict(int)) on the scheduler.
+After N=3 consecutive failures the repo is quarantined (not rescheduled) and
+ONE ERROR-level log is emitted.  Counter resets to 0 on any successful refresh.
+
+Anti-mock strategy: only injected dependencies (tracking_backend, golden_backend,
+config_manager, claude_cli_manager) are mocked.  The scheduler's own methods
+run real code.  A stale repo is produced by having tracking_backend return a row
+with next_run in the past.  The prompt fails naturally because _meta_dir is left
+unset (None), so _read_existing_description() logs a warning and returns None.
+
+Test inventory:
+    TestCircuitBreakerQuarantine
+        test_repo_quarantined_on_nth_failure_not_rescheduled
+        test_repo_not_quarantined_after_n_minus_one_failures
+    TestCircuitBreakerReset
+        test_counter_resets_to_zero_after_success
+        test_after_reset_repo_is_rescheduled_on_next_failure
+        test_after_reset_repo_quarantines_again_on_nth_failure
+    TestCircuitBreakerLogging
+        test_exactly_one_error_logged_on_quarantine
+        test_no_additional_error_logged_after_quarantine_established
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+_QUARANTINE_THRESHOLD = 3   # must match PROMPT_FAILURE_QUARANTINE_THRESHOLD in scheduler
+_PAST_TIME = "2000-01-01T00:00:00+00:00"  # always stale -- triggers get_stale_repos
+_REFRESH_INTERVAL_HOURS = 24  # bucket count for calculate_next_run()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_scheduler(tmp_path):
+    """
+    Construct DescriptionRefreshScheduler with injectable backends.
+
+    tracking_backend returns one stale repo row (next_run in the past).
+    golden_backend returns the matching clone_path.
+    config_manager returns a minimal config so calculate_next_run() works.
+    claude_cli_manager is required so _run_loop_single_pass() enters the
+    prompt-generation branch (without it the scheduler skips silently).
+    _meta_dir is intentionally not set so _get_refresh_prompt() returns None
+    naturally via _read_existing_description() -> "meta directory not set".
+
+    Returns (scheduler, tracking_backend, alias, clone_path).
+    """
+    from code_indexer.server.services.description_refresh_scheduler import (
+        DescriptionRefreshScheduler,
+    )
+    from code_indexer.server.utils.config_manager import (
+        ClaudeIntegrationConfig,
+        ServerConfig,
+    )
+
+    alias = "broken-repo"
+    clone_path = str(tmp_path)
+
+    stale_row = {
+        "repo_alias": alias,
+        "clone_path": clone_path,
+        "next_run": _PAST_TIME,
+        "status": "pending",
+    }
+
+    tracking_backend = MagicMock(name="tracking_backend")
+    tracking_backend.get_stale_repos.return_value = [stale_row]
+
+    golden_backend = MagicMock(name="golden_backend")
+    golden_backend.get_repo.return_value = {"clone_path": clone_path}
+
+    config = ServerConfig(server_dir=str(tmp_path))
+    config.claude_integration_config = ClaudeIntegrationConfig()
+    config.claude_integration_config.description_refresh_enabled = True
+    config.claude_integration_config.description_refresh_interval_hours = (
+        _REFRESH_INTERVAL_HOURS
+    )
+
+    config_manager = MagicMock(name="config_manager")
+    config_manager.load_config.return_value = config
+
+    scheduler = DescriptionRefreshScheduler(
+        tracking_backend=tracking_backend,
+        golden_backend=golden_backend,
+        config_manager=config_manager,
+        claude_cli_manager=MagicMock(name="claude_cli_manager"),
+        # _meta_dir intentionally omitted -- prompt returns None naturally
+    )
+    return scheduler, tracking_backend, alias, clone_path
+
+
+def _was_repo_rescheduled(tracking_backend: MagicMock, alias: str) -> bool:
+    """Return True if upsert_tracking was called for *alias* on the last pass."""
+    return any(
+        call_.kwargs.get("repo_alias") == alias
+        or (len(call_.args) > 0 and call_.args[0] == alias)
+        for call_ in tracking_backend.upsert_tracking.call_args_list
+    )
+
+
+def _run_one_failing_pass(scheduler, tracking_backend) -> None:
+    """Reset the upsert mock and run one _run_loop_single_pass()."""
+    tracking_backend.upsert_tracking.reset_mock()
+    scheduler._run_loop_single_pass()
+
+
+def _run_n_failing_passes(scheduler, tracking_backend, n: int) -> None:
+    """Run *n* failing passes, resetting the upsert mock before each."""
+    for _ in range(n):
+        _run_one_failing_pass(scheduler, tracking_backend)
+
+
+def _collect_quarantine_errors(
+    scheduler, tracking_backend, alias: str, passes: int
+) -> list:
+    """Run *passes* failing passes and return quarantine ERROR log records for *alias*."""
+    error_records: list = []
+    module_logger = logging.getLogger(
+        "code_indexer.server.services.description_refresh_scheduler"
+    )
+
+    class _ErrorCapture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            if (
+                record.levelno >= logging.ERROR
+                and alias in record.getMessage()
+                and "quarantine" in record.getMessage().lower()
+            ):
+                error_records.append(record)
+
+    handler = _ErrorCapture()
+    module_logger.addHandler(handler)
+    try:
+        _run_n_failing_passes(scheduler, tracking_backend, passes)
+    finally:
+        module_logger.removeHandler(handler)
+    return error_records
+
+
+# ---------------------------------------------------------------------------
+# TestCircuitBreakerQuarantine
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreakerQuarantine:
+    """Verify that a repo is quarantined on the Nth consecutive prompt failure."""
+
+    def test_repo_quarantined_on_nth_failure_not_rescheduled(self, tmp_path):
+        """
+        On the Nth consecutive None-prompt failure the scheduler must NOT call
+        upsert_tracking for that repo (quarantine fires on the Nth run itself).
+        """
+        scheduler, tracking_backend, alias, _ = _make_scheduler(tmp_path)
+
+        for i in range(_QUARANTINE_THRESHOLD - 1):
+            _run_one_failing_pass(scheduler, tracking_backend)
+            assert _was_repo_rescheduled(tracking_backend, alias), (
+                f"Repo must be rescheduled on failure #{i + 1} "
+                f"(threshold={_QUARANTINE_THRESHOLD})"
+            )
+
+        # Nth pass: quarantine fires -- must NOT reschedule
+        _run_one_failing_pass(scheduler, tracking_backend)
+
+        assert not _was_repo_rescheduled(tracking_backend, alias), (
+            f"Quarantined repo '{alias}' must NOT be rescheduled on the "
+            f"{_QUARANTINE_THRESHOLD}th consecutive failure"
+        )
+
+    def test_repo_not_quarantined_after_n_minus_one_failures(self, tmp_path):
+        """
+        After N-1 consecutive failures the repo must still be rescheduled;
+        quarantine must not fire before the Nth failure.
+        """
+        scheduler, tracking_backend, alias, _ = _make_scheduler(tmp_path)
+
+        for i in range(_QUARANTINE_THRESHOLD - 1):
+            _run_one_failing_pass(scheduler, tracking_backend)
+            assert _was_repo_rescheduled(tracking_backend, alias), (
+                f"Repo must still be rescheduled on failure #{i + 1} "
+                f"(threshold is {_QUARANTINE_THRESHOLD})"
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestCircuitBreakerReset
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreakerReset:
+    """Verify counter resets to zero on success and quarantine re-arms correctly."""
+
+    def test_counter_resets_to_zero_after_success(self, tmp_path):
+        """on_refresh_complete(success=True) resets _prompt_failure_counts to 0."""
+        scheduler, tracking_backend, alias, clone_path = _make_scheduler(tmp_path)
+
+        _run_n_failing_passes(scheduler, tracking_backend, _QUARANTINE_THRESHOLD - 1)
+
+        assert scheduler._prompt_failure_counts[alias] == _QUARANTINE_THRESHOLD - 1, (
+            f"Expected failure count {_QUARANTINE_THRESHOLD - 1}, "
+            f"got {scheduler._prompt_failure_counts[alias]}"
+        )
+
+        scheduler.on_refresh_complete(alias, clone_path, success=True)
+
+        assert scheduler._prompt_failure_counts[alias] == 0, (
+            f"Failure counter must reset to 0 after success, "
+            f"got {scheduler._prompt_failure_counts[alias]}"
+        )
+
+    def test_after_reset_repo_is_rescheduled_on_next_failure(self, tmp_path):
+        """After a reset, the first subsequent failure must reschedule (not quarantine)."""
+        scheduler, tracking_backend, alias, clone_path = _make_scheduler(tmp_path)
+
+        _run_n_failing_passes(scheduler, tracking_backend, _QUARANTINE_THRESHOLD - 1)
+        scheduler.on_refresh_complete(alias, clone_path, success=True)
+
+        _run_one_failing_pass(scheduler, tracking_backend)
+
+        assert _was_repo_rescheduled(tracking_backend, alias), (
+            "After counter reset, the first new failure must reschedule the repo"
+        )
+
+    def test_after_reset_repo_quarantines_again_on_nth_failure(self, tmp_path):
+        """After a reset and N new failures, the repo must be quarantined again."""
+        scheduler, tracking_backend, alias, clone_path = _make_scheduler(tmp_path)
+
+        _run_n_failing_passes(scheduler, tracking_backend, _QUARANTINE_THRESHOLD - 1)
+        scheduler.on_refresh_complete(alias, clone_path, success=True)
+
+        _run_n_failing_passes(scheduler, tracking_backend, _QUARANTINE_THRESHOLD - 1)
+        _run_one_failing_pass(scheduler, tracking_backend)
+
+        assert not _was_repo_rescheduled(tracking_backend, alias), (
+            f"After counter reset and {_QUARANTINE_THRESHOLD} new failures, "
+            "repo must be quarantined again"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestCircuitBreakerLogging
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreakerLogging:
+    """Verify that the quarantine boundary emits exactly one ERROR log."""
+
+    def test_exactly_one_error_logged_on_quarantine(self, tmp_path):
+        """Exactly one ERROR quarantine log must be emitted when the threshold is hit."""
+        scheduler, tracking_backend, alias, _ = _make_scheduler(tmp_path)
+
+        errors = _collect_quarantine_errors(
+            scheduler, tracking_backend, alias, _QUARANTINE_THRESHOLD
+        )
+
+        assert len(errors) == 1, (
+            f"Expected exactly 1 quarantine ERROR log, got {len(errors)}: "
+            f"{[r.getMessage() for r in errors]}"
+        )
+
+    def test_no_additional_error_logged_after_quarantine_established(self, tmp_path):
+        """No further quarantine ERROR logs after the repo is already quarantined."""
+        scheduler, tracking_backend, alias, _ = _make_scheduler(tmp_path)
+
+        _collect_quarantine_errors(
+            scheduler, tracking_backend, alias, _QUARANTINE_THRESHOLD
+        )
+
+        post_errors = _collect_quarantine_errors(
+            scheduler, tracking_backend, alias, _QUARANTINE_THRESHOLD
+        )
+
+        assert len(post_errors) == 0, (
+            f"No additional quarantine ERROR logs expected after quarantine established, "
+            f"got {len(post_errors)}"
+        )

--- a/tests/unit/server/services/test_job_tracker_bug952.py
+++ b/tests/unit/server/services/test_job_tracker_bug952.py
@@ -1,0 +1,124 @@
+"""
+Unit tests for Bug #952: update_status WARNING flood on cleared jobs.
+
+Bug #952: JobTracker.update_status logs WARNING every time it is called for a
+job that has already been removed from _active_jobs.  Producers (background
+workers) keep calling update_status for a short window after a job completes
+and is cleared — this is normal concurrent behaviour, not an error.
+
+Fix: downgrade the WARNING at line 439 to DEBUG so operators are not flooded.
+
+Acceptance criteria:
+  AC1 - update_status on a completed/cleared job: no WARNING, returns None.
+  AC2 - update_status on a failed/cleared job: no WARNING, returns None.
+  AC3 - update_status on a completely unknown job_id: no WARNING, returns None.
+  AC4 - update_status on an unknown job_id does emit a DEBUG entry (info
+        preserved for debug sessions, just not polluting operator logs).
+"""
+
+import logging
+
+
+def _assert_no_warning(caplog) -> None:
+    """Raise AssertionError if any WARNING (or higher) records exist."""
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == [], (
+        f"Expected no WARNING entries, got: {[r.message for r in warnings]}"
+    )
+
+
+class TestUpdateStatusClearedJobNoWarning:
+    """AC1 + AC2: update_status on a cleared job must not emit WARNING."""
+
+    def test_update_status_cleared_job_no_warning(self, tracker, caplog):
+        """
+        Calling update_status for a completed (cleared) job must not emit
+        a WARNING and must return None gracefully.
+
+        Given a registered job that has been completed (removed from memory)
+        When update_status is called for that job_id
+        Then no WARNING-level entry is emitted and result is None.
+        """
+        tracker.register_job("job-bug952-ac1", "dep_map_analysis", "admin")
+        tracker.complete_job("job-bug952-ac1")
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="code_indexer.server.services.job_tracker",
+        ):
+            result = tracker.update_status(
+                "job-bug952-ac1", status="running", progress=50
+            )
+
+        _assert_no_warning(caplog)
+        assert result is None
+
+    def test_update_status_failed_job_no_warning(self, tracker, caplog):
+        """
+        Calling update_status for a failed (cleared) job must not emit
+        a WARNING and must return None gracefully.
+
+        Given a registered job that has been failed (removed from memory)
+        When update_status is called for that job_id
+        Then no WARNING-level entry is emitted and result is None.
+        """
+        tracker.register_job("job-bug952-ac2", "dep_map_analysis", "admin")
+        tracker.fail_job("job-bug952-ac2", error="intentional failure")
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="code_indexer.server.services.job_tracker",
+        ):
+            result = tracker.update_status("job-bug952-ac2", progress=75)
+
+        _assert_no_warning(caplog)
+        assert result is None
+
+
+class TestUpdateStatusUnknownJobNoWarning:
+    """AC3 + AC4: update_status on an unknown job_id."""
+
+    def test_update_status_unknown_job_no_warning(self, tracker, caplog):
+        """
+        Calling update_status for a job_id never registered must not emit
+        a WARNING and must return None gracefully.
+
+        Given a job_id that was never registered
+        When update_status is called
+        Then no WARNING-level entry is emitted and result is None.
+        """
+        with caplog.at_level(
+            logging.WARNING,
+            logger="code_indexer.server.services.job_tracker",
+        ):
+            result = tracker.update_status(
+                "job-never-existed-952", status="running"
+            )
+
+        _assert_no_warning(caplog)
+        assert result is None
+
+    def test_update_status_unknown_job_emits_debug(self, tracker, caplog):
+        """
+        Calling update_status for an unknown job_id SHOULD emit a DEBUG entry
+        so the information is available when debug logging is enabled.
+
+        Given a job_id that was never registered
+        When update_status is called with DEBUG logging enabled
+        Then at least one DEBUG entry mentioning the job_id is present.
+        """
+        job_id = "job-debug-check-952"
+        with caplog.at_level(
+            logging.DEBUG,
+            logger="code_indexer.server.services.job_tracker",
+        ):
+            tracker.update_status(job_id, status="running")
+
+        debug_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.DEBUG and job_id in r.getMessage()
+        ]
+        assert debug_records, (
+            "Expected at least one DEBUG entry mentioning the job_id, got none"
+        )

--- a/tests/unit/services/test_progress_subprocess_runner.py
+++ b/tests/unit/services/test_progress_subprocess_runner.py
@@ -253,6 +253,179 @@ class TestRunWithPopenProgress:
         )
 
 
+class TestSigtermErrorDetails:
+    """Tests for Bug #934: SIGTERM (returncode -15) must always appear in error_details."""
+
+    def test_sigterm_exit_error_details_contains_signal_info(self):
+        """
+        When subprocess returncode is -15 (SIGTERM) and stderr is empty but stdout
+        has content (e.g. startup banner), the raised IndexingSubprocessError must
+        contain signal-identifying text so the refresh_scheduler SIGTERM matcher works.
+        The startup banner text must NOT be the only content.
+        """
+        import os
+        import signal
+        import sys
+
+        from code_indexer.services.progress_phase_allocator import (
+            ProgressPhaseAllocator,
+        )
+        from code_indexer.services.progress_subprocess_runner import (
+            IndexingSubprocessError,
+            run_with_popen_progress,
+        )
+
+        allocator = ProgressPhaseAllocator()
+        allocator.calculate_weights(
+            index_types=["semantic"],
+            file_count=10,
+            commit_count=0,
+        )
+
+        # Script prints banner to stdout (like cidx startup), then kills itself with SIGTERM.
+        # stderr stays empty. Simulates cidx being SIGTERMed while it just printed its banner.
+        script = (
+            "import os, signal, sys\n"
+            "sys.stdout.write('cidx startup banner line 1\\n')\n"
+            "sys.stdout.write('cidx startup banner line 2\\n')\n"
+            "sys.stdout.flush()\n"
+            "os.kill(os.getpid(), signal.SIGTERM)\n"
+        )
+        command = [sys.executable, "-c", script]
+        all_stdout: list = []
+        all_stderr: list = []
+
+        with pytest.raises(IndexingSubprocessError) as exc_info:
+            run_with_popen_progress(
+                command=command,
+                phase_name="semantic",
+                allocator=allocator,
+                progress_callback=None,
+                all_stdout=all_stdout,
+                all_stderr=all_stderr,
+                cwd=None,
+            )
+
+        error_msg = str(exc_info.value)
+        # Bug #934: signal info must be present — "Exit code -15" is what refresh_scheduler matches
+        assert "Exit code -15" in error_msg, (
+            f"Expected 'Exit code -15' in error message for SIGTERM kill, "
+            f"but got: {error_msg!r}. The startup banner must not be the only content."
+        )
+
+    def test_negative_returncode_signal_info_always_present(self):
+        """
+        For any negative returncode (not just -15), the error_details must
+        contain 'Exit code <N>' so that callers can reliably match on returncode.
+        When stderr is empty and stdout has content, the signal info still takes precedence.
+        """
+        import sys
+
+        from code_indexer.services.progress_phase_allocator import (
+            ProgressPhaseAllocator,
+        )
+        from code_indexer.services.progress_subprocess_runner import (
+            IndexingSubprocessError,
+            run_with_popen_progress,
+        )
+
+        allocator = ProgressPhaseAllocator()
+        allocator.calculate_weights(
+            index_types=["semantic"],
+            file_count=10,
+            commit_count=0,
+        )
+
+        # Script prints stdout banner, then exits with SIGKILL equivalent (-9) by using
+        # os.kill with SIGKILL.
+        import signal
+
+        script = (
+            "import os, signal, sys\n"
+            "sys.stdout.write('some startup output\\n')\n"
+            "sys.stdout.flush()\n"
+            "os.kill(os.getpid(), signal.SIGKILL)\n"
+        )
+        command = [sys.executable, "-c", script]
+        all_stdout: list = []
+        all_stderr: list = []
+
+        with pytest.raises(IndexingSubprocessError) as exc_info:
+            run_with_popen_progress(
+                command=command,
+                phase_name="semantic",
+                allocator=allocator,
+                progress_callback=None,
+                all_stdout=all_stdout,
+                all_stderr=all_stderr,
+                cwd=None,
+            )
+
+        error_msg = str(exc_info.value)
+        # For SIGKILL (-9), error must contain "Exit code -9"
+        assert "Exit code -9" in error_msg, (
+            f"Expected 'Exit code -9' in error for SIGKILL, got: {error_msg!r}"
+        )
+
+    def test_refresh_scheduler_sigterm_detection_matches_new_format(self):
+        """
+        The refresh_scheduler.py SIGTERM detection at line 1683 checks for
+        'Exit code -15' in the error message. After Bug #934 fix, the
+        IndexingSubprocessError raised for returncode=-15 must contain that
+        substring so the routing works correctly.
+        This test verifies the produced error message is compatible with the
+        refresh_scheduler matcher without importing refresh_scheduler itself.
+        """
+        import signal
+        import sys
+
+        from code_indexer.services.progress_phase_allocator import (
+            ProgressPhaseAllocator,
+        )
+        from code_indexer.services.progress_subprocess_runner import (
+            IndexingSubprocessError,
+            run_with_popen_progress,
+        )
+
+        allocator = ProgressPhaseAllocator()
+        allocator.calculate_weights(
+            index_types=["semantic"],
+            file_count=10,
+            commit_count=0,
+        )
+
+        # Simulate cidx being SIGTERMed with non-empty stdout (startup banner) and empty stderr
+        script = (
+            "import os, signal, sys\n"
+            "sys.stdout.write('Code Indexer v9.x.y - startup banner\\n')\n"
+            "sys.stdout.flush()\n"
+            "os.kill(os.getpid(), signal.SIGTERM)\n"
+        )
+        command = [sys.executable, "-c", script]
+        all_stdout: list = []
+        all_stderr: list = []
+
+        error_msg = ""
+        with pytest.raises(IndexingSubprocessError) as exc_info:
+            run_with_popen_progress(
+                command=command,
+                phase_name="semantic",
+                allocator=allocator,
+                progress_callback=None,
+                all_stdout=all_stdout,
+                all_stderr=all_stderr,
+                cwd=None,
+            )
+        error_msg = str(exc_info.value)
+
+        # This is exactly what refresh_scheduler.py:1683 checks:
+        sigterm_detected = "Exit code -15" in error_msg or "returncode=-15" in error_msg
+        assert sigterm_detected, (
+            f"refresh_scheduler SIGTERM detection would FAIL for error: {error_msg!r}. "
+            f"SIGTERM jobs would be mis-routed to ERROR path and counted as failed_jobs."
+        )
+
+
 class TestGatherRepoMetrics:
     """Tests for gather_repo_metrics shared utility."""
 

--- a/tests/unit/services/test_provider_health_monitor_959.py
+++ b/tests/unit/services/test_provider_health_monitor_959.py
@@ -1,0 +1,316 @@
+"""Tests for Bug #959: transition-gate provider health warnings to suppress repeated log spam.
+
+When a provider stays in "degraded" or "down" state across repeated _compute_status()
+calls, the logger must emit WARNING only on the transition into that state — not on
+every subsequent call that yields the same status.
+
+When the provider returns to "healthy", one INFO log is emitted and the tracker is
+reset so that a future degraded/down transition again logs one WARNING.
+
+Test inventory:
+    TestTransitionBasedLogging
+        test_warning_logged_once_when_entering_degraded
+        test_warning_logged_once_when_entering_down
+        test_warning_logged_again_on_down_to_degraded_transition
+        test_recovery_to_healthy_logs_info_and_resets
+        test_debug_on_repeated_same_status
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from code_indexer.services.provider_health_monitor import ProviderHealthMonitor
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Provider key used across all tests
+_PROVIDER = "voyage-ai"
+
+# Module logger name (for caplog targeting)
+_LOGGER_NAME = "code_indexer.services.provider_health_monitor"
+
+# Monitor configuration thresholds
+_ERROR_RATE_THRESHOLD = 0.1       # 10% error rate -> degraded
+_LATENCY_P95_MS = 5000.0          # 5 s p95 latency threshold
+
+# Failure count well above DEFAULT_DOWN_CONSECUTIVE_FAILURES (5) -> "down"
+_DOWN_FAILURE_COUNT = 10
+
+# Latency used when recording failures (irrelevant; only success flag matters)
+_FAILURE_CALL_LATENCY_MS = 0.0
+
+# _drive_degraded pattern: _DEGRADED_ROUNDS rounds of _DEGRADED_SUCCESS_PER_ROUND
+# successes + _DEGRADED_FAILURE_PER_ROUND failure = 20 calls, 20% error rate
+_DEGRADED_ROUNDS = 5
+_DEGRADED_SUCCESS_PER_ROUND = 4
+_DEGRADED_FAILURE_PER_ROUND = 1
+_DEGRADED_CALL_LATENCY_MS = 100.0
+
+# Number of consecutive successes sufficient to restore "healthy" after "down".
+# Must satisfy BOTH: error_rate < 0.1 AND availability >= 0.95 (DEFAULT_AVAILABILITY_THRESHOLD).
+# With _DOWN_FAILURE_COUNT (10) failures: need N such that N/(10+N) >= 0.95 → N >= 190.
+# N=200 gives availability=200/210≈0.952 > 0.95 and error_rate=10/210≈0.048 < 0.1.
+_RECOVERY_SUCCESS_COUNT = 200
+
+# Partial recovery: enough successes to drop below DEFAULT_DOWN_ERROR_RATE (50%)
+# while keeping error rate above _ERROR_RATE_THRESHOLD (10%) -> "degraded".
+# Trailing failures must be < DEFAULT_DOWN_CONSECUTIVE_FAILURES (5) to avoid
+# re-triggering "down" via the consecutive-failures gate.
+# With 10 prior + 40 successes + 4 failures = 54 calls: error_rate = 14/54 ≈ 25.9%,
+# consecutive = 4 < 5 → "degraded".
+_PARTIAL_RECOVERY_SUCCESS_COUNT = 40
+_PARTIAL_RECOVERY_FAILURE_COUNT = 4
+
+# get_health poll counts for the single-status-entry tests
+_GET_HEALTH_CALLS = 3          # repeated polls in the degraded-entry test
+_DOWN_GET_HEALTH_CALLS = 5     # repeated polls in the down-entry test
+
+# How many times to call get_health in the "repeated same status" scenario
+_REPEATED_GET_HEALTH_CALLS = 4
+
+# Expected log counts used in assertions (no raw literals in test bodies)
+_EXPECTED_SINGLE_WARNING = 1    # exactly one WARNING per status transition
+_EXPECTED_SINGLE_INFO = 1       # exactly one INFO on recovery to healthy
+_EXPECTED_NO_WARNINGS = 0       # no WARNINGs when status has not changed
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset() -> ProviderHealthMonitor:
+    """Return a fresh ProviderHealthMonitor with the singleton reset."""
+    ProviderHealthMonitor.reset_instance()
+    return ProviderHealthMonitor(
+        error_rate_threshold=_ERROR_RATE_THRESHOLD,
+        latency_p95_threshold_ms=_LATENCY_P95_MS,
+    )
+
+
+def _count_logs(
+    caplog: pytest.LogCaptureFixture,
+    level: int,
+    *,
+    provider: str = _PROVIDER,
+) -> int:
+    """Count log records at *level* whose message contains *provider*."""
+    return len([
+        r for r in caplog.records
+        if r.levelno == level and provider in r.getMessage()
+    ])
+
+
+def _count_health_transition_logs(
+    caplog: pytest.LogCaptureFixture,
+    level: int,
+    *,
+    provider: str = _PROVIDER,
+) -> int:
+    """Count health-state transition logs, excluding sin-bin circuit-breaker messages."""
+    return len([
+        r for r in caplog.records
+        if r.levelno == level
+        and provider in r.getMessage()
+        and "sin-binned" not in r.getMessage()
+    ])
+
+
+def _drive_down(monitor: ProviderHealthMonitor, n: int = _DOWN_FAILURE_COUNT) -> None:
+    """Record n consecutive failures to push provider into 'down' state."""
+    for _ in range(n):
+        monitor.record_call(_PROVIDER, latency_ms=_FAILURE_CALL_LATENCY_MS, success=False)
+
+
+def _drive_degraded(monitor: ProviderHealthMonitor) -> None:
+    """Interleave successes/failures to produce >10% error rate without triggering 'down'.
+
+    Pattern: _DEGRADED_SUCCESS_PER_ROUND successes then _DEGRADED_FAILURE_PER_ROUND
+    failure per round, repeated _DEGRADED_ROUNDS times.
+    Error rate = 20% > _ERROR_RATE_THRESHOLD.
+    Consecutive failures never exceed 1, so the down threshold (5) is not reached.
+    """
+    for _ in range(_DEGRADED_ROUNDS):
+        for _ in range(_DEGRADED_SUCCESS_PER_ROUND):
+            monitor.record_call(_PROVIDER, latency_ms=_DEGRADED_CALL_LATENCY_MS, success=True)
+        monitor.record_call(
+            _PROVIDER, latency_ms=_DEGRADED_CALL_LATENCY_MS, success=False
+        )
+
+
+def _drive_healthy(monitor: ProviderHealthMonitor, n: int = _RECOVERY_SUCCESS_COUNT) -> None:
+    """Record n consecutive successes to return provider to 'healthy' state."""
+    for _ in range(n):
+        monitor.record_call(_PROVIDER, latency_ms=_DEGRADED_CALL_LATENCY_MS, success=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionBasedLogging:
+    """WARNING must fire once on status entry; DEBUG thereafter; INFO on healthy return."""
+
+    def setup_method(self) -> None:
+        ProviderHealthMonitor.reset_instance()
+
+    def teardown_method(self) -> None:
+        ProviderHealthMonitor.reset_instance()
+
+    def test_warning_logged_once_when_entering_degraded(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Degraded polled _GET_HEALTH_CALLS times via get_health: exactly 1 WARNING logged."""
+        monitor = _reset()
+        _drive_degraded(monitor)  # establish degraded state
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            caplog.clear()
+            for _ in range(_GET_HEALTH_CALLS):
+                result = monitor.get_health(_PROVIDER)
+                assert result[_PROVIDER].status == "degraded", (
+                    f"Expected 'degraded', got {result[_PROVIDER].status}"
+                )
+
+        warning_count = _count_logs(caplog, logging.WARNING)
+        assert warning_count == _EXPECTED_SINGLE_WARNING, (
+            f"Expected {_EXPECTED_SINGLE_WARNING} WARNING for degraded entry, "
+            f"got {warning_count}. "
+            f"Records: {[r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]}"
+        )
+
+    def test_warning_logged_once_when_entering_down(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Down polled _DOWN_GET_HEALTH_CALLS times via get_health: exactly 1 WARNING logged."""
+        monitor = _reset()
+        _drive_down(monitor)  # establish down state
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            caplog.clear()
+            for _ in range(_DOWN_GET_HEALTH_CALLS):
+                result = monitor.get_health(_PROVIDER)
+                assert result[_PROVIDER].status == "down", (
+                    f"Expected 'down', got {result[_PROVIDER].status}"
+                )
+
+        warning_count = _count_logs(caplog, logging.WARNING)
+        assert warning_count == _EXPECTED_SINGLE_WARNING, (
+            f"Expected {_EXPECTED_SINGLE_WARNING} WARNING for down entry, "
+            f"got {warning_count}. "
+            f"Records: {[r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]}"
+        )
+
+    def test_warning_logged_again_on_down_to_degraded_transition(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Status transitions down -> degraded: exactly 1 WARNING for the new transition."""
+        monitor = _reset()
+
+        # Phase 1: drive to 'down'
+        _drive_down(monitor)
+
+        # Phase 2: inject _PARTIAL_RECOVERY_SUCCESS_COUNT successes to bring error_rate
+        # below DEFAULT_DOWN_ERROR_RATE (50%), then _PARTIAL_RECOVERY_FAILURE_COUNT
+        # failures to keep it above _ERROR_RATE_THRESHOLD (10%) -> "degraded".
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            caplog.clear()
+
+            for _ in range(_PARTIAL_RECOVERY_SUCCESS_COUNT):
+                monitor.record_call(
+                    _PROVIDER, latency_ms=_DEGRADED_CALL_LATENCY_MS, success=True
+                )
+            for _ in range(_PARTIAL_RECOVERY_FAILURE_COUNT):
+                monitor.record_call(
+                    _PROVIDER, latency_ms=_DEGRADED_CALL_LATENCY_MS, success=False
+                )
+
+            new_status = monitor.get_health(_PROVIDER)[_PROVIDER].status
+            assert new_status == "degraded", (
+                f"Expected 'degraded' after partial recovery, got '{new_status}'"
+            )
+
+        # Use health-transition-only counter: sin-bin circuit-breaker WARNINGs are
+        # unrelated to the transition gate and must not inflate the count.
+        warning_count = _count_health_transition_logs(caplog, logging.WARNING)
+        assert warning_count == _EXPECTED_SINGLE_WARNING, (
+            f"Expected {_EXPECTED_SINGLE_WARNING} WARNING for down->degraded transition, "
+            f"got {warning_count}. "
+            f"Records: {[r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]}"
+        )
+
+    def test_recovery_to_healthy_logs_info_and_resets(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Healthy after down: exactly 1 INFO logged; next degraded entry logs exactly 1 WARNING."""
+        monitor = _reset()
+
+        # Establish 'down'
+        _drive_down(monitor)
+
+        with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+            caplog.clear()
+            _drive_healthy(monitor)
+            result = monitor.get_health(_PROVIDER)
+            assert result[_PROVIDER].status == "healthy", (
+                f"Expected 'healthy' after recovery, got '{result[_PROVIDER].status}'"
+            )
+
+        info_count = _count_logs(caplog, logging.INFO)
+        assert info_count == _EXPECTED_SINGLE_INFO, (
+            f"Expected {_EXPECTED_SINGLE_INFO} INFO on recovery to healthy, "
+            f"got {info_count}. "
+            f"Records: {[r.getMessage() for r in caplog.records if r.levelno == logging.INFO]}"
+        )
+
+        # Drive degraded again — tracker was reset on healthy, must log exactly 1 WARNING
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            caplog.clear()
+            _drive_degraded(monitor)
+            monitor.get_health(_PROVIDER)
+
+        warning_count_after_reset = _count_health_transition_logs(caplog, logging.WARNING)
+        assert warning_count_after_reset == _EXPECTED_SINGLE_WARNING, (
+            f"Expected {_EXPECTED_SINGLE_WARNING} WARNING after recovery reset, "
+            f"got {warning_count_after_reset}"
+        )
+
+    def test_debug_on_repeated_same_status(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Repeated same-status calls: 0 WARNINGs, at least _REPEATED_GET_HEALTH_CALLS DEBUGs."""
+        monitor = _reset()
+
+        # Establish 'down' and consume the first transition WARNING before the
+        # assertion window. record_call() uses _log_transitions=False so the
+        # tracker hasn't fired yet; this get_health() call fires the first WARNING
+        # and updates _last_logged_status so subsequent calls produce DEBUG.
+        _drive_down(monitor)
+        monitor.get_health(_PROVIDER)  # consume first "down" transition
+
+        with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+            caplog.clear()
+            for _ in range(_REPEATED_GET_HEALTH_CALLS):
+                result = monitor.get_health(_PROVIDER)
+                assert result[_PROVIDER].status == "down", (
+                    f"Expected 'down', got {result[_PROVIDER].status}"
+                )
+
+        warning_count = _count_logs(caplog, logging.WARNING)
+        debug_count = _count_logs(caplog, logging.DEBUG)
+
+        assert warning_count == _EXPECTED_NO_WARNINGS, (
+            f"Expected {_EXPECTED_NO_WARNINGS} WARNINGs for repeated same-status (down), "
+            f"got {warning_count}. "
+            f"Records: {[r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]}"
+        )
+        assert debug_count >= _REPEATED_GET_HEALTH_CALLS, (
+            f"Expected >= {_REPEATED_GET_HEALTH_CALLS} DEBUG records for "
+            f"{_REPEATED_GET_HEALTH_CALLS} same-status get_health calls, got {debug_count}"
+        )

--- a/tests/unit/storage/test_atomic_writes_946.py
+++ b/tests/unit/storage/test_atomic_writes_946.py
@@ -1,0 +1,432 @@
+"""
+Tests for Bug #946 atomic write fixes.
+
+Verifies that each fixed write site leaves the original file intact
+when the write raises midway (simulating a process kill via partial content
+then exception). Also verifies no temp files are leaked on both failure
+and success paths, and that the successful write path produces valid output.
+
+Patching strategies by site:
+  Site 1 (save_incremental_update HNSW): instance-level patch on the index object
+  Sites 2-4 (JSON writes): module-level json.dump patching via string target
+  Site 5 (build_index HNSW): class-level patch on hnswlib.Index.save_index since
+    build_index creates its own index internally
+
+Sites covered:
+  1. hnsw_index_manager.save_incremental_update — HNSW binary (active production crash)
+  2. hnsw_index_manager.mark_stale — metadata JSON
+  3. hnsw_index_manager._update_metadata — metadata JSON
+  4. progressive_metadata._save_metadata — watermark JSON
+  5. hnsw_index_manager.build_index — full-rebuild HNSW binary
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from code_indexer.services.progressive_metadata import ProgressiveMetadata
+from code_indexer.storage.hnsw_index_manager import HNSWIndexManager
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VECTOR_DIM = 64  # small for speed
+
+
+# ---------------------------------------------------------------------------
+# Shared failure simulators
+# ---------------------------------------------------------------------------
+
+
+def _partial_write_then_raise(path: str) -> None:
+    """Write partial binary content to path then raise OSError.
+
+    Simulates a process kill that occurs after the file is opened but before
+    the write completes. Used to patch index.save_index.
+    """
+    with open(path, "wb") as f:
+        f.write(b"\x00" * 8)
+    raise OSError("Simulated kill during HNSW binary write")
+
+
+def _partial_json_then_raise(obj: Any, f: Any, **kwargs: Any) -> None:
+    """Write an incomplete JSON fragment then raise OSError.
+
+    Simulates a process kill mid json.dump.
+    """
+    f.write('{"partial": true, "incomplete":')
+    raise OSError("Simulated kill during json.dump")
+
+
+# ---------------------------------------------------------------------------
+# Shared assertion helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_no_tmp_files(directory: Path) -> None:
+    """Assert that no .tmp files exist in the given directory."""
+    tmp_files = list(directory.glob("*.tmp"))
+    assert tmp_files == [], f"Leaked tmp files in {directory}: {tmp_files}"
+
+
+def _assert_file_unchanged(path: Path, original_bytes: bytes) -> None:
+    """Assert that the file content has not changed from original_bytes."""
+    current = path.read_bytes()
+    assert current == original_bytes, (
+        f"File {path.name} was corrupted after write failure.\n"
+        f"  original size: {len(original_bytes)}, current size: {len(current)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared test flow helpers
+# ---------------------------------------------------------------------------
+
+
+def _verify_json_write_atomic(
+    target_file: Path,
+    directory: Path,
+    patch_target: str,
+    invoke_write: Callable[[], None],
+) -> None:
+    """Verify a JSON write site is atomic via module-level json.dump patching.
+
+    Patches json.dump at the module level (via string target) to simulate a
+    partial write followed by a process kill. Asserts the original file is
+    unchanged and no .tmp files are leaked after the failure.
+
+    Args:
+        target_file: The JSON file that must not be corrupted.
+        directory: Directory to check for leaked .tmp files.
+        patch_target: Dotted module path to json.dump (e.g.
+            "code_indexer.storage.hnsw_index_manager.json.dump").
+        invoke_write: Zero-argument callable that triggers the write under test.
+    """
+    original_bytes = target_file.read_bytes()
+
+    with patch(patch_target, side_effect=_partial_json_then_raise):
+        with pytest.raises(OSError, match="Simulated kill"):
+            invoke_write()
+
+    _assert_file_unchanged(target_file, original_bytes)
+    _assert_no_tmp_files(directory)
+
+
+def _verify_hnsw_write_atomic(
+    index_file: Path,
+    directory: Path,
+    invoke_write: Callable[[], None],
+) -> None:
+    """Verify an HNSW binary write is atomic via class-level patching of hnswlib.
+
+    Patches hnswlib.Index.save_index at the class level (an external dependency,
+    not the SUT) so the simulated failure applies to any instance created or used
+    inside the SUT. This avoids patching private SUT methods and works around the
+    read-only C extension attribute limitation on individual hnswlib instances.
+
+    Args:
+        index_file: The hnsw_index.bin file that must not be corrupted.
+        directory: Directory to check for leaked .tmp files.
+        invoke_write: Zero-argument callable that triggers the write under test.
+    """
+    import hnswlib
+
+    original_bytes = index_file.read_bytes()
+    assert len(original_bytes) > 0, "Precondition: index file must exist with content"
+
+    with patch.object(hnswlib.Index, "save_index", side_effect=_partial_write_then_raise):
+        with pytest.raises(OSError, match="Simulated kill"):
+            invoke_write()
+
+    _assert_file_unchanged(index_file, original_bytes)
+    _assert_no_tmp_files(directory)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / factory helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_collection(tmp_path: Path) -> Path:
+    """Create a minimal collection directory with collection_meta.json."""
+    col = tmp_path / "test_collection"
+    col.mkdir()
+    meta = {
+        "hnsw_index": {
+            "version": 1,
+            "index_rebuild_uuid": "abc-123",
+            "vector_count": 0,
+            "vector_dim": VECTOR_DIM,
+            "M": 16,
+            "ef_construction": 200,
+            "space": "cosine",
+            "last_rebuild": "2026-01-01T00:00:00+00:00",
+            "file_size_bytes": 0,
+            "id_mapping": {},
+            "is_stale": False,
+            "last_marked_stale": None,
+        }
+    }
+    (col / "collection_meta.json").write_text(json.dumps(meta, indent=2))
+    return col
+
+
+def _make_hnsw_index(col: Path) -> Any:
+    """Build a tiny real HNSW index and save it so the binary exists on disk."""
+    import hnswlib
+
+    index = hnswlib.Index(space="cosine", dim=VECTOR_DIM)
+    index.init_index(max_elements=10, ef_construction=50, M=8)
+    rng = np.random.default_rng(0)
+    vectors = rng.random((3, VECTOR_DIM)).astype(np.float32)
+    index.add_items(vectors, [0, 1, 2])
+    index_file = col / "hnsw_index.bin"
+    index.save_index(str(index_file))
+    return index
+
+
+# ---------------------------------------------------------------------------
+# Site 1: save_incremental_update — HNSW binary
+# (instance-level patching: caller supplies the index object)
+# ---------------------------------------------------------------------------
+
+
+class TestSaveIncrementalUpdateHNSWBinaryAtomic:
+    """HNSW binary in save_incremental_update must not corrupt existing file on failure."""
+
+    def test_hnsw_binary_atomic_on_failure(self, tmp_path: Path):
+        """If index.save_index raises after partial write, hnsw_index.bin is unchanged."""
+        col = _make_collection(tmp_path)
+        index = _make_hnsw_index(col)
+        manager = HNSWIndexManager(vector_dim=VECTOR_DIM)
+
+        _verify_hnsw_write_atomic(
+            index_file=col / "hnsw_index.bin",
+            directory=col,
+            invoke_write=lambda: manager.save_incremental_update(
+                index=index,
+                collection_path=col,
+                id_to_label={"point-0": 0, "point-1": 1, "point-2": 2},
+                label_to_id={0: "point-0", 1: "point-1", 2: "point-2"},
+                vector_count=3,
+            ),
+        )
+
+    def test_successful_incremental_update_writes_loadable_index(self, tmp_path: Path):
+        """Successful save_incremental_update produces a valid, loadable HNSW binary."""
+        import hnswlib
+
+        col = _make_collection(tmp_path)
+        index = _make_hnsw_index(col)
+
+        rng = np.random.default_rng(99)
+        new_vec = rng.random((1, VECTOR_DIM)).astype(np.float32)
+        index.add_items(new_vec, [3])
+
+        manager = HNSWIndexManager(vector_dim=VECTOR_DIM)
+        manager.save_incremental_update(
+            index=index,
+            collection_path=col,
+            id_to_label={"p0": 0, "p1": 1, "p2": 2, "p3": 3},
+            label_to_id={0: "p0", 1: "p1", 2: "p2", 3: "p3"},
+            vector_count=4,
+        )
+
+        # Must be reloadable as a valid hnswlib index with correct element count
+        loaded = hnswlib.Index(space="cosine", dim=VECTOR_DIM)
+        loaded.load_index(str(col / "hnsw_index.bin"), max_elements=10)
+        assert loaded.get_current_count() == 4
+        _assert_no_tmp_files(col)
+
+
+# ---------------------------------------------------------------------------
+# Site 2: mark_stale — metadata JSON
+# (module-level json.dump patching)
+# ---------------------------------------------------------------------------
+
+
+class TestMarkStaleMetadataAtomic:
+    """mark_stale collection_meta.json must not corrupt original file on failure."""
+
+    def test_json_write_atomic_on_failure(self, tmp_path: Path):
+        """If json.dump raises after partial write, collection_meta.json is unchanged."""
+        col = _make_collection(tmp_path)
+        manager = HNSWIndexManager(vector_dim=VECTOR_DIM)
+
+        _verify_json_write_atomic(
+            target_file=col / "collection_meta.json",
+            directory=col,
+            patch_target="code_indexer.storage.hnsw_index_manager.json.dump",
+            invoke_write=lambda: manager.mark_stale(col),
+        )
+
+    def test_mark_stale_success_sets_is_stale_true(self, tmp_path: Path):
+        """Successful mark_stale sets is_stale=True in metadata and leaves no tmp files."""
+        col = _make_collection(tmp_path)
+        manager = HNSWIndexManager(vector_dim=VECTOR_DIM)
+        manager.mark_stale(col)
+
+        meta = json.loads((col / "collection_meta.json").read_text())
+        assert meta["hnsw_index"]["is_stale"] is True
+        _assert_no_tmp_files(col)
+
+
+# ---------------------------------------------------------------------------
+# Site 3: _update_metadata — metadata JSON
+# (module-level json.dump patching)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMetadataAtomic:
+    """_update_metadata collection_meta.json must not corrupt original file on failure."""
+
+    def test_json_write_atomic_on_failure(self, tmp_path: Path):
+        """If json.dump raises after partial write during _update_metadata, file is unchanged."""
+        col = _make_collection(tmp_path)
+        manager = HNSWIndexManager(vector_dim=VECTOR_DIM)
+
+        _verify_json_write_atomic(
+            target_file=col / "collection_meta.json",
+            directory=col,
+            patch_target="code_indexer.storage.hnsw_index_manager.json.dump",
+            invoke_write=lambda: manager._update_metadata(
+                collection_path=col,
+                vector_count=3,
+                M=16,
+                ef_construction=200,
+                ids=["id-0", "id-1", "id-2"],
+                index_file_size=1024,
+            ),
+        )
+
+    def test_update_metadata_success_writes_vector_count(self, tmp_path: Path):
+        """Successful _update_metadata writes correct vector_count and leaves no tmp files."""
+        col = _make_collection(tmp_path)
+        (col / "hnsw_index.bin").write_bytes(b"\x00" * 256)  # fake binary for stat
+
+        manager = HNSWIndexManager(vector_dim=VECTOR_DIM)
+        manager._update_metadata(
+            collection_path=col,
+            vector_count=7,
+            M=16,
+            ef_construction=200,
+            ids=[f"id-{i}" for i in range(7)],
+            index_file_size=256,
+        )
+
+        meta = json.loads((col / "collection_meta.json").read_text())
+        assert meta["hnsw_index"]["vector_count"] == 7
+        _assert_no_tmp_files(col)
+
+
+# ---------------------------------------------------------------------------
+# Site 4: progressive_metadata._save_metadata — watermark JSON
+# (module-level json.dump patching)
+# ---------------------------------------------------------------------------
+
+
+class TestProgressiveMetadataSaveAtomic:
+    """_save_metadata must leave original watermark file intact on write failure."""
+
+    def test_json_write_atomic_on_failure(self, tmp_path: Path):
+        """If json.dump raises after partial write in _save_metadata, original is unchanged."""
+        meta_path = tmp_path / ".code-indexer" / "index_metadata.json"
+        meta_path.parent.mkdir(parents=True)
+        original_content = {
+            "status": "completed",
+            "files_processed": 100,
+            "chunks_indexed": 500,
+        }
+        meta_path.write_text(json.dumps(original_content, indent=2))
+
+        pm = ProgressiveMetadata(meta_path)
+
+        _verify_json_write_atomic(
+            target_file=meta_path,
+            directory=tmp_path / ".code-indexer",
+            patch_target="code_indexer.services.progressive_metadata.json.dump",
+            invoke_write=pm._save_metadata,
+        )
+
+    def test_save_metadata_success_persists_data(self, tmp_path: Path):
+        """Successful _save_metadata persists in-memory metadata and leaves no tmp files."""
+        meta_path = tmp_path / "index_metadata.json"
+        meta_path.write_text(json.dumps({"status": "completed", "files_processed": 0}))
+
+        pm = ProgressiveMetadata(meta_path)
+        pm.metadata["files_processed"] = 42
+        pm._save_metadata()
+
+        persisted = json.loads(meta_path.read_text())
+        assert persisted["files_processed"] == 42
+        _assert_no_tmp_files(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Site 5: build_index — full-rebuild HNSW binary
+# (class-level patching: build_index creates its own hnswlib.Index internally)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildIndexHNSWBinaryAtomic:
+    """build_index HNSW binary save must not corrupt existing file on failure."""
+
+    def test_hnsw_binary_atomic_on_failure(self, tmp_path: Path):
+        """If save_index raises after partial write during build_index, original is unchanged.
+
+        build_index constructs its own hnswlib.Index internally, so we patch
+        hnswlib.Index.save_index at the class level so the patch applies to any
+        instance created inside build_index.
+        """
+        import hnswlib
+
+        col = _make_collection(tmp_path)
+        # Place an existing binary so we can assert it is not corrupted
+        _make_hnsw_index(col)
+        original_bytes = (col / "hnsw_index.bin").read_bytes()
+        assert len(original_bytes) > 0
+
+        manager = HNSWIndexManager(vector_dim=VECTOR_DIM)
+        rng = np.random.default_rng(1)
+        new_vectors = rng.random((5, VECTOR_DIM)).astype(np.float32)
+        new_ids = [f"new-{i}" for i in range(5)]
+
+        with patch.object(hnswlib.Index, "save_index", side_effect=_partial_write_then_raise):
+            with pytest.raises(OSError, match="Simulated kill"):
+                manager.build_index(
+                    collection_path=col,
+                    vectors=new_vectors,
+                    ids=new_ids,
+                )
+
+        _assert_file_unchanged(col / "hnsw_index.bin", original_bytes)
+        _assert_no_tmp_files(col)
+
+    def test_successful_build_index_creates_loadable_binary(self, tmp_path: Path):
+        """Successful build_index writes a binary that is loadable with hnswlib."""
+        import hnswlib
+
+        col = _make_collection(tmp_path)
+        manager = HNSWIndexManager(vector_dim=VECTOR_DIM)
+
+        rng = np.random.default_rng(3)
+        vectors = rng.random((4, VECTOR_DIM)).astype(np.float32)
+        ids = ["v0", "v1", "v2", "v3"]
+
+        manager.build_index(
+            collection_path=col,
+            vectors=vectors,
+            ids=ids,
+        )
+
+        index_file = col / "hnsw_index.bin"
+        loaded = hnswlib.Index(space="cosine", dim=VECTOR_DIM)
+        loaded.load_index(str(index_file), max_elements=10)
+        assert loaded.get_current_count() == 4
+        _assert_no_tmp_files(col)

--- a/tests/unit/storage/test_hnsw_index_manager_954.py
+++ b/tests/unit/storage/test_hnsw_index_manager_954.py
@@ -1,0 +1,232 @@
+"""Tests for Bug #954 / Bug #948: knn_query retry on contiguous-2D-array RuntimeError.
+
+When hnswlib raises:
+    RuntimeError: Cannot return the results in a contiguous 2D array.
+    Probably ef or M is too small
+
+the query() method must retry with progressively smaller k values:
+    k_actual -> k_actual // 2 -> max(1, k_actual // 4) -> 1
+
+A WARNING must be logged on the FIRST retry only (not on every attempt).
+If ALL retries fail (including k=1), the original exception must be re-raised.
+An unrelated RuntimeError must propagate immediately without retries.
+"""
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import numpy as np
+import pytest
+
+from code_indexer.storage.hnsw_index_manager import HNSWIndexManager
+
+_CONTIGUOUS_MSG = "Cannot return the results in a contiguous 2D array. Probably ef or M is too small"
+
+
+def _make_manager(vector_dim: int = 64) -> HNSWIndexManager:
+    return HNSWIndexManager(vector_dim=vector_dim, space="cosine")
+
+
+def _make_mock_index(
+    *,
+    current_count: int,
+    id_mapping: dict,
+) -> MagicMock:
+    """Build a mock hnswlib.Index with the given count and fixed knn_query result."""
+    mock = MagicMock()
+    mock.get_current_count.return_value = current_count
+    return mock
+
+
+def _write_metadata(collection_path: Path, id_mapping: dict) -> None:
+    """Write minimal collection_meta.json with id_mapping for _load_id_mapping()."""
+    meta = {
+        "hnsw_index": {
+            "id_mapping": {str(k): v for k, v in id_mapping.items()},
+        }
+    }
+    meta_file = collection_path / "collection_meta.json"
+    with open(meta_file, "w") as f:
+        json.dump(meta, f)
+
+
+class TestKnnQueryRetryOnContiguous2DArrayError:
+    """query() must retry with smaller k when hnswlib raises the contiguous-2D-array error."""
+
+    def test_retry_succeeds_on_second_attempt_with_half_k(self, tmp_path: Path):
+        """knn_query fails at k_actual, succeeds at k_actual // 2 — returns results."""
+        manager = _make_manager(vector_dim=64)
+        collection_path = tmp_path / "coll"
+        collection_path.mkdir()
+
+        # 10 vectors in metadata (k=10 initially)
+        id_mapping = {i: f"vec_{i}" for i in range(10)}
+        _write_metadata(collection_path, id_mapping)
+
+        mock_index = _make_mock_index(current_count=10, id_mapping=id_mapping)
+
+        # First call (k=10) raises; second call (k=5) succeeds
+        success_labels = np.array([[0, 1, 2, 3, 4]])
+        success_distances = np.array([[0.1, 0.2, 0.3, 0.4, 0.5]])
+
+        call_count = [0]
+
+        def knn_side_effect(query_vector, k):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError(_CONTIGUOUS_MSG)
+            return success_labels, success_distances
+
+        mock_index.knn_query.side_effect = knn_side_effect
+
+        query_vector = np.random.randn(64).astype(np.float32)
+        result_ids, result_distances = manager.query(
+            mock_index, query_vector, collection_path, k=10, ef=50
+        )
+
+        assert len(result_ids) == 5
+        assert len(result_distances) == 5
+        assert call_count[0] == 2
+
+    def test_retry_logs_warning_on_first_retry_only(self, tmp_path: Path, caplog):
+        """A WARNING is emitted on the first retry, not on every attempt."""
+        manager = _make_manager(vector_dim=64)
+        collection_path = tmp_path / "coll"
+        collection_path.mkdir()
+
+        id_mapping = {i: f"vec_{i}" for i in range(8)}
+        _write_metadata(collection_path, id_mapping)
+
+        mock_index = _make_mock_index(current_count=8, id_mapping=id_mapping)
+
+        # First call fails, second succeeds
+        success_labels = np.array([[0, 1]])
+        success_distances = np.array([[0.1, 0.2]])
+        call_count = [0]
+
+        def knn_side_effect(query_vector, k):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError(_CONTIGUOUS_MSG)
+            return success_labels, success_distances
+
+        mock_index.knn_query.side_effect = knn_side_effect
+
+        query_vector = np.random.randn(64).astype(np.float32)
+        with caplog.at_level(logging.WARNING, logger="code_indexer.storage.hnsw_index_manager"):
+            manager.query(mock_index, query_vector, collection_path, k=8, ef=50)
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warning_records) == 1, (
+            f"Expected exactly 1 WARNING on first retry, got {len(warning_records)}: "
+            + ", ".join(r.message for r in warning_records)
+        )
+        assert "contiguous" in warning_records[0].message.lower() or "degraded" in warning_records[0].message.lower()
+
+    def test_all_retries_fail_reraises_original_error(self, tmp_path: Path):
+        """When all retry attempts fail (including k=1), the original error is re-raised."""
+        manager = _make_manager(vector_dim=64)
+        collection_path = tmp_path / "coll"
+        collection_path.mkdir()
+
+        id_mapping = {i: f"vec_{i}" for i in range(4)}
+        _write_metadata(collection_path, id_mapping)
+
+        mock_index = _make_mock_index(current_count=4, id_mapping=id_mapping)
+
+        # All knn_query calls raise the contiguous error
+        mock_index.knn_query.side_effect = RuntimeError(_CONTIGUOUS_MSG)
+
+        query_vector = np.random.randn(64).astype(np.float32)
+        with pytest.raises(RuntimeError, match="contiguous 2D array"):
+            manager.query(mock_index, query_vector, collection_path, k=4, ef=50)
+
+    def test_unrelated_runtime_error_propagates_immediately(self, tmp_path: Path):
+        """RuntimeErrors unrelated to 'contiguous 2D array' propagate without retry."""
+        manager = _make_manager(vector_dim=64)
+        collection_path = tmp_path / "coll"
+        collection_path.mkdir()
+
+        id_mapping = {i: f"vec_{i}" for i in range(4)}
+        _write_metadata(collection_path, id_mapping)
+
+        mock_index = _make_mock_index(current_count=4, id_mapping=id_mapping)
+
+        call_count = [0]
+
+        def knn_side_effect(query_vector, k):
+            call_count[0] += 1
+            raise RuntimeError("some unrelated hnswlib internal error")
+
+        mock_index.knn_query.side_effect = knn_side_effect
+
+        query_vector = np.random.randn(64).astype(np.float32)
+        with pytest.raises(RuntimeError, match="unrelated hnswlib"):
+            manager.query(mock_index, query_vector, collection_path, k=4, ef=50)
+
+        # Must not retry — only one call
+        assert call_count[0] == 1
+
+    def test_retry_progression_k_actual_half_quarter_one(self, tmp_path: Path):
+        """Retries use k_actual, k_actual//2, max(1, k_actual//4), 1 in order."""
+        manager = _make_manager(vector_dim=64)
+        collection_path = tmp_path / "coll"
+        collection_path.mkdir()
+
+        # 20 vectors so k_actual=20, half=10, quarter=5, last=1
+        id_mapping = {i: f"vec_{i}" for i in range(20)}
+        _write_metadata(collection_path, id_mapping)
+
+        mock_index = _make_mock_index(current_count=20, id_mapping=id_mapping)
+
+        attempted_ks = []
+
+        def knn_side_effect(query_vector, k):
+            attempted_ks.append(k)
+            if k > 1:
+                raise RuntimeError(_CONTIGUOUS_MSG)
+            # Succeed at k=1
+            return np.array([[0]]), np.array([[0.1]])
+
+        mock_index.knn_query.side_effect = knn_side_effect
+
+        query_vector = np.random.randn(64).astype(np.float32)
+        manager.query(mock_index, query_vector, collection_path, k=20, ef=50)
+
+        # k_actual=20, then 10 (20//2), then 5 (max(1,20//4)), then 1
+        assert attempted_ks == [20, 10, 5, 1], (
+            f"Expected retry sequence [20, 10, 5, 1], got {attempted_ks}"
+        )
+
+    def test_warning_logged_once_across_multiple_retries(self, tmp_path: Path, caplog):
+        """Warning is logged exactly once even when multiple retries are needed."""
+        manager = _make_manager(vector_dim=64)
+        collection_path = tmp_path / "coll"
+        collection_path.mkdir()
+
+        id_mapping = {i: f"vec_{i}" for i in range(20)}
+        _write_metadata(collection_path, id_mapping)
+
+        mock_index = _make_mock_index(current_count=20, id_mapping=id_mapping)
+
+        call_count = [0]
+
+        def knn_side_effect(query_vector, k):
+            call_count[0] += 1
+            if call_count[0] < 4:
+                raise RuntimeError(_CONTIGUOUS_MSG)
+            # Succeed on the 4th call (k=1)
+            return np.array([[0]]), np.array([[0.1]])
+
+        mock_index.knn_query.side_effect = knn_side_effect
+
+        query_vector = np.random.randn(64).astype(np.float32)
+        with caplog.at_level(logging.WARNING, logger="code_indexer.storage.hnsw_index_manager"):
+            manager.query(mock_index, query_vector, collection_path, k=20, ef=50)
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warning_records) == 1, (
+            f"Expected exactly 1 WARNING across all retries, got {len(warning_records)}"
+        )


### PR DESCRIPTION
## Summary

- Fixed 12 production bugs from the self-monitoring backlog (#934, #935, #945, #946, #948, #951, #952, #953, #954, #957, #959, #960)
- Implemented TOTP elevation inline modal UX — replaced full-page redirect with in-page dialog (#955 follow-up)
- Fixed web UI elevation "No session." error for form-login users (security/auth)

## Key changes

- **Auth fix**: `_hybrid_auth_impl` now sets `request.state.user_jti` from session cookie so TOTP elevation resolves correctly for web UI users
- **TOTP modal**: 403 `elevation_required` responses now open an inline `<dialog>` instead of navigating away; success retries original HTMX request automatically
- **Atomic writes**: 5 HNSW/JSON persistence sites now use tempfile+os.replace pattern
- **JobTracker drain-status**: in-flight refresh jobs now register with JobTracker so auto-updater waits before restarting
- **Log spam fixes**: transition-gated warnings for provider health monitor, dep-map parser missing files, description refresh scheduler, JobTracker, latency tracker
- **HNSW retry**: contiguous 2D array errors now retry with smaller k instead of crashing
- **Temporal --clear**: omit `--clear` when vector files already exist to preserve expensive work

## Test plan

- [ ] All 12 bug-fix tests pass in fast-automation.sh
- [ ] 23/23 elevation tests pass (including new `test_elevate_ajax.py`)
- [ ] No `[BUG]` issues remain open in GitHub
- [ ] TOTP modal works end-to-end on staging: trigger elevation → modal appears → enter code → retries original request

🤖 Generated with [Claude Code](https://claude.com/claude-code)