### PR TITLE
fix: Resolve wiki relative links server-side so ../ does not strip re…

### DIFF
--- a/src/code_indexer/server/wiki/wiki_service.py
+++ b/src/code_indexer/server/wiki/wiki_service.py
@@ -436,13 +436,9 @@ class WikiService:
                 return full_tag
             if href.startswith("/articles/"):
                 return full_tag
-            if "/" in href:
-                new_href = f"/wiki/{repo_alias}/{href}"
-            else:
-                if current_dir:
-                    new_href = f"/wiki/{repo_alias}/{current_dir}/{href}"
-                else:
-                    new_href = f"/wiki/{repo_alias}/{href}"
+
+            resolved = self._resolve_wiki_link(href, current_dir)
+            new_href = f"/wiki/{repo_alias}/{resolved}"
             return full_tag.replace(
                 f"href={quote_char}{href}{quote_char}",
                 f"href={quote_char}{new_href}{quote_char}",
@@ -454,6 +450,33 @@ class WikiService:
             _rewrite_href,
             html,
         )
+
+    @staticmethod
+    def _resolve_wiki_link(href: str, current_dir: str) -> str:
+        """Resolve a relative wiki href against current_dir, collapsing dot segments.
+
+        Splits off any trailing ``#fragment`` or ``?query`` before normalising
+        the path, then re-attaches it. ``..`` segments that climb above the repo
+        root are clamped (dropped) so the resulting path is always repo-root
+        relative with no remaining ``..``.
+        """
+        import posixpath
+
+        suffix = ""
+        sep_match = re.search(r"[#?]", href)
+        if sep_match:
+            suffix = href[sep_match.start() :]
+            href = href[: sep_match.start()]
+
+        joined = posixpath.join(current_dir, href) if current_dir else href
+        normalized = posixpath.normpath(joined).lstrip("/")
+        # Clamp any ../ that escaped the repo root
+        while normalized.startswith("../"):
+            normalized = normalized[3:]
+        if normalized in (".", ".."):
+            normalized = ""
+
+        return f"{normalized}{suffix}"
 
     def build_breadcrumbs(
         self, article_path: str, repo_alias: str

--- a/tests/unit/server/wiki/test_wiki_navigation.py
+++ b/tests/unit/server/wiki/test_wiki_navigation.py
@@ -145,6 +145,33 @@ class TestRewriteLinks:
         # Should not double-add target
         assert result.count("target=") == 1
 
+    def test_parent_relative_link_collapsed_server_side(self, svc):
+        # GitLab-style ../ link from a subdir article: the .. must be resolved
+        # server-side so it never reaches the browser (which would strip the
+        # repo alias). From "guides", "../Public/guide.md" -> repo-root Public/.
+        html = '<a href="../Public/guide.md">Link</a>'
+        result = svc.rewrite_links(html, "my-repo", "guides")
+        assert "/wiki/my-repo/Public/guide.md" in result
+        assert ".." not in result
+
+    def test_parent_relative_link_clamped_at_root(self, svc):
+        # From a root-level article, ../ cannot climb above the repo root.
+        html = '<a href="../Public/guide.md">Link</a>'
+        result = svc.rewrite_links(html, "my-repo", "")
+        assert "/wiki/my-repo/Public/guide.md" in result
+        assert ".." not in result
+
+    def test_dot_slash_relative_link_normalized(self, svc):
+        html = '<a href="./sibling.md">Link</a>'
+        result = svc.rewrite_links(html, "my-repo", "guides")
+        assert "/wiki/my-repo/guides/sibling.md" in result
+
+    def test_relative_link_preserves_fragment(self, svc):
+        html = '<a href="../Public/guide.md#section">Link</a>'
+        result = svc.rewrite_links(html, "my-repo", "guides")
+        assert "/wiki/my-repo/Public/guide.md#section" in result
+        assert ".." not in result
+
 
 class TestBuildBreadcrumbs:
     def test_root_article_path_returns_only_home(self, svc):


### PR DESCRIPTION
…po alias

GitLab-style relative links containing ../ (e.g. ../Public/guide.md) were rewritten to /wiki/{alias}/../Public/guide.md, leaving the ../ for the browser to resolve, which collapsed it and stripped the {alias} segment.

Add _resolve_wiki_link to resolve relative hrefs against the current article's directory using posixpath.normpath, collapsing ./ and ../ server-side, clamping any ../ that escapes the repo root, and preserving #fragment/?query. No .. now reaches the emitted URL.