### PR TITLE
feat: cluster-mode hardening — HRW sharding + 6 Evo-scale fixes + trigram-assisted regex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,129 @@
+# syntax=docker/dockerfile:1
+#
+# cidx (code-indexer) multi-user server image for EKS (cluster / multi-pod mode).
+#
+# Builds the CUSTOM hnswlib (with check_integrity(), Story #54) from the VENDORED
+# third_party/hnswlib source, then installs the code_indexer package, and runs the
+# FastAPI server via uvicorn (single worker — HNSW index is a process-local in-RAM
+# singleton; horizontal scaling is via Postgres cluster mode + leader election, not
+# uvicorn workers).
+#
+# Runtime data dir (config.json, .jwt_secret, caches) = /data via CIDX_SERVER_DATA_DIR;
+# the k8s Deployment mounts a volume there and seeds config.json (storage_mode=postgres,
+# postgres_dsn, cluster.node_id) to enable cluster mode.
+
+# ---- Build stage ----
+# Pin bookworm: it ships openjdk-17 (trixie, the current `slim` default, does
+# not) which the runtime stage needs for scip-java + Gradle 7.x compatibility.
+# Both stages must match so the copied site-packages/glibc are consistent.
+FROM python:3.11-slim-bookworm AS builder
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    DEBIAN_FRONTEND=noninteractive
+
+# Build toolchain for the hnswlib native extension (+ any sdist-only deps).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential cmake git pkg-config python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Install cidx. v11.30 declares the custom hnswlib fork + psycopg as direct deps
+# in pyproject (git+https hnswlib, psycopg[binary]/psycopg-pool), so a plain
+# `pip install .` pulls everything (git + gcc/g++ present above for the git dep).
+COPY pyproject.toml README.md ./
+COPY src ./src
+RUN pip install ".[cluster,cohere]"
+
+# ---- Runtime stage ----
+FROM python:3.11-slim-bookworm
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    CIDX_SERVER_DATA_DIR=/data \
+    DEBIAN_FRONTEND=noninteractive
+
+# Runtime deps: git (GitPython + golden-repo clone/refresh), libgomp1 (hnswlib OpenMP),
+# tini (PID 1 signal handling / zombie reaping).
+#
+# C11: a headless JDK + Coursier (`cs`) so Java/Kotlin SCIP works. scip-java is
+# launched on demand via Coursier and runs the target project's gradle/maven
+# build, both of which need a JDK. curl fetches the Coursier launcher.
+#
+# Java SCIP needs TWO JDKs:
+#  - JDK 17 (openjdk-17, apt) is the Gradle LAUNCHER. The JDK that runs a
+#    project's Gradle must be old enough for that Gradle version: Gradle 7.x
+#    (still common) only supports Java <=17 (Java 21 -> "Unsupported class file
+#    major version 65"), and Java 17 also runs Gradle 8.x and scip-java itself.
+#  - JDK 21 (Temurin, tarball at /opt/jdk-21) is available as a Gradle TOOLCHAIN
+#    for projects that compile at languageVersion=21 (e.g. the Evolution
+#    monolith). Gradle launched with 17 picks 21 up via installations.paths
+#    (set in the cidx user's gradle.properties below).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git libgomp1 tini openjdk-17-jdk-headless curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz \
+         | gzip -d > /usr/local/bin/cs \
+    && chmod +x /usr/local/bin/cs \
+    && mkdir -p /opt/jdk-21 \
+    && curl -fsSL "https://api.adoptium.net/v3/binary/latest/21/ga/linux/x64/jdk/hotspot/normal/eclipse" \
+         | tar -xz -C /opt/jdk-21 --strip-components=1
+
+# Bake Gradle so scip-java can build + index Gradle projects. The image had
+# scip-java + JDK but NO build tool (gradle/maven), so scip-java's build step
+# failed and Java SCIP generation produced empty .scip.db -- the observed
+# "SCIP fast-but-empty" pathology. Gradle 8.5 runs on the JDK 17 launcher and
+# supports the JDK 21 toolchain (installations.paths, set below).
+RUN apt-get update && apt-get install -y --no-install-recommends unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://services.gradle.org/distributions/gradle-8.5-bin.zip -o /tmp/gradle.zip \
+    && unzip -q /tmp/gradle.zip -d /opt \
+    && ln -sf /opt/gradle-8.5/bin/gradle /usr/local/bin/gradle \
+    && rm /tmp/gradle.zip
+
+# ripgrep (rg) is REQUIRED for /api/regex/search: RegexSearchService prefers rg
+# (rg --json over a gitignored tree is sub-second) and silently falls back to a
+# linear `grep -r` scan when `which("rg")` is falsy. On a 14G working tree that
+# fallback always hits the 30s search timeout, so the binary must be present.
+# Kept as its own layer (after the heavy JDK/coursier/gradle steps) so adding it
+# does not invalidate their build cache.
+RUN apt-get update && apt-get install -y --no-install-recommends ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# JAVA_HOME points at the 17 launcher; 21 is a toolchain (installations.paths).
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+
+# Bring over the installed site-packages + the `cidx` console script from the builder.
+COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Non-root runtime. /data is the server data dir — the Deployment mounts a volume here.
+RUN useradd -m -u 1000 cidx && mkdir -p /data && chown -R cidx:cidx /data
+USER cidx
+WORKDIR /home/cidx
+
+# Gradle setup for the cidx user so scip-java indexing works out-of-the-box:
+#  - installations.paths=/opt/jdk-21: expose the Java 21 toolchain (see above) so
+#    projects requiring languageVersion=21 compile without "No matching toolchains".
+#  - init.d repositoriesMode=PREFER_PROJECT: let scip-java's SemanticdbGradlePlugin
+#    add its own repository (to fetch semanticdb-javac) on projects that set
+#    dependencyResolutionManagement FAIL_ON_PROJECT_REPOS (e.g. Evolution). cidx
+#    only runs Gradle for SCIP indexing, so relaxing this globally is safe.
+RUN mkdir -p /home/cidx/.gradle/init.d \
+    && printf 'org.gradle.java.installations.paths=/opt/jdk-21\n' \
+         > /home/cidx/.gradle/gradle.properties \
+    && printf 'settingsEvaluated { s -> s.dependencyResolutionManagement { repositoriesMode.set(RepositoriesMode.PREFER_PROJECT) } }\n' \
+         > /home/cidx/.gradle/init.d/cidx-scip.gradle
+
+# C11: pre-fetch the scip-java artifact into the runtime user's Coursier cache so
+# index-time `cs launch` is offline-safe (no Maven Central round-trip per index).
+# Non-fatal: if the build host can't reach Maven Central, index-time falls back
+# to an on-demand download.
+RUN cs fetch com.sourcegraph:scip-java_2.13:0.11.1 || true
+
+EXPOSE 8090
+
+# uvicorn binds 0.0.0.0 (the CLI default is 127.0.0.1, which is unreachable in a pod).
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["python", "-m", "code_indexer.server.main", "--host", "0.0.0.0", "--port", "8090"]

--- a/src/code_indexer/global_repos/refresh_scheduler.py
+++ b/src/code_indexer/global_repos/refresh_scheduler.py
@@ -2217,6 +2217,25 @@ class RefreshScheduler:
         )
         logger.info(f"cidx index on source completed successfully for {alias_name}")
 
+        # Step 1b: build the trigram index for index-assisted regex search, so
+        # /api/regex/search can pre-filter candidate files instead of scanning the
+        # whole (NFS-backed) working tree. Built here at index time from the same
+        # gitignore-aware file set. Non-fatal: on any failure regex search simply
+        # falls back to a full scan.
+        try:
+            from code_indexer.global_repos.trigram_index_manager import (
+                TrigramIndexManager,
+            )
+
+            _tri_dir = source_path / ".code-indexer" / "trigram_index"
+            _tri_files = TrigramIndexManager(_tri_dir).build(source_path)
+            logger.info(f"Trigram index built for {alias_name} ({_tri_files} files)")
+        except Exception as _tri_exc:  # never fail indexing over the pre-filter
+            logger.warning(
+                f"Trigram index build failed for {alias_name} "
+                f"(regex search will full-scan): {_tri_exc}"
+            )
+
         # Execute Step 2: temporal indexing (if enabled)
         if temporal_command is not None:
             # Bug #1313 round-3: in postgres/cluster mode, hand the child

--- a/src/code_indexer/global_repos/regex_search.py
+++ b/src/code_indexer/global_repos/regex_search.py
@@ -30,6 +30,11 @@ DEFAULT_SEARCH_TIMEOUT_SECONDS = 300
 # Timeout for PCRE2 availability check subprocess
 _PCRE2_CHECK_TIMEOUT_SEC = 5
 
+# Above this many trigram-index candidates, skip the pre-filter and full-scan:
+# the ripgrep arg list would be unwieldy and the filter is not selective enough
+# to beat a plain scan.
+_MAX_PREFILTER_CANDIDATES = 8000
+
 
 class RipgrepExecutionError(Exception):
     """Raised when ripgrep/grep exits with a non-zero code AND has stderr output.
@@ -181,18 +186,29 @@ class RegexSearchService:
             raise ValueError(f"Path does not exist: {path}")
 
         if self._search_engine == "ripgrep":
-            matches, total = await self._search_ripgrep(
-                pattern,
-                search_path,
-                include_patterns,
-                exclude_patterns,
-                case_sensitive,
-                context_lines,
-                max_results,
-                timeout_seconds,
-                multiline=multiline,
-                pcre2=pcre2,
+            # Index-assisted pre-filter: when a trigram index is present, narrow
+            # the scan to files that could match instead of walking the whole
+            # (NFS-backed) working tree. Returns None to fall back to a full
+            # scan; an empty list means no file can match.
+            candidate_files = self._prefilter_candidate_files(
+                pattern, search_path, path, case_sensitive
             )
+            if candidate_files is not None and not candidate_files:
+                matches, total = [], 0
+            else:
+                matches, total = await self._search_ripgrep(
+                    pattern,
+                    search_path,
+                    include_patterns,
+                    exclude_patterns,
+                    case_sensitive,
+                    context_lines,
+                    max_results,
+                    timeout_seconds,
+                    multiline=multiline,
+                    pcre2=pcre2,
+                    candidate_files=candidate_files,
+                )
         else:
             matches, total = await self._search_grep(
                 pattern,
@@ -301,6 +317,56 @@ class RegexSearchService:
 
         return matches, total
 
+    def _prefilter_candidate_files(
+        self,
+        pattern: str,
+        search_path: Path,
+        path: Optional[str],
+        case_sensitive: bool,
+    ) -> Optional[List[Path]]:
+        """Return candidate file paths from the trigram index, or None.
+
+        None means "no usable pre-filter -> scan the whole ``search_path``". A
+        (possibly empty) list means the scan can be restricted to exactly those
+        files -- a guaranteed superset of matches (see :mod:`trigram_index_manager`).
+        Any failure degrades to None (full scan); the pre-filter never narrows
+        unsafely.
+        """
+        try:
+            from .regex_trigram import extract_required_trigrams
+            from .trigram_index_manager import TrigramIndexManager
+
+            index = TrigramIndexManager(
+                self.repo_path / ".code-indexer" / "trigram_index"
+            )
+            if not index.exists():
+                return None
+            required = extract_required_trigrams(
+                pattern, case_insensitive=not case_sensitive
+            )
+            if not required:
+                return None
+            rel_candidates = index.query(required)
+            if rel_candidates is None:
+                return None
+            if len(rel_candidates) > _MAX_PREFILTER_CANDIDATES:
+                # Too many candidates: the arg list would be huge and the filter
+                # is not selective -- a full scan is simpler and comparable.
+                return None
+            scope = search_path.resolve()
+            abs_paths: List[Path] = []
+            for rel in rel_candidates:
+                ap = (self.repo_path / rel).resolve()
+                try:
+                    ap.relative_to(scope)  # keep only files under the scan scope
+                except ValueError:
+                    continue
+                abs_paths.append(ap)
+            return abs_paths
+        except Exception as exc:  # never let the optimization break search
+            logger.debug("trigram pre-filter unavailable (%s); full scan", exc)
+            return None
+
     async def _search_ripgrep(
         self,
         pattern: str,
@@ -313,8 +379,14 @@ class RegexSearchService:
         timeout_seconds: Optional[int],
         multiline: bool = False,
         pcre2: bool = False,
+        candidate_files: Optional[List[Path]] = None,
     ) -> tuple:
-        """Search using ripgrep with JSON output and timeout protection."""
+        """Search using ripgrep with JSON output and timeout protection.
+
+        When ``candidate_files`` is provided, ripgrep searches exactly those
+        files (the trigram pre-filter's superset) instead of walking
+        ``search_path``; include/exclude globs still apply.
+        """
         cmd = ["rg", "--json", "-e", pattern]
 
         if multiline:
@@ -338,7 +410,14 @@ class RegexSearchService:
         cmd.extend(["-g", "!.code-indexer/**"])
         cmd.extend(["-g", "!.git/**"])
 
-        cmd.extend(["--", str(search_path)])
+        if candidate_files is not None:
+            # Trigram pre-filter narrowed the search to specific files; ripgrep
+            # searches those directly (gitignore is irrelevant for explicit paths,
+            # and the candidates already came from a gitignore-aware index).
+            cmd.append("--")
+            cmd.extend(str(f) for f in candidate_files)
+        else:
+            cmd.extend(["--", str(search_path)])
 
         # Create temp file for output
         temp_fd, temp_path = tempfile.mkstemp(suffix=".txt", prefix="rg_search_")

--- a/src/code_indexer/global_repos/regex_search.py
+++ b/src/code_indexer/global_repos/regex_search.py
@@ -66,6 +66,10 @@ class RegexSearchResult:
 class RegexSearchService:
     """Service for performing regex searches on repository files."""
 
+    # Set once, process-wide, the first time we degrade to the grep fallback so
+    # the warning in _detect_search_engine is emitted a single time, not per call.
+    _grep_fallback_warned: bool = False
+
     def __init__(self, repo_path: Path, subprocess_max_workers: int = 2):
         """Initialize the regex search service.
 
@@ -94,6 +98,18 @@ class RegexSearchService:
         if shutil.which("rg"):
             return "ripgrep"
         elif shutil.which("grep"):
+            # ripgrep is absent -> we degrade to a linear `grep -r` scan that has
+            # no gitignore awareness and reads the entire working tree. On large
+            # repos this reliably hits the search timeout. Warn loudly (once) so
+            # the degradation is visible instead of manifesting as opaque 30s
+            # timeouts. Install ripgrep in the deployment image to avoid this.
+            if not RegexSearchService._grep_fallback_warned:
+                RegexSearchService._grep_fallback_warned = True
+                logger.warning(
+                    "ripgrep (rg) not found on PATH; falling back to 'grep -r'. "
+                    "Regex search will linearly scan the full working tree and "
+                    "may time out on large repos. Install ripgrep in the image."
+                )
             return "grep"
         else:
             raise RuntimeError("Neither ripgrep nor grep found on system")

--- a/src/code_indexer/global_repos/regex_search.py
+++ b/src/code_indexer/global_repos/regex_search.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -34,6 +35,53 @@ _PCRE2_CHECK_TIMEOUT_SEC = 5
 # the ripgrep arg list would be unwieldy and the filter is not selective enough
 # to beat a plain scan.
 _MAX_PREFILTER_CANDIDATES = 8000
+
+# Lazy trigram-index rebuild: when a regex search finds no compatible trigram
+# index (missing, or stale/old-format per the schema-version guard), kick off a
+# one-shot background build so the index self-heals before the next scheduled
+# golden-repo refresh. This request still full-scans; later ones use the index.
+# Disable by setting CIDX_TRIGRAM_LAZY_BUILD=0.
+_LAZY_BUILD_COOLDOWN_SEC = 300
+_lazy_build_lock = threading.Lock()
+_lazy_build_in_progress: "set[str]" = set()
+_lazy_build_last_attempt: "dict[str, float]" = {}
+
+
+def _lazy_build_enabled() -> bool:
+    return os.environ.get("CIDX_TRIGRAM_LAZY_BUILD", "1") not in ("0", "false", "False")
+
+
+def _maybe_trigger_lazy_index_build(repo_path: Path) -> None:
+    """Start a background trigram-index build for ``repo_path`` if none is
+    already running/recent. Best-effort; never raises into the caller."""
+    if not _lazy_build_enabled():
+        return
+    key = str(repo_path)
+    now = time.monotonic()
+    with _lazy_build_lock:
+        if key in _lazy_build_in_progress:
+            return  # a build is already running for this repo
+        last = _lazy_build_last_attempt.get(key)
+        if last is not None and now - last < _LAZY_BUILD_COOLDOWN_SEC:
+            return  # backed off after a recent attempt (avoid retry storms)
+        _lazy_build_in_progress.add(key)
+        _lazy_build_last_attempt[key] = now
+
+    def _run() -> None:
+        try:
+            from .trigram_index_manager import TrigramIndexManager
+
+            index_dir = repo_path / ".code-indexer" / "trigram_index"
+            n = TrigramIndexManager(index_dir).build(repo_path)
+            logger.info("lazy trigram index build complete for %s (%d files)", key, n)
+        except Exception as exc:  # never let the background build crash the server
+            logger.warning("lazy trigram index build failed for %s: %s", key, exc)
+        finally:
+            with _lazy_build_lock:
+                _lazy_build_in_progress.discard(key)
+                _lazy_build_last_attempt[key] = time.monotonic()
+
+    threading.Thread(target=_run, name="trigram-lazy-build", daemon=True).start()
 
 
 class RipgrepExecutionError(Exception):
@@ -340,6 +388,10 @@ class RegexSearchService:
                 self.repo_path / ".code-indexer" / "trigram_index"
             )
             if not index.exists():
+                # No compatible index (missing or stale/old-format). Self-heal in
+                # the background so later searches are pre-filtered; this one
+                # full-scans.
+                _maybe_trigger_lazy_index_build(self.repo_path)
                 return None
             required = extract_required_trigrams(
                 pattern, case_insensitive=not case_sensitive

--- a/src/code_indexer/global_repos/regex_trigram.py
+++ b/src/code_indexer/global_repos/regex_trigram.py
@@ -35,6 +35,41 @@ def trigrams(text: str) -> Set[str]:
     return {text[i : i + _TRIGRAM] for i in range(len(text) - _TRIGRAM + 1)}
 
 
+def _index_storable(ch: str) -> bool:
+    """True if a trigram containing ``ch`` could exist in the index.
+
+    The trigram index only stores runs of printable ASCII (plus tab/newline/CR),
+    mirroring ``trigram_index_manager._PRINTABLE_RUN``. A required trigram with
+    any other character can never be present, so requiring it would wrongly prune
+    every indexed file. Keep this predicate in sync with that pattern.
+    """
+    o = ord(ch)
+    return 0x20 <= o <= 0x7E or ch in "\t\n\r"
+
+
+def _ascii_subruns(run: str) -> List[str]:
+    """Split a literal run into its maximal index-storable (printable-ASCII) parts.
+
+    A file matching the pattern contains the whole run contiguously, so it also
+    contains each maximal ASCII sub-run contiguously -- and the index stores that
+    sub-run's trigrams. Trigrams of a sub-run are therefore a valid *necessary*
+    condition; trigrams spanning a non-ASCII character are not (the index never
+    holds them), so they must be excluded to preserve the no-false-negative
+    guarantee.
+    """
+    parts: List[str] = []
+    current: List[str] = []
+    for ch in run:
+        if _index_storable(ch):
+            current.append(ch)
+        elif current:
+            parts.append("".join(current))
+            current.clear()
+    if current:
+        parts.append("".join(current))
+    return parts
+
+
 def _is_quantifier_at(pattern: str, i: int) -> int:
     """If a quantifier starts at ``pattern[i]``, return its length, else 0.
 
@@ -181,7 +216,12 @@ def extract_required_trigrams(
         return None
     required: Set[str] = set()
     for run in runs:
-        if len(run) >= _TRIGRAM:
-            required |= trigrams(run.lower())
+        # Only derive trigrams from the ASCII portions of each run: the index
+        # stores printable-ASCII trigrams only, so a trigram spanning a non-ASCII
+        # literal (e.g. the ``afe`` of ``cafe`` with an accented e) would have
+        # zero document frequency and wrongly prune every indexed file.
+        for sub in _ascii_subruns(run):
+            if len(sub) >= _TRIGRAM:
+                required |= trigrams(sub.lower())
     # An empty set would select every file (no pruning) -> signal full scan.
     return required or None

--- a/src/code_indexer/global_repos/regex_trigram.py
+++ b/src/code_indexer/global_repos/regex_trigram.py
@@ -1,0 +1,187 @@
+"""Regex -> required-trigram analysis for index-assisted regex search.
+
+The regex endpoint scans a repository's working tree with ripgrep. On a large
+repo hosted on NFS that scan is I/O-bound (tens of seconds). A trigram index
+(``trigram -> files``) lets us pre-select a small set of candidate files and run
+ripgrep over only those, preserving ripgrep's exact regex semantics.
+
+The pre-filter is only correct if it never drops a real match. This module
+derives, from a regex, a set of trigrams that EVERY matching string must
+contain -- a *necessary* condition. Candidate files are those containing all of
+those trigrams (a guaranteed superset of the true matches). ripgrep then does
+the precise matching over that superset.
+
+Safety over cleverness: when the pattern cannot be analysed into a provably
+required trigram set, :func:`extract_required_trigrams` returns ``None`` and the
+caller falls back to a full scan. It must never return a set that could exclude
+a matching file.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Set
+
+# Minimum literal-run length that yields at least one trigram.
+_TRIGRAM = 3
+
+# Escaped ASCII letters/digits are metacharacter escapes (``\w \s \d \b \n \1``
+# ...) rather than literals, so they break a fixed literal run. Escaped
+# non-alphanumerics (``\. \+ \/ \\``) are literal characters.
+_QUANTIFIER_STARTS = frozenset("?*+{")
+
+
+def trigrams(text: str) -> Set[str]:
+    """Return the set of 3-character substrings (trigrams) of ``text``."""
+    return {text[i : i + _TRIGRAM] for i in range(len(text) - _TRIGRAM + 1)}
+
+
+def _is_quantifier_at(pattern: str, i: int) -> int:
+    """If a quantifier starts at ``pattern[i]``, return its length, else 0.
+
+    Recognises ``?``, ``*``, ``+`` and ``{m}`` / ``{m,}`` / ``{m,n}``. A ``{``
+    that does not form a valid counted quantifier is treated as a literal.
+    """
+    if i >= len(pattern):
+        return 0
+    c = pattern[i]
+    if c in "?*+":
+        return 1
+    if c == "{":
+        j = i + 1
+        saw_digit = False
+        while j < len(pattern) and pattern[j].isdigit():
+            j += 1
+            saw_digit = True
+        if j < len(pattern) and pattern[j] == ",":
+            j += 1
+            while j < len(pattern) and pattern[j].isdigit():
+                j += 1
+        if saw_digit and j < len(pattern) and pattern[j] == "}":
+            return j - i + 1
+    return 0
+
+
+def _required_literal_runs(pattern: str) -> Optional[List[str]]:
+    """Return the maximal runs of fixed, required literal characters, or None.
+
+    A "fixed required literal" is a literal character that appears exactly once
+    in every match: it is not a metacharacter, not inside a character class, and
+    not followed by any quantifier (``?``/``*``/``+``/``{...}``). Consecutive
+    such characters form a run that is guaranteed to appear contiguously in every
+    matching string.
+
+    Returns ``None`` (meaning "cannot analyse safely -> full scan") when the
+    pattern contains alternation ``|`` or a group ``(`` -- either can make a
+    literal optional or introduce OR semantics that this conservative analysis
+    does not model.
+    """
+    runs: List[str] = []
+    current: List[str] = []
+
+    def flush() -> None:
+        if current:
+            runs.append("".join(current))
+            current.clear()
+
+    i = 0
+    n = len(pattern)
+    while i < n:
+        c = pattern[i]
+
+        # Constructs we do not model -> bail to a full scan.
+        if c == "|" or c == "(":
+            return None
+
+        # Character class: a single variable character -> run breaker. Skip to
+        # the matching ']' (respecting an escaped ']' and a literal leading ']').
+        if c == "[":
+            flush()
+            j = i + 1
+            if j < n and pattern[j] == "^":
+                j += 1
+            if j < n and pattern[j] == "]":  # literal ']' as first class member
+                j += 1
+            while j < n and pattern[j] != "]":
+                j += 2 if pattern[j] == "\\" else 1
+            i = j + 1
+            continue
+
+        # Anchors / dot -> run breakers, single char.
+        if c in ".^$":
+            flush()
+            i += 1
+            continue
+
+        # A quantifier appearing here applies to the previous atom. If we had a
+        # literal in the current run, its last char is quantified (optional or
+        # variable) and must be removed from the required run.
+        qlen = _is_quantifier_at(pattern, i)
+        if qlen:
+            if current:
+                current.pop()
+                flush()
+            i += qlen
+            continue
+
+        # Escape sequence.
+        if c == "\\":
+            if i + 1 >= n:  # dangling backslash -> treat as run breaker
+                flush()
+                i += 1
+                continue
+            nxt = pattern[i + 1]
+            if nxt.isalnum():
+                # \w \s \d \b \n \1 ... -> metacharacter/escape -> run breaker.
+                flush()
+                i += 2
+                continue
+            # \. \+ \/ \\ ... -> literal punctuation char. It is required only
+            # if not immediately quantified.
+            after = i + 2
+            if _is_quantifier_at(pattern, after):
+                flush()  # quantified escaped literal -> not fixed
+                i = after + _is_quantifier_at(pattern, after)
+                continue
+            current.append(nxt)
+            i += 2
+            continue
+
+        # Plain literal char. Required only if the NEXT token is not a quantifier
+        # (a quantifier would make this char optional/variable).
+        if _is_quantifier_at(pattern, i + 1):
+            flush()
+            i += 1 + _is_quantifier_at(pattern, i + 1)
+            continue
+        current.append(c)
+        i += 1
+
+    flush()
+    return runs
+
+
+def extract_required_trigrams(
+    pattern: str, case_insensitive: bool = False
+) -> Optional[Set[str]]:
+    """Return trigrams every match of ``pattern`` must contain, or ``None``.
+
+    The returned set is a *necessary* condition: any string matching ``pattern``
+    contains every trigram in it, so files lacking any of them cannot match and
+    are safely excluded. Trigrams are lowercased so the same index serves both
+    case-sensitive and case-insensitive searches (a superset either way; the
+    caller's ripgrep pass enforces exact case).
+
+    Returns ``None`` when no provably-required trigram can be derived (short or
+    wildcard-dominated patterns, alternation, groups) -- the caller must then
+    scan without pre-filtering. Never returns a set that could exclude a match.
+    """
+    if not pattern:
+        return None
+    runs = _required_literal_runs(pattern)
+    if runs is None:
+        return None
+    required: Set[str] = set()
+    for run in runs:
+        if len(run) >= _TRIGRAM:
+            required |= trigrams(run.lower())
+    # An empty set would select every file (no pruning) -> signal full scan.
+    return required or None

--- a/src/code_indexer/global_repos/trigram_index_manager.py
+++ b/src/code_indexer/global_repos/trigram_index_manager.py
@@ -1,0 +1,215 @@
+"""Trigram inverted index for index-assisted regex search.
+
+Stores, per repository, a mapping ``trigram -> files containing it`` in a SQLite
+database under ``<repo>/.code-indexer/trigram_index/``. Given a set of trigrams
+that a regex match must contain (see :mod:`regex_trigram`), the index returns the
+small set of candidate files, which ripgrep then searches precisely.
+
+Correctness contract: :meth:`query` must return a SUPERSET of the files that
+could contain a match. Files that could not be trigram-indexed (unreadable,
+binary, decode errors) are recorded as "always candidates" so they are never
+silently excluded.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+from typing import Iterable, List, Optional, Set
+
+from .regex_trigram import trigrams
+
+logger = logging.getLogger(__name__)
+
+_DB_NAME = "trigrams.db"
+# Skip trigram extraction for files larger than this (still recorded as an
+# always-candidate so matches inside them are never missed). Keeps build I/O and
+# db size bounded; large files are rare and ripgrep handles them in the pass.
+_MAX_INDEX_BYTES = 5 * 1024 * 1024
+_INSERT_BATCH = 5000
+
+
+class TrigramIndexManager:
+    """Build and query a per-repository trigram inverted index."""
+
+    def __init__(self, index_dir: Path) -> None:
+        self._dir = Path(index_dir)
+        self._db_path = self._dir / _DB_NAME
+
+    # ------------------------------------------------------------------
+    # Availability
+    # ------------------------------------------------------------------
+    @property
+    def db_path(self) -> Path:
+        return self._db_path
+
+    def exists(self) -> bool:
+        """True when a populated index database is present."""
+        if not self._db_path.exists():
+            return False
+        try:
+            with sqlite3.connect(f"file:{self._db_path}?mode=ro", uri=True) as conn:
+                row = conn.execute("SELECT COUNT(*) FROM files").fetchone()
+                return bool(row and row[0] > 0)
+        except sqlite3.Error:
+            return False
+
+    # ------------------------------------------------------------------
+    # Build
+    # ------------------------------------------------------------------
+    def build(self, repo_path: Path, file_list: Optional[Iterable[str]] = None) -> int:
+        """Build (or rebuild) the index for ``repo_path``.
+
+        ``file_list`` is an optional iterable of repo-relative file paths (e.g.
+        the set the indexer already enumerated). When omitted, files are listed
+        with ``rg --files`` so the set matches exactly what ripgrep searches.
+        Returns the number of files recorded.
+        """
+        repo_path = Path(repo_path)
+        rel_files = (
+            list(file_list)
+            if file_list is not None
+            else self._enumerate_files(repo_path)
+        )
+
+        self._dir.mkdir(parents=True, exist_ok=True)
+        tmp_path = self._db_path.with_suffix(".db.building")
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+        conn = sqlite3.connect(str(tmp_path))
+        try:
+            conn.execute("PRAGMA journal_mode=OFF")
+            conn.execute("PRAGMA synchronous=OFF")
+            conn.executescript(
+                """
+                CREATE TABLE files (
+                    id      INTEGER PRIMARY KEY,
+                    path    TEXT NOT NULL,
+                    indexed INTEGER NOT NULL DEFAULT 1
+                );
+                CREATE TABLE postings (
+                    trigram TEXT NOT NULL,
+                    file_id INTEGER NOT NULL
+                );
+                """
+            )
+            count = 0
+            batch: List[tuple] = []
+            for rel in rel_files:
+                file_id = count + 1
+                tris, indexed = self._file_trigrams(repo_path / rel)
+                conn.execute(
+                    "INSERT INTO files (id, path, indexed) VALUES (?, ?, ?)",
+                    (file_id, rel, 1 if indexed else 0),
+                )
+                for t in tris:
+                    batch.append((t, file_id))
+                    if len(batch) >= _INSERT_BATCH:
+                        conn.executemany(
+                            "INSERT INTO postings (trigram, file_id) VALUES (?, ?)",
+                            batch,
+                        )
+                        batch.clear()
+                count += 1
+            if batch:
+                conn.executemany(
+                    "INSERT INTO postings (trigram, file_id) VALUES (?, ?)", batch
+                )
+            conn.execute("CREATE INDEX idx_postings_trigram ON postings(trigram)")
+            conn.commit()
+        finally:
+            conn.close()
+
+        os.replace(tmp_path, self._db_path)  # atomic publish
+        logger.info(
+            "TrigramIndexManager: built index for %s (%d files) at %s",
+            repo_path,
+            count,
+            self._db_path,
+        )
+        return count
+
+    def _enumerate_files(self, repo_path: Path) -> List[str]:
+        """List repo-relative files ripgrep would search (gitignore-aware)."""
+        try:
+            proc = subprocess.run(
+                ["rg", "--files"],
+                cwd=str(repo_path),
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            if proc.returncode not in (0, 1):
+                logger.warning(
+                    "rg --files failed (%s); trigram build empty", proc.returncode
+                )
+                return []
+            return [line for line in proc.stdout.splitlines() if line]
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            logger.warning("rg --files unavailable (%s); trigram build empty", exc)
+            return []
+
+    @staticmethod
+    def _file_trigrams(abs_path: Path) -> "tuple[Set[str], bool]":
+        """Return ``(trigrams, indexed)`` for a file.
+
+        ``indexed`` is False for files that cannot be trigram-indexed (too large,
+        unreadable, binary/decode error); such files carry no postings and are
+        treated as always-candidates at query time so matches are never missed.
+        """
+        try:
+            if abs_path.stat().st_size > _MAX_INDEX_BYTES:
+                return set(), False
+            data = abs_path.read_bytes()
+        except OSError:
+            return set(), False
+        if b"\x00" in data:  # binary; ripgrep would skip it too
+            return set(), False
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            try:
+                text = data.decode("latin-1")
+            except UnicodeDecodeError:
+                return set(), False
+        return trigrams(text.lower()), True
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+    def query(self, required: Set[str]) -> Optional[List[str]]:
+        """Return repo-relative candidate paths for ``required`` trigrams.
+
+        Candidates = every always-candidate (unindexed) file PLUS every indexed
+        file that contains all ``required`` trigrams -- a guaranteed superset of
+        real matches. Returns ``None`` when ``required`` is empty (no pruning
+        possible) so the caller falls back to a full scan.
+        """
+        if not required:
+            return None
+        tris = [t.lower() for t in required]
+        placeholders = ",".join("?" for _ in tris)
+        try:
+            with sqlite3.connect(f"file:{self._db_path}?mode=ro", uri=True) as conn:
+                rows = conn.execute(
+                    f"""
+                    SELECT path FROM files WHERE indexed = 0
+                    UNION
+                    SELECT f.path FROM files f
+                    WHERE f.indexed = 1 AND f.id IN (
+                        SELECT file_id FROM postings
+                        WHERE trigram IN ({placeholders})
+                        GROUP BY file_id
+                        HAVING COUNT(DISTINCT trigram) = ?
+                    )
+                    """,
+                    (*tris, len(set(tris))),
+                ).fetchall()
+            return [r[0] for r in rows]
+        except sqlite3.Error as exc:
+            logger.warning("trigram query failed (%s); caller should full-scan", exc)
+            return None

--- a/src/code_indexer/global_repos/trigram_index_manager.py
+++ b/src/code_indexer/global_repos/trigram_index_manager.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import sqlite3
 import subprocess
 from pathlib import Path
@@ -23,6 +24,12 @@ from typing import Iterable, List, Optional, Set
 from .regex_trigram import trigrams
 
 logger = logging.getLogger(__name__)
+
+# Maximal runs of printable ASCII (plus tab/newline/CR) of length >= 3. Trigrams
+# are extracted only from these runs, so a binary file (e.g. a .class) is indexed
+# by its embedded text -- exactly the content ripgrep can match -- without the
+# dense noise trigrams of its raw bytes bloating the index.
+_PRINTABLE_RUN = re.compile(rb"[\t\n\r\x20-\x7e]{3,}")
 
 _DB_NAME = "trigrams.db"
 # Skip trigram extraction for files larger than this (still recorded as an
@@ -34,15 +41,6 @@ _INSERT_BATCH = 5000
 # reclaimed during a large build instead of accumulating against the container
 # memory limit.
 _COMMIT_EVERY_FILES = 2000
-# A required trigram present in more than this FRACTION of files is "too common"
-# to discriminate; it is dropped from the candidate query so we never scan its
-# huge posting list. Dropping required trigrams keeps the result a superset
-# (still correct -- ripgrep does the exact match). Selectivity comes from the
-# remaining discriminating trigrams.
-_COMMON_DF_FRACTION = 0.15
-# Fallback: if every required trigram is "too common", still query with at least
-# this many of the rarest ones so we retain some pruning.
-_MIN_QUERY_TRIGRAMS = 3
 
 
 class TrigramIndexManager:
@@ -149,11 +147,15 @@ class TrigramIndexManager:
                     "INSERT INTO postings (trigram, file_id) VALUES (?, ?)", batch
                 )
             conn.commit()
-            conn.execute("CREATE INDEX idx_postings_trigram ON postings(trigram)")
+            # Composite (trigram, file_id) index: serves both "file_ids of the
+            # rarest trigram" (WHERE trigram=?) and the per-candidate membership
+            # seek (WHERE trigram=? AND file_id=?) that the rarest-first
+            # intersection relies on -- so checking "does file X contain trigram
+            # T" is O(1), not a scan of T's whole posting list.
+            conn.execute("CREATE INDEX idx_postings_tc ON postings(trigram, file_id)")
             conn.commit()
             # Document frequency per trigram + total file count, so the query can
-            # cheaply rank trigrams and drop non-discriminating common ones
-            # without scanning their posting lists.
+            # order the required trigrams rarest-first.
             conn.execute(
                 "CREATE TABLE trigram_df AS "
                 "SELECT trigram, COUNT(*) AS df FROM postings GROUP BY trigram"
@@ -200,43 +202,46 @@ class TrigramIndexManager:
     def _file_trigrams(abs_path: Path) -> "tuple[Set[str], bool]":
         """Return ``(trigrams, indexed)`` for a file.
 
-        ``indexed`` is False for files that cannot be trigram-indexed (too large,
-        unreadable, binary/decode error); such files carry no postings and are
-        treated as always-candidates at query time so matches are never missed.
+        ``indexed`` is False only for files that cannot be trigram-indexed here
+        (too large, or unreadable); such files carry no postings and are treated
+        as always-candidates at query time so matches are never missed. Files
+        with binary content are still indexed (latin-1) because ripgrep searches
+        their text too.
         """
         try:
             if abs_path.stat().st_size > _MAX_INDEX_BYTES:
-                return set(), False
+                return set(), False  # large -> always-candidate (rg still scans)
             data = abs_path.read_bytes()
         except OSError:
-            return set(), False
-        if b"\x00" in data:  # binary; ripgrep would skip it too
-            return set(), False
-        try:
-            text = data.decode("utf-8")
-        except UnicodeDecodeError:
-            try:
-                text = data.decode("latin-1")
-            except UnicodeDecodeError:
-                return set(), False
-        return trigrams(text.lower()), True
+            return set(), False  # unreadable -> always-candidate
+        # Extract trigrams from printable text runs only. This indexes a binary
+        # file (e.g. a .class) by its embedded text -- the content ripgrep can
+        # match -- so it becomes prunable, without the dense random-byte trigrams
+        # of its raw bytes bloating the index. Correct: a match's required
+        # literals are printable and contiguous, so they fall within one run and
+        # their trigrams are captured here.
+        tris: Set[str] = set()
+        for m in _PRINTABLE_RUN.finditer(data):
+            tris |= trigrams(m.group().decode("ascii").lower())
+        return tris, True
 
     # ------------------------------------------------------------------
     # Query
     # ------------------------------------------------------------------
     def query(self, required: Set[str]) -> Optional[List[str]]:
-        """Return repo-relative candidate paths for ``required`` trigrams.
+        """Return repo-relative candidate paths that contain ALL ``required``
+        trigrams, plus every always-candidate (unindexed) file.
 
-        Candidates = every always-candidate (unindexed) file PLUS every indexed
-        file that contains the selected trigrams -- a guaranteed superset of real
-        matches. Returns ``None`` when ``required`` is empty (no pruning possible)
-        so the caller falls back to a full scan.
+        The result is a guaranteed superset of real matches (ripgrep does the
+        exact match over it). Returns ``None`` when ``required`` is empty (no
+        pruning possible) so the caller falls back to a full scan.
 
-        Only the RAREST few required trigrams are used for the candidate query.
-        Requiring a subset of the trigrams keeps the result a superset (still
-        correct -- ripgrep does the exact match), while avoiding the huge posting
-        lists of common trigrams (e.g. those from "class") that would otherwise
-        dominate the query. Selectivity comes from the rare trigrams anyway.
+        Requiring ALL trigrams is what makes the candidate set small; the
+        intersection is computed rarest-first so it stays cheap: seed the
+        candidate set from the rarest trigram's posting list, then for each
+        remaining trigram (in increasing document frequency) drop candidates that
+        lack it via an O(1) ``(trigram, file_id)`` index seek -- never scanning a
+        common trigram's full posting list.
         """
         if not required:
             return None
@@ -244,51 +249,52 @@ class TrigramIndexManager:
         ph_all = ",".join("?" for _ in tris)
         try:
             with sqlite3.connect(f"file:{self._db_path}?mode=ro", uri=True) as conn:
-                # Document frequency per required trigram (0 if absent from every
-                # file). Cheap lookups against the small trigram_df table.
+                # Order the required trigrams rarest-first (df 0 == absent).
                 df_map = {t: 0 for t in tris}
                 for t, df in conn.execute(
                     f"SELECT trigram, df FROM trigram_df WHERE trigram IN ({ph_all})",
                     tris,
                 ):
                     df_map[t] = df
-                row = conn.execute(
-                    "SELECT value FROM meta WHERE key = 'file_count'"
-                ).fetchone()
-                total = row[0] if row else None
+                ordered = sorted(tris, key=lambda t: df_map[t])
 
-                # Drop non-discriminating (very common) trigrams so we never scan
-                # their huge posting lists. Dropping REQUIRED trigrams only widens
-                # the candidate set (still a correct superset). Keep the rarest
-                # few if everything is common.
-                threshold = int(total * _COMMON_DF_FRACTION) if total else None
-                chosen = [
-                    t for t in tris if threshold is None or df_map[t] <= threshold
+                always = [
+                    r[0]
+                    for r in conn.execute("SELECT path FROM files WHERE indexed = 0")
                 ]
-                if not chosen:
-                    chosen = [
-                        t
-                        for _, t in sorted((df_map[t], t) for t in tris)[
-                            :_MIN_QUERY_TRIGRAMS
-                        ]
-                    ]
+                # A required trigram present in no file -> no indexed file can
+                # contain the literal; only always-candidates remain.
+                if df_map[ordered[0]] == 0:
+                    return always
 
-                placeholders = ",".join("?" for _ in chosen)
-                rows = conn.execute(
-                    f"""
-                    SELECT path FROM files WHERE indexed = 0
-                    UNION
-                    SELECT f.path FROM files f
-                    WHERE f.indexed = 1 AND f.id IN (
-                        SELECT file_id FROM postings
-                        WHERE trigram IN ({placeholders})
-                        GROUP BY file_id
-                        HAVING COUNT(DISTINCT trigram) = ?
+                # Rarest-first intersection in a connection-local temp table.
+                conn.execute("PRAGMA temp_store=FILE")
+                conn.execute("CREATE TEMP TABLE cand (id INTEGER PRIMARY KEY)")
+                try:
+                    conn.execute(
+                        "INSERT INTO cand SELECT file_id FROM postings WHERE trigram = ?",
+                        (ordered[0],),
                     )
-                    """,
-                    (*chosen, len(chosen)),
-                ).fetchall()
-            return [r[0] for r in rows]
+                    for t in ordered[1:]:
+                        conn.execute(
+                            "DELETE FROM cand WHERE NOT EXISTS ("
+                            "  SELECT 1 FROM postings"
+                            "  WHERE trigram = ? AND file_id = cand.id)",
+                            (t,),
+                        )
+                        if not conn.execute(
+                            "SELECT EXISTS(SELECT 1 FROM cand)"
+                        ).fetchone()[0]:
+                            break
+                    indexed = [
+                        r[0]
+                        for r in conn.execute(
+                            "SELECT f.path FROM files f JOIN cand ON f.id = cand.id"
+                        )
+                    ]
+                finally:
+                    conn.execute("DROP TABLE cand")
+            return always + indexed
         except sqlite3.Error as exc:
             logger.warning("trigram query failed (%s); caller should full-scan", exc)
             return None

--- a/src/code_indexer/global_repos/trigram_index_manager.py
+++ b/src/code_indexer/global_repos/trigram_index_manager.py
@@ -37,16 +37,6 @@ _DB_NAME = "trigrams.db"
 # db size bounded; large files are rare and ripgrep handles them in the pass.
 _MAX_INDEX_BYTES = 5 * 1024 * 1024
 _INSERT_BATCH = 5000
-# Positional bucketing: each file is divided into this many line-buckets, and a
-# mask per (trigram, file) records which buckets the trigram appears in. A
-# default (line-oriented) ripgrep match lies on a single line, so all its
-# trigrams share that line's bucket -> the AND of their masks is non-zero. This
-# lets the query drop files where the required trigrams only co-occur in
-# DIFFERENT parts of the file (e.g. "public" and "enum" far apart) -- the main
-# source of false candidates -- while adding only 8 bytes per posting.
-# 63 (not 64): the mask is stored in SQLite's signed 64-bit INTEGER, so the
-# highest usable bit is 62 (1 << 63 overflows).
-_NUM_BUCKETS = 63
 # Commit (and fsync) every N files so dirty database pages are flushed and
 # reclaimed during a large build instead of accumulating against the container
 # memory limit.
@@ -122,45 +112,47 @@ class TrigramIndexManager:
                 );
                 CREATE TABLE postings (
                     trigram TEXT NOT NULL,
-                    file_id INTEGER NOT NULL,
-                    mask    INTEGER NOT NULL
+                    file_id INTEGER NOT NULL
                 );
                 """
-            )
-            insert_sql = (
-                "INSERT INTO postings (trigram, file_id, mask) VALUES (?, ?, ?)"
             )
             count = 0
             batch: List[tuple] = []
             for rel in rel_files:
                 file_id = count + 1
-                masks, indexed = self._file_trigrams(repo_path / rel)
+                tris, indexed = self._file_trigrams(repo_path / rel)
                 conn.execute(
                     "INSERT INTO files (id, path, indexed) VALUES (?, ?, ?)",
                     (file_id, rel, 1 if indexed else 0),
                 )
-                for t, mask in masks.items():
-                    batch.append((t, file_id, mask))
+                for t in tris:
+                    batch.append((t, file_id))
                     if len(batch) >= _INSERT_BATCH:
-                        conn.executemany(insert_sql, batch)
+                        conn.executemany(
+                            "INSERT INTO postings (trigram, file_id) VALUES (?, ?)",
+                            batch,
+                        )
                         batch.clear()
                 count += 1
                 if count % _COMMIT_EVERY_FILES == 0:
                     if batch:
-                        conn.executemany(insert_sql, batch)
+                        conn.executemany(
+                            "INSERT INTO postings (trigram, file_id) VALUES (?, ?)",
+                            batch,
+                        )
                         batch.clear()
                     conn.commit()  # flush dirty pages, bound memory
             if batch:
-                conn.executemany(insert_sql, batch)
+                conn.executemany(
+                    "INSERT INTO postings (trigram, file_id) VALUES (?, ?)", batch
+                )
             conn.commit()
             # Composite (trigram, file_id) index: serves both "file_ids of the
             # rarest trigram" (WHERE trigram=?) and the per-candidate membership
             # seek (WHERE trigram=? AND file_id=?) that the rarest-first
             # intersection relies on -- so checking "does file X contain trigram
             # T" is O(1), not a scan of T's whole posting list.
-            conn.execute(
-                "CREATE INDEX idx_postings_tc ON postings(trigram, file_id, mask)"
-            )
+            conn.execute("CREATE INDEX idx_postings_tc ON postings(trigram, file_id)")
             # Index the always-candidate flag so fetching unindexed files is a
             # seek, not a full scan of the (large) files table.
             conn.execute("CREATE INDEX idx_files_indexed ON files(indexed)")
@@ -210,36 +202,31 @@ class TrigramIndexManager:
             return []
 
     @staticmethod
-    def _file_trigrams(abs_path: Path) -> "tuple[dict[str, int], bool]":
-        """Return ``({trigram: bucket_mask}, indexed)`` for a file.
+    def _file_trigrams(abs_path: Path) -> "tuple[Set[str], bool]":
+        """Return ``(trigrams, indexed)`` for a file.
 
         ``indexed`` is False only for files that cannot be trigram-indexed here
         (too large, or unreadable); such files carry no postings and are treated
         as always-candidates at query time so matches are never missed. Files
-        with binary content are still indexed because ripgrep searches their text
-        too -- but only their printable text runs are indexed, so a binary file
-        (e.g. a .class) is prunable without its dense raw-byte trigrams bloating
-        the index. Correct: a match's required literals are printable and lie on
-        one line, so their trigrams share a run and a bucket.
-
-        ``bucket_mask`` is a 64-bit value with a bit set for each line-bucket the
-        trigram occurs in (see ``_NUM_BUCKETS``).
+        with binary content are still indexed (latin-1) because ripgrep searches
+        their text too.
         """
         try:
             if abs_path.stat().st_size > _MAX_INDEX_BYTES:
-                return {}, False  # large -> always-candidate (rg still scans)
+                return set(), False  # large -> always-candidate (rg still scans)
             data = abs_path.read_bytes()
         except OSError:
-            return {}, False  # unreadable -> always-candidate
-        lines = data.split(b"\n")
-        total = len(lines) or 1
-        masks: "dict[str, int]" = {}
-        for i, line in enumerate(lines):
-            bit = 1 << (i * _NUM_BUCKETS // total)
-            for m in _PRINTABLE_RUN.finditer(line):
-                for tg in trigrams(m.group().decode("ascii").lower()):
-                    masks[tg] = masks.get(tg, 0) | bit
-        return masks, True
+            return set(), False  # unreadable -> always-candidate
+        # Extract trigrams from printable text runs only. This indexes a binary
+        # file (e.g. a .class) by its embedded text -- the content ripgrep can
+        # match -- so it becomes prunable, without the dense random-byte trigrams
+        # of its raw bytes bloating the index. Correct: a match's required
+        # literals are printable and contiguous, so they fall within one run and
+        # their trigrams are captured here.
+        tris: Set[str] = set()
+        for m in _PRINTABLE_RUN.finditer(data):
+            tris |= trigrams(m.group().decode("ascii").lower())
+        return tris, True
 
     # ------------------------------------------------------------------
     # Query
@@ -255,12 +242,9 @@ class TrigramIndexManager:
         Requiring ALL trigrams is what makes the candidate set small; the
         intersection is computed rarest-first so it stays cheap: seed the
         candidate set from the rarest trigram's posting list, then for each
-        remaining trigram (in increasing document frequency) AND its per-file
-        bucket mask into the running candidate mask via an O(1)
-        ``(trigram, file_id)`` index seek -- never scanning a common trigram's
-        full posting list. A candidate is dropped when the AND reaches zero,
-        i.e. the required trigrams never share a line-bucket, so no default
-        (line-oriented) ripgrep match is possible.
+        remaining trigram (in increasing document frequency) drop candidates that
+        lack it via an O(1) ``(trigram, file_id)`` index seek -- never scanning a
+        common trigram's full posting list.
         """
         if not required:
             return None
@@ -286,29 +270,21 @@ class TrigramIndexManager:
                 if df_map[ordered[0]] == 0:
                     return always
 
-                # Rarest-first bucket-mask intersection in a connection-local
-                # temp table. cand.mask is the running AND of the required
-                # trigrams' bucket masks for that file.
+                # Rarest-first intersection in a connection-local temp table.
                 conn.execute("PRAGMA temp_store=FILE")
-                conn.execute(
-                    "CREATE TEMP TABLE cand (id INTEGER PRIMARY KEY, mask INTEGER)"
-                )
+                conn.execute("CREATE TEMP TABLE cand (id INTEGER PRIMARY KEY)")
                 try:
                     conn.execute(
-                        "INSERT INTO cand SELECT file_id, mask FROM postings "
-                        "WHERE trigram = ?",
+                        "INSERT INTO cand SELECT file_id FROM postings WHERE trigram = ?",
                         (ordered[0],),
                     )
                     for t in ordered[1:]:
-                        # AND this trigram's mask into each candidate; a file
-                        # lacking the trigram yields 0 (COALESCE) -> dropped next.
                         conn.execute(
-                            "UPDATE cand SET mask = mask & COALESCE("
-                            "  (SELECT p.mask FROM postings p"
-                            "   WHERE p.trigram = ? AND p.file_id = cand.id), 0)",
+                            "DELETE FROM cand WHERE NOT EXISTS ("
+                            "  SELECT 1 FROM postings"
+                            "  WHERE trigram = ? AND file_id = cand.id)",
                             (t,),
                         )
-                        conn.execute("DELETE FROM cand WHERE mask = 0")
                         if not conn.execute(
                             "SELECT EXISTS(SELECT 1 FROM cand)"
                         ).fetchone()[0]:

--- a/src/code_indexer/global_repos/trigram_index_manager.py
+++ b/src/code_indexer/global_repos/trigram_index_manager.py
@@ -30,6 +30,19 @@ _DB_NAME = "trigrams.db"
 # db size bounded; large files are rare and ripgrep handles them in the pass.
 _MAX_INDEX_BYTES = 5 * 1024 * 1024
 _INSERT_BATCH = 5000
+# Commit (and fsync) every N files so dirty database pages are flushed and
+# reclaimed during a large build instead of accumulating against the container
+# memory limit.
+_COMMIT_EVERY_FILES = 2000
+# A required trigram present in more than this FRACTION of files is "too common"
+# to discriminate; it is dropped from the candidate query so we never scan its
+# huge posting list. Dropping required trigrams keeps the result a superset
+# (still correct -- ripgrep does the exact match). Selectivity comes from the
+# remaining discriminating trigrams.
+_COMMON_DF_FRACTION = 0.15
+# Fallback: if every required trigram is "too common", still query with at least
+# this many of the rarest ones so we retain some pruning.
+_MIN_QUERY_TRIGRAMS = 3
 
 
 class TrigramIndexManager:
@@ -82,8 +95,16 @@ class TrigramIndexManager:
 
         conn = sqlite3.connect(str(tmp_path))
         try:
+            # Memory-frugal build: a bounded page cache, disk-backed temp store
+            # (so the final index sort spills to disk instead of RAM), no rollback
+            # journal (we publish atomically via a temp file), and periodic
+            # commits that fsync so dirty db pages are flushed and reclaimed
+            # instead of accumulating against the container memory limit.
             conn.execute("PRAGMA journal_mode=OFF")
-            conn.execute("PRAGMA synchronous=OFF")
+            conn.execute("PRAGMA synchronous=NORMAL")
+            conn.execute("PRAGMA cache_size=-8000")  # ~8 MB
+            conn.execute("PRAGMA temp_store=FILE")
+            conn.execute("PRAGMA mmap_size=0")
             conn.executescript(
                 """
                 CREATE TABLE files (
@@ -115,11 +136,33 @@ class TrigramIndexManager:
                         )
                         batch.clear()
                 count += 1
+                if count % _COMMIT_EVERY_FILES == 0:
+                    if batch:
+                        conn.executemany(
+                            "INSERT INTO postings (trigram, file_id) VALUES (?, ?)",
+                            batch,
+                        )
+                        batch.clear()
+                    conn.commit()  # flush dirty pages, bound memory
             if batch:
                 conn.executemany(
                     "INSERT INTO postings (trigram, file_id) VALUES (?, ?)", batch
                 )
+            conn.commit()
             conn.execute("CREATE INDEX idx_postings_trigram ON postings(trigram)")
+            conn.commit()
+            # Document frequency per trigram + total file count, so the query can
+            # cheaply rank trigrams and drop non-discriminating common ones
+            # without scanning their posting lists.
+            conn.execute(
+                "CREATE TABLE trigram_df AS "
+                "SELECT trigram, COUNT(*) AS df FROM postings GROUP BY trigram"
+            )
+            conn.execute("CREATE INDEX idx_trigram_df ON trigram_df(trigram)")
+            conn.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value INTEGER)")
+            conn.execute(
+                "INSERT INTO meta (key, value) VALUES ('file_count', ?)", (count,)
+            )
             conn.commit()
         finally:
             conn.close()
@@ -185,16 +228,52 @@ class TrigramIndexManager:
         """Return repo-relative candidate paths for ``required`` trigrams.
 
         Candidates = every always-candidate (unindexed) file PLUS every indexed
-        file that contains all ``required`` trigrams -- a guaranteed superset of
-        real matches. Returns ``None`` when ``required`` is empty (no pruning
-        possible) so the caller falls back to a full scan.
+        file that contains the selected trigrams -- a guaranteed superset of real
+        matches. Returns ``None`` when ``required`` is empty (no pruning possible)
+        so the caller falls back to a full scan.
+
+        Only the RAREST few required trigrams are used for the candidate query.
+        Requiring a subset of the trigrams keeps the result a superset (still
+        correct -- ripgrep does the exact match), while avoiding the huge posting
+        lists of common trigrams (e.g. those from "class") that would otherwise
+        dominate the query. Selectivity comes from the rare trigrams anyway.
         """
         if not required:
             return None
-        tris = [t.lower() for t in required]
-        placeholders = ",".join("?" for _ in tris)
+        tris = list({t.lower() for t in required})
+        ph_all = ",".join("?" for _ in tris)
         try:
             with sqlite3.connect(f"file:{self._db_path}?mode=ro", uri=True) as conn:
+                # Document frequency per required trigram (0 if absent from every
+                # file). Cheap lookups against the small trigram_df table.
+                df_map = {t: 0 for t in tris}
+                for t, df in conn.execute(
+                    f"SELECT trigram, df FROM trigram_df WHERE trigram IN ({ph_all})",
+                    tris,
+                ):
+                    df_map[t] = df
+                row = conn.execute(
+                    "SELECT value FROM meta WHERE key = 'file_count'"
+                ).fetchone()
+                total = row[0] if row else None
+
+                # Drop non-discriminating (very common) trigrams so we never scan
+                # their huge posting lists. Dropping REQUIRED trigrams only widens
+                # the candidate set (still a correct superset). Keep the rarest
+                # few if everything is common.
+                threshold = int(total * _COMMON_DF_FRACTION) if total else None
+                chosen = [
+                    t for t in tris if threshold is None or df_map[t] <= threshold
+                ]
+                if not chosen:
+                    chosen = [
+                        t
+                        for _, t in sorted((df_map[t], t) for t in tris)[
+                            :_MIN_QUERY_TRIGRAMS
+                        ]
+                    ]
+
+                placeholders = ",".join("?" for _ in chosen)
                 rows = conn.execute(
                     f"""
                     SELECT path FROM files WHERE indexed = 0
@@ -207,7 +286,7 @@ class TrigramIndexManager:
                         HAVING COUNT(DISTINCT trigram) = ?
                     )
                     """,
-                    (*tris, len(set(tris))),
+                    (*chosen, len(chosen)),
                 ).fetchall()
             return [r[0] for r in rows]
         except sqlite3.Error as exc:

--- a/src/code_indexer/global_repos/trigram_index_manager.py
+++ b/src/code_indexer/global_repos/trigram_index_manager.py
@@ -37,6 +37,16 @@ _DB_NAME = "trigrams.db"
 # db size bounded; large files are rare and ripgrep handles them in the pass.
 _MAX_INDEX_BYTES = 5 * 1024 * 1024
 _INSERT_BATCH = 5000
+# Positional bucketing: each file is divided into this many line-buckets, and a
+# mask per (trigram, file) records which buckets the trigram appears in. A
+# default (line-oriented) ripgrep match lies on a single line, so all its
+# trigrams share that line's bucket -> the AND of their masks is non-zero. This
+# lets the query drop files where the required trigrams only co-occur in
+# DIFFERENT parts of the file (e.g. "public" and "enum" far apart) -- the main
+# source of false candidates -- while adding only 8 bytes per posting.
+# 63 (not 64): the mask is stored in SQLite's signed 64-bit INTEGER, so the
+# highest usable bit is 62 (1 << 63 overflows).
+_NUM_BUCKETS = 63
 # Commit (and fsync) every N files so dirty database pages are flushed and
 # reclaimed during a large build instead of accumulating against the container
 # memory limit.
@@ -112,47 +122,45 @@ class TrigramIndexManager:
                 );
                 CREATE TABLE postings (
                     trigram TEXT NOT NULL,
-                    file_id INTEGER NOT NULL
+                    file_id INTEGER NOT NULL,
+                    mask    INTEGER NOT NULL
                 );
                 """
+            )
+            insert_sql = (
+                "INSERT INTO postings (trigram, file_id, mask) VALUES (?, ?, ?)"
             )
             count = 0
             batch: List[tuple] = []
             for rel in rel_files:
                 file_id = count + 1
-                tris, indexed = self._file_trigrams(repo_path / rel)
+                masks, indexed = self._file_trigrams(repo_path / rel)
                 conn.execute(
                     "INSERT INTO files (id, path, indexed) VALUES (?, ?, ?)",
                     (file_id, rel, 1 if indexed else 0),
                 )
-                for t in tris:
-                    batch.append((t, file_id))
+                for t, mask in masks.items():
+                    batch.append((t, file_id, mask))
                     if len(batch) >= _INSERT_BATCH:
-                        conn.executemany(
-                            "INSERT INTO postings (trigram, file_id) VALUES (?, ?)",
-                            batch,
-                        )
+                        conn.executemany(insert_sql, batch)
                         batch.clear()
                 count += 1
                 if count % _COMMIT_EVERY_FILES == 0:
                     if batch:
-                        conn.executemany(
-                            "INSERT INTO postings (trigram, file_id) VALUES (?, ?)",
-                            batch,
-                        )
+                        conn.executemany(insert_sql, batch)
                         batch.clear()
                     conn.commit()  # flush dirty pages, bound memory
             if batch:
-                conn.executemany(
-                    "INSERT INTO postings (trigram, file_id) VALUES (?, ?)", batch
-                )
+                conn.executemany(insert_sql, batch)
             conn.commit()
             # Composite (trigram, file_id) index: serves both "file_ids of the
             # rarest trigram" (WHERE trigram=?) and the per-candidate membership
             # seek (WHERE trigram=? AND file_id=?) that the rarest-first
             # intersection relies on -- so checking "does file X contain trigram
             # T" is O(1), not a scan of T's whole posting list.
-            conn.execute("CREATE INDEX idx_postings_tc ON postings(trigram, file_id)")
+            conn.execute(
+                "CREATE INDEX idx_postings_tc ON postings(trigram, file_id, mask)"
+            )
             # Index the always-candidate flag so fetching unindexed files is a
             # seek, not a full scan of the (large) files table.
             conn.execute("CREATE INDEX idx_files_indexed ON files(indexed)")
@@ -202,31 +210,36 @@ class TrigramIndexManager:
             return []
 
     @staticmethod
-    def _file_trigrams(abs_path: Path) -> "tuple[Set[str], bool]":
-        """Return ``(trigrams, indexed)`` for a file.
+    def _file_trigrams(abs_path: Path) -> "tuple[dict[str, int], bool]":
+        """Return ``({trigram: bucket_mask}, indexed)`` for a file.
 
         ``indexed`` is False only for files that cannot be trigram-indexed here
         (too large, or unreadable); such files carry no postings and are treated
         as always-candidates at query time so matches are never missed. Files
-        with binary content are still indexed (latin-1) because ripgrep searches
-        their text too.
+        with binary content are still indexed because ripgrep searches their text
+        too -- but only their printable text runs are indexed, so a binary file
+        (e.g. a .class) is prunable without its dense raw-byte trigrams bloating
+        the index. Correct: a match's required literals are printable and lie on
+        one line, so their trigrams share a run and a bucket.
+
+        ``bucket_mask`` is a 64-bit value with a bit set for each line-bucket the
+        trigram occurs in (see ``_NUM_BUCKETS``).
         """
         try:
             if abs_path.stat().st_size > _MAX_INDEX_BYTES:
-                return set(), False  # large -> always-candidate (rg still scans)
+                return {}, False  # large -> always-candidate (rg still scans)
             data = abs_path.read_bytes()
         except OSError:
-            return set(), False  # unreadable -> always-candidate
-        # Extract trigrams from printable text runs only. This indexes a binary
-        # file (e.g. a .class) by its embedded text -- the content ripgrep can
-        # match -- so it becomes prunable, without the dense random-byte trigrams
-        # of its raw bytes bloating the index. Correct: a match's required
-        # literals are printable and contiguous, so they fall within one run and
-        # their trigrams are captured here.
-        tris: Set[str] = set()
-        for m in _PRINTABLE_RUN.finditer(data):
-            tris |= trigrams(m.group().decode("ascii").lower())
-        return tris, True
+            return {}, False  # unreadable -> always-candidate
+        lines = data.split(b"\n")
+        total = len(lines) or 1
+        masks: "dict[str, int]" = {}
+        for i, line in enumerate(lines):
+            bit = 1 << (i * _NUM_BUCKETS // total)
+            for m in _PRINTABLE_RUN.finditer(line):
+                for tg in trigrams(m.group().decode("ascii").lower()):
+                    masks[tg] = masks.get(tg, 0) | bit
+        return masks, True
 
     # ------------------------------------------------------------------
     # Query
@@ -242,9 +255,12 @@ class TrigramIndexManager:
         Requiring ALL trigrams is what makes the candidate set small; the
         intersection is computed rarest-first so it stays cheap: seed the
         candidate set from the rarest trigram's posting list, then for each
-        remaining trigram (in increasing document frequency) drop candidates that
-        lack it via an O(1) ``(trigram, file_id)`` index seek -- never scanning a
-        common trigram's full posting list.
+        remaining trigram (in increasing document frequency) AND its per-file
+        bucket mask into the running candidate mask via an O(1)
+        ``(trigram, file_id)`` index seek -- never scanning a common trigram's
+        full posting list. A candidate is dropped when the AND reaches zero,
+        i.e. the required trigrams never share a line-bucket, so no default
+        (line-oriented) ripgrep match is possible.
         """
         if not required:
             return None
@@ -270,21 +286,29 @@ class TrigramIndexManager:
                 if df_map[ordered[0]] == 0:
                     return always
 
-                # Rarest-first intersection in a connection-local temp table.
+                # Rarest-first bucket-mask intersection in a connection-local
+                # temp table. cand.mask is the running AND of the required
+                # trigrams' bucket masks for that file.
                 conn.execute("PRAGMA temp_store=FILE")
-                conn.execute("CREATE TEMP TABLE cand (id INTEGER PRIMARY KEY)")
+                conn.execute(
+                    "CREATE TEMP TABLE cand (id INTEGER PRIMARY KEY, mask INTEGER)"
+                )
                 try:
                     conn.execute(
-                        "INSERT INTO cand SELECT file_id FROM postings WHERE trigram = ?",
+                        "INSERT INTO cand SELECT file_id, mask FROM postings "
+                        "WHERE trigram = ?",
                         (ordered[0],),
                     )
                     for t in ordered[1:]:
+                        # AND this trigram's mask into each candidate; a file
+                        # lacking the trigram yields 0 (COALESCE) -> dropped next.
                         conn.execute(
-                            "DELETE FROM cand WHERE NOT EXISTS ("
-                            "  SELECT 1 FROM postings"
-                            "  WHERE trigram = ? AND file_id = cand.id)",
+                            "UPDATE cand SET mask = mask & COALESCE("
+                            "  (SELECT p.mask FROM postings p"
+                            "   WHERE p.trigram = ? AND p.file_id = cand.id), 0)",
                             (t,),
                         )
+                        conn.execute("DELETE FROM cand WHERE mask = 0")
                         if not conn.execute(
                             "SELECT EXISTS(SELECT 1 FROM cand)"
                         ).fetchone()[0]:

--- a/src/code_indexer/global_repos/trigram_index_manager.py
+++ b/src/code_indexer/global_repos/trigram_index_manager.py
@@ -18,6 +18,7 @@ import os
 import re
 import sqlite3
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Iterable, List, Optional, Set
 
@@ -105,9 +106,19 @@ class TrigramIndexManager:
         )
 
         self._dir.mkdir(parents=True, exist_ok=True)
-        tmp_path = self._db_path.with_suffix(".db.building")
-        if tmp_path.exists():
-            tmp_path.unlink()
+        # Build into a UNIQUE temp file (not a fixed ".db.building" name): in
+        # cluster mode this index dir lives on shared NFS under the golden repo,
+        # so a lazy rebuild on another pod -- or a scheduled refresh racing a
+        # lazy build -- can target it concurrently. A shared temp name let one
+        # build's unlink()/write corrupt the other and publish a
+        # partially-populated index that passes exists() and silently drops
+        # matches. With a unique temp per build, os.replace still atomically
+        # publishes the last writer and neither build damages the other's file.
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(self._dir), prefix="trigrams.", suffix=".db.building"
+        )
+        os.close(fd)
+        tmp_path = Path(tmp_name)
 
         conn = sqlite3.connect(str(tmp_path))
         try:
@@ -188,6 +199,16 @@ class TrigramIndexManager:
                 [("file_count", count), ("schema_version", _SCHEMA_VERSION)],
             )
             conn.commit()
+        except BaseException:
+            # A failed build must not leave its half-written temp behind. Each
+            # build's temp is unique, so this only ever removes our own file --
+            # never a concurrent build's in-progress database.
+            conn.close()
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+            raise
         finally:
             conn.close()
 

--- a/src/code_indexer/global_repos/trigram_index_manager.py
+++ b/src/code_indexer/global_repos/trigram_index_manager.py
@@ -153,6 +153,9 @@ class TrigramIndexManager:
             # intersection relies on -- so checking "does file X contain trigram
             # T" is O(1), not a scan of T's whole posting list.
             conn.execute("CREATE INDEX idx_postings_tc ON postings(trigram, file_id)")
+            # Index the always-candidate flag so fetching unindexed files is a
+            # seek, not a full scan of the (large) files table.
+            conn.execute("CREATE INDEX idx_files_indexed ON files(indexed)")
             conn.commit()
             # Document frequency per trigram + total file count, so the query can
             # order the required trigrams rarest-first.

--- a/src/code_indexer/global_repos/trigram_index_manager.py
+++ b/src/code_indexer/global_repos/trigram_index_manager.py
@@ -32,6 +32,12 @@ logger = logging.getLogger(__name__)
 _PRINTABLE_RUN = re.compile(rb"[\t\n\r\x20-\x7e]{3,}")
 
 _DB_NAME = "trigrams.db"
+# Bump whenever the on-disk index schema changes (a new table/column, different
+# posting semantics, ...). An index whose stamped version differs is treated as
+# absent by exists(), so a stale/old-format index (e.g. a golden-repo refresh
+# swapped the alias to a snapshot indexed by an older build) yields a clean
+# full-scan + rebuild instead of a caught "no such column" query error.
+_SCHEMA_VERSION = 1
 # Skip trigram extraction for files larger than this (still recorded as an
 # always-candidate so matches inside them are never missed). Keeps build I/O and
 # db size bounded; large files are rare and ripgrep handles them in the pass.
@@ -58,14 +64,26 @@ class TrigramIndexManager:
         return self._db_path
 
     def exists(self) -> bool:
-        """True when a populated index database is present."""
+        """True when a populated, CURRENT-schema index database is present.
+
+        An index whose stamped ``schema_version`` differs from this build's (or
+        that predates the ``meta`` stamp) is reported as absent, so the caller
+        full-scans and a rebuild regenerates it -- rather than the query failing
+        on a missing table/column and silently degrading forever.
+        """
         if not self._db_path.exists():
             return False
         try:
             with sqlite3.connect(f"file:{self._db_path}?mode=ro", uri=True) as conn:
-                row = conn.execute("SELECT COUNT(*) FROM files").fetchone()
-                return bool(row and row[0] > 0)
+                row = conn.execute(
+                    "SELECT value FROM meta WHERE key = 'schema_version'"
+                ).fetchone()
+                if not row or row[0] != _SCHEMA_VERSION:
+                    return False  # missing stamp or wrong version -> rebuild
+                populated = conn.execute("SELECT COUNT(*) FROM files").fetchone()
+                return bool(populated and populated[0] > 0)
         except sqlite3.Error:
+            # Missing tables / unreadable / pre-stamp format -> treat as absent.
             return False
 
     # ------------------------------------------------------------------
@@ -165,8 +183,9 @@ class TrigramIndexManager:
             )
             conn.execute("CREATE INDEX idx_trigram_df ON trigram_df(trigram)")
             conn.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value INTEGER)")
-            conn.execute(
-                "INSERT INTO meta (key, value) VALUES ('file_count', ?)", (count,)
+            conn.executemany(
+                "INSERT INTO meta (key, value) VALUES (?, ?)",
+                [("file_count", count), ("schema_version", _SCHEMA_VERSION)],
             )
             conn.commit()
         finally:

--- a/src/code_indexer/scip/query/composites.py
+++ b/src/code_indexer/scip/query/composites.py
@@ -15,7 +15,6 @@ from .primitives import QueryResult, SCIPQueryEngine
 from .backends import CallChain as BackendCallChain
 from ..database.queries import QueryTimeoutError
 
-
 logger = logging.getLogger(__name__)
 
 MAX_TRAVERSAL_DEPTH = 10
@@ -424,6 +423,22 @@ def analyze_impact(
 
     # Find target definition
     target_location = _find_target_definition(symbol, scip_dir)
+
+    # Early-out: a symbol with no definition anywhere in the index cannot have
+    # dependents, so skip the (expensive) BFS pass. Without this guard an
+    # unresolved symbol still triggers a full depth-N dependents traversal over
+    # every .scip.db under scip_dir -- tens of seconds for a guaranteed-empty
+    # result.
+    if target_location is None:
+        return ImpactAnalysisResult(
+            target_symbol=symbol,
+            target_location=None,
+            depth_analyzed=depth,
+            affected_symbols=[],
+            affected_files=[],
+            truncated=False,
+            total_affected=0,
+        )
 
     # BFS traversal to find affected symbols
     affected_symbols = _bfs_traverse_dependents(

--- a/src/code_indexer/server/logging_utils.py
+++ b/src/code_indexer/server/logging_utils.py
@@ -13,7 +13,26 @@ Usage:
     )
 """
 
+import re
 from typing import Any, Dict
+
+# Matches the userinfo (``user:pass@`` / ``oauth2:TOKEN@`` / ``TOKEN@``) between a
+# URL scheme separator and the host, so embedded credentials can be stripped
+# before a repo URL is serialized into an API response or log line.
+_URL_CREDENTIALS_RE = re.compile(r"(://)[^/@\s]+@")
+
+
+def mask_url_credentials(url: Any) -> Any:
+    """Strip embedded credentials from a git/HTTP URL for safe exposure.
+
+    ``https://oauth2:glpat-XXXX@gitlab.com/org/repo.git`` ->
+    ``https://***@gitlab.com/org/repo.git``. Non-string input, credential-free
+    URLs, and scheme-only forms (e.g. ``local://alias``) are returned unchanged.
+    Idempotent: masking an already-masked URL is a no-op.
+    """
+    if not isinstance(url, str):
+        return url
+    return _URL_CREDENTIALS_RE.sub(r"\1***@", url)
 
 
 # Sensitive field names that should be redacted in logs

--- a/src/code_indexer/server/multi/multi_search_service.py
+++ b/src/code_indexer/server/multi/multi_search_service.py
@@ -122,6 +122,26 @@ class MultiSearchService:
         self.thread_executor = ThreadPoolExecutor(max_workers=config.max_workers)
         self._shutdown = False
 
+        # Repo-shard ownership (cluster sharding). None/solo -> caching stays off
+        # for fan-out (Bug #881, unchanged). When sharding is active, an OWNED
+        # repo warms this pod's cache (bounded to its shard) instead of
+        # load-and-discard.
+        self._shard_ownership: Optional[Any] = None
+
+    def set_shard_ownership(self, shard_ownership: Any) -> None:
+        """Inject shard ownership so owned-repo fan-out searches warm the cache."""
+        self._shard_ownership = shard_ownership
+
+    def _owns_for_cache(self, repo_id: str) -> bool:
+        """True only when sharding is active AND this node owns ``repo_id``.
+
+        Returns False in solo mode (no ownership injected), preserving the
+        fan-out cache-bypass behavior (Bug #881) by default.
+        """
+        # getattr default keeps instances built via __new__ (some tests) safe.
+        shard_ownership = getattr(self, "_shard_ownership", None)
+        return shard_ownership is not None and shard_ownership.owns(repo_id)
+
     def search(self, request: MultiSearchRequest) -> MultiSearchResponse:
         """
         Execute search across multiple repositories.
@@ -404,7 +424,11 @@ class MultiSearchService:
             response = search_service.search_repository_path(
                 repo_path,
                 single_repo_request,
-                hnsw_cache=None,
+                # Bug #881: fan-out bypasses the cache by default; under cluster
+                # sharding an OWNED repo warms this pod's (shard-bounded) cache.
+                hnsw_cache=(
+                    self.hnsw_index_cache if self._owns_for_cache(repo_id) else None
+                ),
                 precomputed_query_vector=effective_precomputed,
             )
 

--- a/src/code_indexer/server/query/semantic_query_manager.py
+++ b/src/code_indexer/server/query/semantic_query_manager.py
@@ -214,6 +214,32 @@ class SemanticQueryManager:
         # Track concurrent queries per user (in production this would need persistence)
         self._active_queries_per_user: Dict[str, int] = {}
 
+        # Repo-shard ownership (cluster sharding). None = solo/symmetric: this pod
+        # caches every repo. Injected in cluster mode so a pod only populates its
+        # per-pod index cache for repos it owns; non-owned repos are still served,
+        # just load-and-discard (hnsw_cache=None).
+        self._shard_ownership: Optional[Any] = None
+
+    def set_shard_ownership(self, shard_ownership: Any) -> None:
+        """Inject repo-shard ownership (cluster mode only).
+
+        When set, single-repo searches only populate this pod's index cache for
+        repos this node owns; non-owned repos are served load-and-discard.
+        """
+        self._shard_ownership = shard_ownership
+
+    def _owns_for_cache(self, repository_alias: str) -> bool:
+        """Whether this node should use its shared index cache for ``alias``.
+
+        True (use the per-pod cache) when sharding is off (solo mode) or this node
+        owns the alias; False means bypass the cache (load-and-discard) so a
+        non-owned repo does not bloat this pod's cache. Fails open via
+        ShardOwnership.owns, so a query is never denied incorrectly.
+        """
+        # getattr default keeps instances built via __new__ (some tests) safe.
+        shard_ownership = getattr(self, "_shard_ownership", None)
+        return shard_ownership is None or shard_ownership.owns(repository_alias)
+
     def _is_composite_repository(self, repo_path: Path) -> bool:
         """
         Check if repository is in proxy mode (composite).
@@ -1424,8 +1450,8 @@ class SemanticQueryManager:
                     _degraded_in_query.append(_pname)
                     continue
                 _captured_kwargs = _kwargs
-                provider_tasks[_pname] = (
-                    lambda _kw=_captured_kwargs: self._search_with_provider(**_kw)
+                provider_tasks[_pname] = lambda _kw=_captured_kwargs: (
+                    self._search_with_provider(**_kw)
                 )
 
             primary_results: List[QueryResult] = []
@@ -2247,7 +2273,13 @@ class SemanticQueryManager:
             backend = BackendFactory.create(
                 config=config,
                 project_root=repo_path,
-                hnsw_cache=_server_hnsw_cache,
+                # Cluster sharding: only populate this pod's shared index cache for
+                # repos it owns; non-owned repos load-and-discard (fail-open).
+                hnsw_cache=(
+                    _server_hnsw_cache
+                    if self._owns_for_cache(repository_alias)
+                    else None
+                ),
                 memory_governor=get_memory_governor(),
             )
             vector_store = backend.get_vector_store_client()

--- a/src/code_indexer/server/repositories/activated_repo_manager.py
+++ b/src/code_indexer/server/repositories/activated_repo_manager.py
@@ -191,6 +191,37 @@ class ActivatedRepoManager:
             "ActivatedRepoManager: using shared storage at %s",
             self.activated_repos_dir,
         )
+        self._warn_if_activated_storage_not_shared(shared_dir)
+
+    def _warn_if_activated_storage_not_shared(self, shared_dir: str) -> None:
+        """Warn loudly when activated-repos is NOT on the same shared volume as
+        golden-repos in cluster mode.
+
+        Cluster mode runs multiple pods behind a load balancer. Activation writes
+        a per-user working tree to ``activated-repos``; if that directory is on a
+        pod-local filesystem (e.g. only ``golden-repos`` was mounted on the shared
+        RWX/NFS volume, leaving its ``activated-repos`` sibling on local disk),
+        then a repo activated on one pod is invisible to the others -- browse,
+        list-files, branch and file-content reads 404 on ~(N-1)/N of requests.
+        Detect the split by comparing the backing device of the two sibling
+        directories and surface it, since it otherwise manifests only as opaque,
+        intermittent 404s. Best-effort: any stat failure is ignored.
+        """
+        golden = Path(shared_dir) / "golden-repos"
+        try:
+            if not golden.exists():
+                return
+            if os.stat(self.activated_repos_dir).st_dev != os.stat(golden).st_dev:
+                self.logger.warning(
+                    "ActivatedRepoManager: activated-repos (%s) is on a different "
+                    "filesystem than golden-repos (%s). In a multi-pod cluster a "
+                    "repo activated on one pod will 404 on the others. Mount "
+                    "activated-repos on the same shared RWX volume as golden-repos.",
+                    self.activated_repos_dir,
+                    str(golden),
+                )
+        except OSError:
+            pass
 
     # ------------------------------------------------------------------
     # Dual-mode metadata helpers (Bug #587)

--- a/src/code_indexer/server/repositories/golden_repo_manager.py
+++ b/src/code_indexer/server/repositories/golden_repo_manager.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from code_indexer.server.services.group_access_manager import GroupAccessManager
 
 from pydantic import BaseModel
-from code_indexer.server.logging_utils import format_error_log
+from code_indexer.server.logging_utils import format_error_log, mask_url_credentials
 from code_indexer.server.git.git_subprocess_env import build_non_interactive_git_env
 from code_indexer.utils.subprocess_env import build_cidx_subprocess_env
 
@@ -100,10 +100,15 @@ class GoldenRepo(BaseModel):
     category_auto_assigned: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
-        """Convert golden repository to dictionary."""
+        """Convert golden repository to dictionary.
+
+        ``repo_url`` is credential-masked here because every consumer of this
+        method serializes the result into an API response; git/clone operations
+        read ``self.repo_url`` directly and are unaffected.
+        """
         return {
             "alias": self.alias,
-            "repo_url": self.repo_url,
+            "repo_url": mask_url_credentials(self.repo_url),
             "default_branch": self.default_branch,
             "clone_path": self.clone_path,
             "created_at": self.created_at,

--- a/src/code_indexer/server/routers/inline_query.py
+++ b/src/code_indexer/server/routers/inline_query.py
@@ -14,6 +14,7 @@ from fastapi import (
     HTTPException,
     status,
     Depends,
+    Request,
 )
 
 from ..models.query import (
@@ -66,6 +67,7 @@ def register_query_routes(
     @app.post("/api/query")
     def semantic_query(
         request: SemanticQueryRequest,
+        raw_request: Request,
         current_user: dependencies.User = Depends(dependencies.get_current_user),
     ):
         """
@@ -93,6 +95,43 @@ def register_query_routes(
             SearchEventRecord,
         )
         from code_indexer.server.services.config_service import get_config_service
+        from ..services.shard_router import FORWARD_HEADER
+
+        # Cluster sharding: if this is a concrete single-repo query for a repo this
+        # node does not own, forward it to an owner pod (which has it cached) and
+        # return that response. Loop-guarded via FORWARD_HEADER; wildcards (omni)
+        # and async job submissions stay local. Fails open: any routing problem
+        # (or no shard_router at all -> solo/symmetric) falls through to local.
+        shard_router = getattr(raw_request.app.state, "shard_router", None)
+        if (
+            shard_router is not None
+            and raw_request.headers.get(FORWARD_HEADER.lower()) != "1"
+        ):
+            alias = request.repository_alias
+            if (
+                isinstance(alias, str)
+                and alias
+                and "*" not in alias
+                and not getattr(request, "async_query", False)
+            ):
+                try:
+                    target = shard_router.target_for(alias)
+                    if target:
+                        from fastapi.responses import JSONResponse
+
+                        forwarded = shard_router.forward(
+                            target,
+                            request.model_dump(),
+                            raw_request.headers.get("authorization"),
+                        )
+                        return JSONResponse(content=forwarded)
+                except Exception as exc:
+                    logging.getLogger(__name__).warning(
+                        "shard forward failed for %r (%s); serving locally",
+                        alias,
+                        exc,
+                        extra={"correlation_id": get_correlation_id()},
+                    )
 
         start_time = time.time()
 

--- a/src/code_indexer/server/routers/inline_repos.py
+++ b/src/code_indexer/server/routers/inline_repos.py
@@ -40,6 +40,7 @@ from ..services.repository_discovery_service import (
     RepositoryDiscoveryError,
 )  # noqa: E402
 from ..validators.composite_repo_validator import CompositeRepoValidator  # noqa: E402
+from ..logging_utils import mask_url_credentials  # noqa: E402
 from ..repositories.golden_repo_manager import GitOperationError  # noqa: E402
 
 from fastapi import (
@@ -1202,7 +1203,9 @@ def register_repo_routes(
             repositories = [
                 RepositoryInfo(
                     alias=repo["alias"],
-                    repo_url=repo["repo_url"],
+                    # Never expose embedded clone credentials (e.g. an oauth2 PAT)
+                    # in the listing response.
+                    repo_url=mask_url_credentials(repo["repo_url"]),
                     default_branch=repo["default_branch"],
                     created_at=repo["created_at"],
                 )
@@ -1638,18 +1641,43 @@ def register_repo_routes(
     def list_repository_files(
         user_alias: str,
         path: Optional[str] = Query(None, description="Subdirectory path to list"),
+        recursive: bool = Query(
+            False,
+            description="Walk the full subtree in one response instead of one level",
+        ),
+        max_depth: Optional[int] = Query(
+            None,
+            ge=1,
+            description="When recursive, limit descent to this many levels below path",
+        ),
+        limit: int = Query(
+            10000,
+            ge=1,
+            le=100000,
+            description="When recursive, cap total entries returned (sets truncated)",
+        ),
         current_user: dependencies.User = Depends(dependencies.get_current_user),
     ):
         """
-        List files in an activated repository (non-recursive, root level by default).
+        List files in an activated repository.
+
+        By default lists a single directory level (root, or ``path``). With
+        ``recursive=true`` the whole subtree is returned in ONE response, which
+        avoids the thousands of sequential per-directory calls a client would
+        otherwise need to build a tree (a 12k-directory repo took ~59s that way).
 
         Args:
             user_alias: User's alias for the repository
             path: Optional relative subdirectory to scope the listing
+            recursive: Return the full subtree in one response
+            max_depth: When recursive, max levels to descend (None = unlimited)
+            limit: When recursive, max entries before truncating
             current_user: Current authenticated user
 
         Returns:
             JSON dict with ``files`` list; each item has name, path, type, size.
+            When ``recursive`` is set, also returns ``truncated`` (bool) and
+            ``count`` (int).
 
         Raises:
             HTTPException 400: path escapes repo root (traversal) or is not a directory
@@ -1690,19 +1718,68 @@ def register_repo_routes(
             )
 
         try:
+            if not recursive:
+                entries = []
+                with os.scandir(scan_root) as it:
+                    for entry in it:
+                        rel = Path(entry.path).relative_to(repo_resolved)
+                        entries.append(
+                            {
+                                "name": entry.name,
+                                "path": str(rel),
+                                "type": "dir" if entry.is_dir() else "file",
+                                "size": entry.stat().st_size if entry.is_file() else 0,
+                            }
+                        )
+                return {"files": entries}
+
+            # Recursive: walk the subtree once, depth-bounded and count-capped.
             entries = []
-            with os.scandir(scan_root) as it:
-                for entry in it:
-                    rel = Path(entry.path).relative_to(repo_resolved)
+            truncated = False
+            base_depth = len(scan_root.parts)
+            # topdown so we can prune directories in-place at max_depth and stop
+            # descending once the entry cap is hit; followlinks=False avoids
+            # cycles and escaping the repo via symlinks.
+            for dirpath, dirnames, filenames in os.walk(scan_root, followlinks=False):
+                current = Path(dirpath)
+                # depth of this directory relative to scan_root (root == 0); its
+                # children sit at depth+1. Skip emitting a directory's children
+                # once they would exceed max_depth, and prune descent so os.walk
+                # does not visit levels we would only discard.
+                depth = len(current.parts) - base_depth
+                if max_depth is not None and depth >= max_depth:
+                    dirnames[:] = []
+                    continue
+                for name in sorted(dirnames):  # sorted -> deterministic output
+                    if len(entries) >= limit:
+                        truncated = True
+                        break
+                    rel = (current / name).relative_to(repo_resolved)
                     entries.append(
-                        {
-                            "name": entry.name,
-                            "path": str(rel),
-                            "type": "dir" if entry.is_dir() else "file",
-                            "size": entry.stat().st_size if entry.is_file() else 0,
-                        }
+                        {"name": name, "path": str(rel), "type": "dir", "size": 0}
                     )
-            return {"files": entries}
+                if truncated:
+                    break
+                for name in sorted(filenames):
+                    if len(entries) >= limit:
+                        truncated = True
+                        break
+                    fp = current / name
+                    try:
+                        size = fp.stat().st_size
+                    except OSError:
+                        size = 0
+                    rel = fp.relative_to(repo_resolved)
+                    entries.append(
+                        {"name": name, "path": str(rel), "type": "file", "size": size}
+                    )
+                if truncated:
+                    break
+                # We have listed this directory's immediate children; if they are
+                # at the depth ceiling, do not descend into them.
+                if max_depth is not None and depth + 1 >= max_depth:
+                    dirnames[:] = []
+            return {"files": entries, "count": len(entries), "truncated": truncated}
 
         except OSError as e:
             logger.error(

--- a/src/code_indexer/server/services/node_heartbeat_service.py
+++ b/src/code_indexer/server/services/node_heartbeat_service.py
@@ -174,6 +174,27 @@ class NodeHeartbeatService:
                 rows = cur.fetchall()
         return [row[0] for row in rows]
 
+    def get_node_addresses(self) -> "dict[str, str]":
+        """Return ``{node_id: 'host:port'}`` for currently-online nodes.
+
+        Used by the shard router to reach the pod that owns a repo. Explicit
+        tuple_row cursor so positional access is correct regardless of a borrowed
+        connection's row_factory.
+        """
+        with self._pool.connection() as conn:
+            with conn.cursor(row_factory=tuple_row) as cur:
+                cur.execute(
+                    """
+                    SELECT node_id, hostname, port
+                    FROM   cluster_nodes
+                    WHERE  status = 'online'
+                      AND  last_heartbeat >= NOW() - %s * INTERVAL '1 second'
+                    """,
+                    (self._active_threshold_seconds,),
+                )
+                rows = cur.fetchall()
+        return {str(r[0]): f"{r[1]}:{r[2] or 8090}" for r in rows if r[1]}
+
     def set_leader_election(self, leader_election: Any) -> None:
         """Set leader election service reference for role updates."""
         self._leader_election = leader_election
@@ -215,19 +236,27 @@ class NodeHeartbeatService:
         """Insert or update this node's row with the given status."""
         import os
 
-        hostname = os.uname().nodename
+        # Peers address this node at hostname:port for shard routing. Prefer the
+        # routable pod IP (downward API POD_IP); fall back to the node name. Port
+        # is the server port (CIDX_PORT), default 8090.
+        hostname = os.environ.get("POD_IP") or os.uname().nodename
+        try:
+            port = int(os.environ.get("CIDX_PORT", "8090"))
+        except ValueError:
+            port = 8090
         with self._pool.connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    INSERT INTO cluster_nodes (node_id, hostname, status, last_heartbeat)
-                    VALUES (%s, %s, %s, NOW())
+                    INSERT INTO cluster_nodes (node_id, hostname, port, status, last_heartbeat)
+                    VALUES (%s, %s, %s, %s, NOW())
                     ON CONFLICT (node_id) DO UPDATE
                         SET status         = EXCLUDED.status,
                             hostname       = EXCLUDED.hostname,
+                            port           = EXCLUDED.port,
                             last_heartbeat = NOW()
                     """,
-                    (self._node_id, hostname, status),
+                    (self._node_id, hostname, port, status),
                 )
             conn.commit()
 

--- a/src/code_indexer/server/services/scip_query_service.py
+++ b/src/code_indexer/server/services/scip_query_service.py
@@ -177,6 +177,22 @@ class SCIPQueryService:
 
         return scip_files
 
+    @staticmethod
+    def _scip_dir_for_files(scip_files: List[Path]) -> Path:
+        """Return the ``.code-indexer/scip`` directory containing ``scip_files``.
+
+        For an alias-scoped query every file lives under a single
+        ``<root>/.code-indexer/scip`` directory (see :meth:`find_scip_files`).
+        Return that directory so a recursive ``**/*.scip.db`` glob crosses only
+        this repo's indexes. Falls back to the first file's parent if the
+        expected layout is not found.
+        """
+        first = scip_files[0]
+        for parent in first.parents:
+            if parent.name == "scip" and parent.parent.name == ".code-indexer":
+                return parent
+        return first.parent
+
     def _resolve_alias_scip_root(self, repo_name: str) -> Optional[Path]:
         """Resolve a repo's alias ``target_path`` to its SCIP-bearing root.
 
@@ -446,19 +462,41 @@ class SCIPQueryService:
             symbol: Symbol name to analyze
             depth: Maximum traversal depth (default 3). Clamped by underlying
                    function to MAX_TRAVERSAL_DEPTH (10).
-            repository_alias: Reserved for future filtering support
-            username: Reserved for future filtering support
+            repository_alias: Repository to scope the analysis to. When given,
+                   only that repo's SCIP indexes are traversed (mirrors the
+                   other SCIP endpoints); when None, all golden repos are.
+            username: Username for access-control filtering.
 
         Returns:
             Dictionary with impact analysis results
         """
         from code_indexer.scip.query.composites import analyze_impact
 
-        # Get the scip directory from golden_repos_dir
-        scip_dir = self.get_golden_repos_dir()
+        # Scope to the requested repo's SCIP indexes and early-out when there is
+        # no index for it. Without this, impact analysis ignored the alias and
+        # scanned EVERY golden repo's .scip.db twice with a depth-N CTE -- tens
+        # of seconds even for a repo with no SCIP index at all. find_scip_files
+        # also enforces access control for the caller.
+        scip_files = self.find_scip_files(
+            repository_alias=repository_alias, username=username
+        )
+        if not scip_files:
+            return {
+                "target_symbol": symbol,
+                "depth_analyzed": min(depth, 10),
+                "total_affected": 0,
+                "truncated": False,
+                "affected_symbols": [],
+                "affected_files": [],
+            }
 
-        # Note: repository_alias and username reserved for future filtering
-        _ = repository_alias, username
+        # Point the composite at the project's own ".code-indexer/scip" dir so
+        # its recursive glob crosses only this repo's indexes. When no alias was
+        # requested, fall back to the full golden-repos dir (cross-repo scan).
+        if repository_alias is not None:
+            scip_dir = self._scip_dir_for_files(scip_files)
+        else:
+            scip_dir = self.get_golden_repos_dir()
 
         result = analyze_impact(symbol, scip_dir, depth=depth)
 

--- a/src/code_indexer/server/services/shard_ownership.py
+++ b/src/code_indexer/server/services/shard_ownership.py
@@ -1,0 +1,135 @@
+"""Repo-shard ownership via rendezvous (HRW) hashing over live cluster nodes.
+
+Phase 0 of repo sharding (C6). In cluster mode every pod otherwise loads every
+repo's index into its own cache, so per-pod memory grows with the *total* repo
+count and adding replicas does not help. This module lets each pod decide which
+repos it "owns": only owned repos populate the per-pod index cache, while
+non-owned repos are still served (load-and-discard), bounding each pod's cache
+footprint to its shard.
+
+Ownership is **stateless and deterministic**: every node computes the same
+top-``replicas`` owners for an alias from the same live-node set (rendezvous /
+highest-random-weight hashing), so no assignment table or cross-node
+coordination is required. Membership changes reshuffle only the minimal set of
+aliases (the property HRW is chosen for).
+
+Design notes:
+- The shard key is the **repo alias** (stable across refreshes), never the
+  on-disk index path (which rotates every golden-repo refresh).
+- ``owns()`` fails **open**: on any error, an empty node set, or a single-node
+  cluster it returns True, degrading to today's cache-everything behaviour --
+  never worse, never a dropped result.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+import time
+from typing import Callable, List
+
+
+def _hrw_score(alias: str, node_id: str) -> int:
+    """Deterministic rendezvous weight for (alias, node_id). Higher wins."""
+    digest = hashlib.blake2b(
+        f"{alias}\x00{node_id}".encode("utf-8"), digest_size=8
+    ).digest()
+    return int.from_bytes(digest, "big")
+
+
+def compute_owners(alias: str, node_ids: List[str], replicas: int) -> List[str]:
+    """Return the top-``replicas`` node_ids for ``alias`` by HRW score.
+
+    Deterministic given the same inputs. ``node_id`` is used as a tie-breaker so
+    the ordering is stable across nodes. ``replicas`` is clamped to
+    ``[1, len(node_ids)]``.
+    """
+    if not node_ids:
+        return []
+    want = max(1, min(replicas, len(node_ids)))
+    ranked = sorted(node_ids, key=lambda n: (_hrw_score(alias, n), n), reverse=True)
+    return ranked[:want]
+
+
+class ShardOwnership:
+    """Decides whether THIS node owns (should cache) a given repo alias.
+
+    Args:
+        node_id: This node's cluster id (``cluster.node_id``).
+        active_nodes_provider: Callable returning the current live node_ids
+            (e.g. ``NodeHeartbeatService.get_active_nodes``). Called at most once
+            per ``refresh_seconds`` and cached, so it is cheap to call per query.
+        replicas: Replication factor -- how many nodes own each alias.
+        refresh_seconds: How long to cache the active-node list.
+        time_fn: Monotonic clock (injectable for tests).
+    """
+
+    def __init__(
+        self,
+        node_id: str,
+        active_nodes_provider: Callable[[], List[str]],
+        replicas: int = 2,
+        refresh_seconds: float = 5.0,
+        time_fn: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._node_id = node_id
+        self._provider = active_nodes_provider
+        self._replicas = max(1, replicas)
+        self._refresh_seconds = refresh_seconds
+        self._time = time_fn
+        self._lock = threading.Lock()
+        self._cached_nodes: List[str] = []
+        self._cached_at: float = 0.0
+
+    def _get_nodes(self) -> List[str]:
+        now = self._time()
+        with self._lock:
+            fresh = self._cached_nodes and (
+                now - self._cached_at < self._refresh_seconds
+            )
+            if fresh:
+                return self._cached_nodes
+        # Refresh outside the lock; tolerate provider failures (fail open).
+        try:
+            nodes = list(self._provider() or [])
+        except Exception:
+            nodes = []
+        # Ensure this node is considered part of the ring even if the heartbeat
+        # row is briefly missing -- otherwise a node could disown everything.
+        if self._node_id and self._node_id not in nodes:
+            nodes.append(self._node_id)
+        with self._lock:
+            self._cached_nodes = nodes
+            self._cached_at = now
+        return nodes
+
+    def owns(self, alias: str) -> bool:
+        """True if this node should cache ``alias``.
+
+        Fails open (returns True) for empty aliases, single-node clusters, or any
+        error, so a query is never denied caching incorrectly.
+        """
+        if not alias:
+            return True
+        nodes = self._get_nodes()
+        if len(nodes) <= 1:
+            return True
+        return self._node_id in compute_owners(alias, nodes, self._replicas)
+
+    def owners_of(self, alias: str) -> List[str]:
+        """Return the owner node_ids for ``alias`` over the current live set.
+
+        Empty for an empty alias or empty node set. Used by the router to pick a
+        peer to forward a non-owned query to.
+        """
+        if not alias:
+            return []
+        return compute_owners(alias, self._get_nodes(), self._replicas)
+
+    def snapshot(self) -> "dict[str, object]":
+        """Observability view: this node's id, replicas, and live node set."""
+        return {
+            "node_id": self._node_id,
+            "replicas": self._replicas,
+            "active_nodes": self._get_nodes(),
+        }

--- a/src/code_indexer/server/services/shard_prewarm_service.py
+++ b/src/code_indexer/server/services/shard_prewarm_service.py
@@ -1,0 +1,114 @@
+"""Rebalance pre-warming for repo sharding (C6).
+
+When cluster membership changes, HRW ownership reshuffles a minimal set of repos
+to new owners. Those newly-owned repos are cold in the new owner's cache, so the
+first query pays a cold load. This service proactively warms (loads into the
+per-pod index cache) the repos this node owns, so the first post-rebalance query
+is already hot.
+
+Design:
+- A daemon loop re-evaluates ownership every ``interval_seconds``. Because
+  ShardOwnership.owns() reflects the live node set, a membership change simply
+  changes which repos this node owns -> newly-owned repos get warmed, and repos
+  it no longer owns are dropped from the warmed set (so they are re-warmed if
+  ownership swings back; the cache evicts them via TTL).
+- The warm operation is injected (``warm_fn``) and every call is best-effort:
+  a failed warm is logged and retried next cycle, never raised. So a warm
+  problem only means a repo stays cold until its first query -- today's
+  behaviour -- and never destabilises the pod.
+- No-op unless there is a shard ownership (cluster mode).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Callable, List, Optional, Set
+
+from code_indexer.server.services.shard_ownership import ShardOwnership
+
+logger = logging.getLogger(__name__)
+
+
+class ShardPrewarmService:
+    """Warms the index cache for repos this node owns (C6 rebalance prewarm).
+
+    Args:
+        shard_ownership: ShardOwnership; None disables the service (solo mode).
+        repos_provider: Returns the current set of shardable repo aliases.
+        warm_fn: Warms one repo (loads its index into the per-pod cache). Called
+            best-effort; exceptions are caught.
+        interval_seconds: How often to re-evaluate ownership and warm.
+    """
+
+    def __init__(
+        self,
+        shard_ownership: Optional[ShardOwnership],
+        repos_provider: Callable[[], List[str]],
+        warm_fn: Callable[[str], None],
+        interval_seconds: float = 30.0,
+    ) -> None:
+        self._ownership = shard_ownership
+        self._repos_provider = repos_provider
+        self._warm_fn = warm_fn
+        self._interval = interval_seconds
+        self._warmed: Set[str] = set()
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def run_once(self) -> None:
+        """One evaluation: warm newly-owned repos, forget no-longer-owned ones.
+
+        Never raises -- individual warm failures are logged and retried next
+        cycle.
+        """
+        ownership = self._ownership
+        if ownership is None:
+            return
+        try:
+            all_repos = list(self._repos_provider() or [])
+        except Exception:
+            logger.warning("C6 prewarm: could not list repos", exc_info=True)
+            return
+        owned = {alias for alias in all_repos if ownership.owns(alias)}
+        # Forget repos this node no longer owns (or that were deleted) so they are
+        # re-warmed if ownership swings back; the cache evicts them via TTL.
+        self._warmed &= owned
+        for alias in owned - self._warmed:
+            try:
+                self._warm_fn(alias)
+                self._warmed.add(alias)
+            except Exception:
+                logger.warning(
+                    "C6 prewarm: failed to warm %r; will retry", alias, exc_info=True
+                )
+
+    def start(self) -> None:
+        """Start the background warm loop (no-op in solo mode or if running)."""
+        if self._ownership is None:
+            return
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._loop, name="cidx-shard-prewarm", daemon=True
+        )
+        self._thread.start()
+        logger.info("C6 prewarm: started (interval=%ss)", self._interval)
+
+    def stop(self) -> None:
+        """Signal the loop to stop and join briefly."""
+        self._stop.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=self._interval + 5)
+        self._thread = None
+
+    def _loop(self) -> None:
+        # Wait one interval before the first pass. Server startup wires the
+        # http_client_factory that the warm search uses, and it runs *after* this
+        # service is started, so an immediate first pass would fail. Warming is
+        # proactive, so a short initial delay is fine. wait() returns True when
+        # stopped, so the loop also exits promptly on shutdown.
+        while not self._stop.wait(self._interval):
+            self.run_once()

--- a/src/code_indexer/server/services/shard_router.py
+++ b/src/code_indexer/server/services/shard_router.py
@@ -1,0 +1,148 @@
+"""Internal shard router (C6 Phase 1, "B2 internal proxy").
+
+kube-proxy load-balances /api/query to a random pod. When a single-repo query
+lands on a pod that does not own the repo, that pod forwards the request to an
+*owner* pod (which has the repo's index cached) over the pod network and returns
+the owner's response. This eliminates the cold-load thrash that Phase 0 only
+bounded the memory of.
+
+Design:
+- Only single-repo queries are routed (Phase 1). Omni/multi/wildcard stay
+  single-pod for now (Phase 2 scatter-gather).
+- The forwarded request carries the caller's Authorization header (the owner
+  re-validates it, so tenancy/identity is preserved) and a loop-guard header so
+  the owner serves locally instead of forwarding again.
+- Everything **fails open**: no shard ownership (solo), we own the alias, no
+  reachable owner, or any error -> serve locally (today's behaviour). A routing
+  problem degrades to a cold local load, never a failed query.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Loop-guard header: set on a forwarded request so the receiving owner serves it
+# locally rather than forwarding again.
+FORWARD_HEADER = "X-CIDX-Shard-Forwarded"
+
+
+class ShardRouter:
+    """Decide whether a single-repo query should be forwarded, and forward it.
+
+    Args:
+        node_id: This node's cluster id.
+        shard_ownership: ShardOwnership instance, or None in solo mode.
+        node_addresses_provider: Callable returning ``{node_id: "host:port"}`` for
+            reachable peers (from cluster_nodes).
+        http_client_factory: HttpClientFactory used for the pod-to-pod POST (all
+            outbound HTTP goes through it, per the fault-injection contract).
+        timeout_seconds: Per-forward timeout.
+    """
+
+    def __init__(
+        self,
+        node_id: str,
+        shard_ownership: Any,
+        node_addresses_provider: Callable[[], Dict[str, str]],
+        http_client_factory: Any,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        self._node_id = node_id
+        self._shard_ownership = shard_ownership
+        self._addresses = node_addresses_provider
+        self._http = http_client_factory
+        self._timeout = timeout_seconds
+        # Coarse observability counters (metric-grade; small races acceptable).
+        self._forwards = 0
+        self._forward_failures = 0
+
+    def target_for(self, alias: str) -> Optional[str]:
+        """Return an owner peer ``"host:port"`` to forward ``alias`` to, or None
+        to serve locally (we own it, solo mode, or no reachable owner)."""
+        shard_ownership = self._shard_ownership
+        if shard_ownership is None:
+            return None  # solo / sharding off
+        if shard_ownership.owns(alias):
+            return None  # this node owns it -> serve locally
+        owners = shard_ownership.owners_of(alias)
+        if not owners:
+            return None  # unknown ownership -> serve locally (fail open)
+        try:
+            addresses = self._addresses() or {}
+        except Exception:
+            logger.warning("C6: node address lookup failed; serving %s locally", alias)
+            return None
+        for owner in owners:
+            if owner == self._node_id:
+                continue
+            addr = addresses.get(owner)
+            if addr:
+                return addr
+        return None  # no reachable non-self owner -> serve locally
+
+    def group_by_owner(
+        self, aliases: "list[str]"
+    ) -> "tuple[list[str], dict[str, list[str]]]":
+        """Partition ``aliases`` for a multi-repo query (C6 Phase 2).
+
+        Returns ``(local, {peer_address: [aliases]})`` where ``local`` are the
+        aliases this node should search itself -- ones it owns, or for which no
+        reachable owner exists (fail open) -- and each remaining group is the set
+        of aliases to forward to a single owning peer.
+        """
+        local: "list[str]" = []
+        groups: "dict[str, list[str]]" = {}
+        for alias in aliases:
+            address = self.target_for(alias)
+            if address is None:
+                local.append(alias)
+            else:
+                groups.setdefault(address, []).append(alias)
+        return local, groups
+
+    def forward(
+        self,
+        address: str,
+        body: Dict[str, Any],
+        auth_header: Optional[str],
+        path: str = "/api/query",
+    ) -> Dict[str, Any]:
+        """POST ``body`` to a peer's ``path`` and return its JSON response.
+
+        Raises on transport/HTTP error so the caller can fall back to local
+        handling. Sets the loop-guard header so the peer serves locally instead
+        of forwarding/scattering again.
+        """
+        headers: Dict[str, str] = {FORWARD_HEADER: "1"}
+        if auth_header:
+            headers["Authorization"] = auth_header
+        self._forwards += 1
+        try:
+            with self._http.create_sync_client(timeout=self._timeout) as client:
+                resp = client.post(
+                    f"http://{address}{path}", json=body, headers=headers
+                )
+                resp.raise_for_status()
+                result: Dict[str, Any] = resp.json()
+                return result
+        except Exception:
+            self._forward_failures += 1
+            raise
+
+    def stats(self) -> Dict[str, Any]:
+        """Observability snapshot: node identity, live ring, addresses, counters."""
+        info: Dict[str, Any] = {
+            "node_id": self._node_id,
+            "forwards": self._forwards,
+            "forward_failures": self._forward_failures,
+        }
+        if self._shard_ownership is not None:
+            info.update(self._shard_ownership.snapshot())
+        try:
+            info["node_addresses"] = self._addresses()
+        except Exception:
+            info["node_addresses"] = {}
+        return info

--- a/src/code_indexer/server/startup/lifespan.py
+++ b/src/code_indexer/server/startup/lifespan.py
@@ -2718,6 +2718,7 @@ def make_lifespan(
                 _pg_dsn = ""
                 _configured_node_id = ""
                 _sharding_enabled = False
+                _shard_replicas = 1
                 try:
                     import json as _json
 
@@ -2726,13 +2727,13 @@ def make_lifespan(
                         with open(_cfg_path) as _f:
                             _cfg_data = _json.load(_f)
                             _pg_dsn = _cfg_data.get("postgres_dsn", "")
-                            _configured_node_id = _cfg_data.get("cluster", {}).get(
-                                "node_id", ""
-                            )
+                            _cluster_cfg = _cfg_data.get("cluster", {})
+                            _configured_node_id = _cluster_cfg.get("node_id", "")
                             _sharding_enabled = bool(
-                                _cfg_data.get("cluster", {}).get(
-                                    "sharding_enabled", False
-                                )
+                                _cluster_cfg.get("sharding_enabled", False)
+                            )
+                            _shard_replicas = max(
+                                1, int(_cluster_cfg.get("shard_replicas", 1))
                             )
                 except Exception:
                     pass
@@ -2796,7 +2797,7 @@ def make_lifespan(
                             _shard_ownership = ShardOwnership(
                                 node_id=_node_id,
                                 active_nodes_provider=_heartbeat.get_active_nodes,
-                                replicas=2,
+                                replicas=_shard_replicas,
                             )
                             _sqm = getattr(app.state, "semantic_query_manager", None)
                             if _sqm is not None:
@@ -2840,8 +2841,10 @@ def make_lifespan(
                                 http_client_factory=_http_factory,
                             )
                             logging.getLogger(__name__).info(
-                                "C6: shard ownership + router wired (node_id=%s, replicas=2)",
+                                "C6: shard ownership + router wired "
+                                "(node_id=%s, replicas=%d)",
                                 _node_id,
+                                _shard_replicas,
                             )
 
                             # C6 rebalance pre-warming: proactively load this pod's

--- a/src/code_indexer/server/startup/lifespan.py
+++ b/src/code_indexer/server/startup/lifespan.py
@@ -2717,6 +2717,7 @@ def make_lifespan(
             try:
                 _pg_dsn = ""
                 _configured_node_id = ""
+                _sharding_enabled = False
                 try:
                     import json as _json
 
@@ -2727,6 +2728,11 @@ def make_lifespan(
                             _pg_dsn = _cfg_data.get("postgres_dsn", "")
                             _configured_node_id = _cfg_data.get("cluster", {}).get(
                                 "node_id", ""
+                            )
+                            _sharding_enabled = bool(
+                                _cfg_data.get("cluster", {}).get(
+                                    "sharding_enabled", False
+                                )
                             )
                 except Exception:
                     pass
@@ -2777,6 +2783,148 @@ def make_lifespan(
                     _heartbeat.set_leader_election(_leader_election)
                     _heartbeat.start()
                     _cluster_services.append(("heartbeat", _heartbeat))
+
+                    if _sharding_enabled:
+                        try:
+                            from code_indexer.server.services.shard_ownership import (
+                                ShardOwnership,
+                            )
+                            from code_indexer.server.services.shard_router import (
+                                ShardRouter,
+                            )
+
+                            _shard_ownership = ShardOwnership(
+                                node_id=_node_id,
+                                active_nodes_provider=_heartbeat.get_active_nodes,
+                                replicas=2,
+                            )
+                            _sqm = getattr(app.state, "semantic_query_manager", None)
+                            if _sqm is not None:
+                                _sqm.set_shard_ownership(_shard_ownership)
+                            # Expose ownership on app.state so the multi-repo endpoint
+                            # can warm the multi-search service's cache for owned repos
+                            # (C6 Phase 3).
+                            app.state.shard_ownership = _shard_ownership
+                            # Also inject into the shared multi-search singleton at
+                            # startup so the MCP omni path (which does not go through
+                            # the REST endpoint) caches owned repos too.
+                            try:
+                                from code_indexer.server.routes.multi_query_routes import (
+                                    get_multi_search_service,
+                                )
+
+                                get_multi_search_service().set_shard_ownership(
+                                    _shard_ownership
+                                )
+                            except Exception:
+                                logging.getLogger(__name__).warning(
+                                    "C6: could not inject shard ownership into the "
+                                    "multi-search singleton at startup"
+                                )
+                            # http_client_factory is set later in startup
+                            # (_apply_fault_injection_state), after this cluster block,
+                            # so app.state may not have it yet -- construct a dedicated
+                            # one for internal pod-to-pod routing (fault injection is
+                            # not relevant to internal forwards).
+                            from code_indexer.server.fault_injection.http_client_factory import (
+                                HttpClientFactory,
+                            )
+
+                            _http_factory = getattr(
+                                app.state, "http_client_factory", None
+                            ) or HttpClientFactory(fault_injection_service=None)
+                            app.state.shard_router = ShardRouter(
+                                node_id=_node_id,
+                                shard_ownership=_shard_ownership,
+                                node_addresses_provider=_heartbeat.get_node_addresses,
+                                http_client_factory=_http_factory,
+                            )
+                            logging.getLogger(__name__).info(
+                                "C6: shard ownership + router wired (node_id=%s, replicas=2)",
+                                _node_id,
+                            )
+
+                            # C6 rebalance pre-warming: proactively load this pod's
+                            # owned repos into the cache so the first query after a
+                            # membership change is not a cold load. Best-effort and
+                            # fully fail-safe (a warm failure just leaves the repo cold
+                            # until its first query -- today's behaviour).
+                            try:
+                                from code_indexer.server.services.shard_prewarm_service import (
+                                    ShardPrewarmService,
+                                )
+                                from code_indexer.server.services.search_service import (
+                                    SemanticSearchService,
+                                )
+                                from code_indexer.server.models.api_models import (
+                                    SemanticSearchRequest,
+                                )
+
+                                def _list_shardable_repos() -> list:
+                                    # The shardable set is the GOLDEN repos (the shared,
+                                    # indexed repos queries fan out over) -- resolved
+                                    # lazily from app.state so startup ordering does not
+                                    # matter.
+                                    grm = getattr(
+                                        app.state, "golden_repo_manager", None
+                                    )
+                                    if grm is None:
+                                        return []
+                                    try:
+                                        return [
+                                            str(
+                                                r.get("alias")
+                                                or r.get("alias_name")
+                                                or ""
+                                            )
+                                            for r in grm.list_golden_repos()
+                                        ]
+                                    except Exception:
+                                        return []
+
+                                def _warm_repo(alias: str) -> None:
+                                    grm = getattr(
+                                        app.state, "golden_repo_manager", None
+                                    )
+                                    if grm is None or not alias:
+                                        return
+                                    repo_path = grm.get_actual_repo_path(alias)
+                                    if not repo_path:
+                                        return
+                                    # A minimal search loads the repo's HNSW index into
+                                    # this pod's cache (Phase 0 caches it since owned).
+                                    SemanticSearchService().search_repository_path(
+                                        str(repo_path),
+                                        SemanticSearchRequest(query="warm", limit=1),
+                                    )
+
+                                _prewarm = ShardPrewarmService(
+                                    _shard_ownership,
+                                    _list_shardable_repos,
+                                    _warm_repo,
+                                )
+                                _prewarm.start()
+                                _cluster_services.append(("shard_prewarm", _prewarm))
+                            except Exception:
+                                logging.getLogger(__name__).warning(
+                                    "C6: could not start shard prewarm service"
+                                )
+                        except Exception:
+                            logging.getLogger(__name__).exception(
+                                "C6: failed to wire sharding; falling back to "
+                                "symmetric caching + local serving"
+                            )
+                    else:
+                        # Replication mode (default): no HRW ownership gate and
+                        # no query forwarding, so every pod caches and serves all
+                        # repos locally -> N replicas scale read concurrency. Enable
+                        # cluster.sharding_enabled only when the working set exceeds
+                        # one pod's cache. Fail-open helpers already treat a missing
+                        # shard_ownership/shard_router as 'own everything, serve local'.
+                        logging.getLogger(__name__).info(
+                            "C6: sharding disabled (cluster.sharding_enabled=false); "
+                            "replication mode -- every pod caches and serves all repos"
+                        )
 
                     # Job reconciliation
                     from code_indexer.server.services.job_reconciliation_service import (

--- a/src/code_indexer/server/startup/lifespan.py
+++ b/src/code_indexer/server/startup/lifespan.py
@@ -2722,7 +2722,19 @@ def make_lifespan(
                 try:
                     import json as _json
 
-                    _cfg_path = Path.home() / ".cidx-server" / "config.json"
+                    # Honor CIDX_SERVER_DATA_DIR for the config location (mirrors
+                    # the data-dir resolution above); a deployment that sets the
+                    # data dir elsewhere keeps config.json there, so hardcoding
+                    # ~/.cidx-server would silently skip cluster services.
+                    _cfg_path = (
+                        Path(
+                            os.environ.get(
+                                "CIDX_SERVER_DATA_DIR",
+                                str(Path.home() / ".cidx-server"),
+                            )
+                        )
+                        / "config.json"
+                    )
                     if _cfg_path.exists():
                         with open(_cfg_path) as _f:
                             _cfg_data = _json.load(_f)
@@ -3474,7 +3486,15 @@ def make_lifespan(
             try:
                 import json as _nm_json
 
-                _nm_cfg_path = Path.home() / ".cidx-server" / "config.json"
+                _nm_cfg_path = (
+                    Path(
+                        os.environ.get(
+                            "CIDX_SERVER_DATA_DIR",
+                            str(Path.home() / ".cidx-server"),
+                        )
+                    )
+                    / "config.json"
+                )
                 if _nm_cfg_path.exists():
                     with open(_nm_cfg_path) as _nm_f:
                         _nm_cfg = _nm_json.load(_nm_f)

--- a/src/code_indexer/server/utils/config_manager.py
+++ b/src/code_indexer/server/utils/config_manager.py
@@ -1036,6 +1036,13 @@ class ClusterConfig:
     """Cluster node configuration (Epic #408)."""
 
     node_id: str = ""
+    # Repo sharding (opt-in). When False (default) the cluster runs symmetric:
+    # every pod may cache every repo, and replicas scale read concurrency. When
+    # True, repos are sharded across pods via HRW ownership so each pod's index
+    # cache holds only its shard -- bounding per-pod memory when the total working
+    # set exceeds one pod's cache. Enable only when memory (not concurrency) is
+    # the limit.
+    sharding_enabled: bool = False
 
 
 @dataclass

--- a/src/code_indexer/server/utils/config_manager.py
+++ b/src/code_indexer/server/utils/config_manager.py
@@ -1043,6 +1043,12 @@ class ClusterConfig:
     # set exceeds one pod's cache. Enable only when memory (not concurrency) is
     # the limit.
     sharding_enabled: bool = False
+    # How many nodes own (cache + serve) each repo under HRW sharding. MUST be
+    # < number of nodes for sharding to do anything: with shard_replicas >= node
+    # count every node owns every repo (no memory bounding, no forwarding).
+    # Default 1 = each repo on exactly one node (maximum bounding, no redundancy);
+    # raise to 2 for owner redundancy on clusters with 3+ nodes.
+    shard_replicas: int = 1
 
 
 @dataclass

--- a/src/code_indexer/server/web/routes.py
+++ b/src/code_indexer/server/web/routes.py
@@ -521,6 +521,7 @@ def dashboard(request: Request):
     # asynchronously via /admin/partials/dashboard-health endpoint
 
     return templates.TemplateResponse(
+        request,
         "dashboard.html",
         {
             "request": request,
@@ -644,6 +645,7 @@ def dashboard_health_partial(request: Request):
         logger.debug("Failed to compute dependency latency rows", exc_info=True)
 
     return templates.TemplateResponse(
+        request,
         "partials/dashboard_health.html",
         {
             "request": request,
@@ -708,6 +710,7 @@ def dashboard_stats_partial(
     )
 
     return templates.TemplateResponse(
+        request,
         "partials/dashboard_stats.html",
         {
             "request": request,
@@ -754,6 +757,7 @@ def dashboard_job_counts_partial(
     )
 
     return templates.TemplateResponse(
+        request,
         "partials/dashboard_job_counts.html",
         {
             "request": request,
@@ -794,6 +798,7 @@ def dashboard_recent_jobs_partial(
     )
 
     return templates.TemplateResponse(
+        request,
         "partials/dashboard_recent_jobs.html",
         {
             "request": request,
@@ -869,6 +874,7 @@ def dashboard_api_metrics_partial(
             logger.debug("Could not read per-node api_metrics: %s", _exc)
 
     return templates.TemplateResponse(
+        request,
         "partials/dashboard_api_metrics.html",
         {
             "request": request,
@@ -1028,6 +1034,7 @@ def dashboard_cache_metrics_partial(request: Request, cache_window: int = 86400)
             )
 
     return templates.TemplateResponse(
+        request,
         "partials/dashboard_cache_metrics.html",
         {
             "request": request,
@@ -1059,6 +1066,7 @@ def dashboard_langfuse_partial(request: Request):
     langfuse_data = dashboard_service.get_langfuse_metrics()
 
     return templates.TemplateResponse(
+        request,
         "partials/dashboard_langfuse.html",
         {
             "request": request,
@@ -1155,6 +1163,7 @@ def dashboard_api_per_user_partial(
     )
 
     return templates.TemplateResponse(
+        request,
         "partials/dashboard_api_per_user.html",
         {
             "request": request,
@@ -1202,6 +1211,7 @@ def dashboard_api_chart_partial(
     )
 
     return templates.TemplateResponse(
+        request,
         "partials/dashboard_api_chart.html",
         {
             "request": request,
@@ -1345,6 +1355,7 @@ def _create_users_page_response(
     csrf_token = generate_csrf_token()
 
     response = templates.TemplateResponse(
+        request,
         "users.html",
         {
             "request": request,
@@ -1751,6 +1762,7 @@ def users_list_partial(request: Request):
     users = _get_users_list()
 
     response = templates.TemplateResponse(
+        request,
         "partials/users_list.html",
         {
             "request": request,
@@ -1975,6 +1987,7 @@ def _create_groups_page_response(
             repo["category_priority"] = UNASSIGNED_CATEGORY_PRIORITY
 
     response = templates.TemplateResponse(
+        request,
         "groups.html",
         {
             "request": request,
@@ -2234,6 +2247,7 @@ def groups_list_partial(request: Request):
     groups_data = _get_groups_data()
 
     response = templates.TemplateResponse(
+        request,
         "partials/groups_list.html",
         {"request": request, "csrf_token": csrf_token, "groups": groups_data},
     )
@@ -2286,6 +2300,7 @@ def groups_users_list_partial(request: Request):
     ]
 
     response = templates.TemplateResponse(
+        request,
         "partials/groups_users_list.html",
         {
             "request": request,
@@ -2325,6 +2340,7 @@ def groups_audit_logs_partial(
         )
 
     return templates.TemplateResponse(
+        request,
         "partials/groups_audit_logs.html",
         {"request": request, "audit_logs": audit_logs, "total_count": total_count},
     )
@@ -2390,6 +2406,7 @@ def groups_repo_access_partial(request: Request):
             repo["category_priority"] = UNASSIGNED_CATEGORY_PRIORITY
 
     response = templates.TemplateResponse(
+        request,
         "partials/groups_repo_access.html",
         {
             "request": request,
@@ -3103,6 +3120,7 @@ def _create_golden_repos_page_response(
         categories = []
 
     response = templates.TemplateResponse(
+        request,
         "golden_repos.html",
         {
             "request": request,
@@ -3422,6 +3440,7 @@ def toggle_wiki_enabled(
         return _create_login_redirect(request)
     if not validate_login_csrf_token(request, csrf_token):
         return templates.TemplateResponse(
+            request,
             "partials/error_message.html",
             {"request": request, "error": "Invalid CSRF token"},
             status_code=400,
@@ -3492,6 +3511,7 @@ def save_temporal_options(
         return _create_login_redirect(request)
     if not validate_login_csrf_token(request, csrf_token):
         return templates.TemplateResponse(
+            request,
             "partials/error_message.html",
             {"request": request, "error": "Invalid CSRF token"},
             status_code=400,
@@ -3507,6 +3527,7 @@ def save_temporal_options(
             options["max_commits"] = mc
         except ValueError:
             return templates.TemplateResponse(
+                request,
                 "partials/error_message.html",
                 {"request": request, "error": "max_commits must be a positive integer"},
                 status_code=400,
@@ -3520,6 +3541,7 @@ def save_temporal_options(
             options["diff_context"] = dc
         except ValueError:
             return templates.TemplateResponse(
+                request,
                 "partials/error_message.html",
                 {"request": request, "error": "diff_context must be an integer 0-50"},
                 status_code=400,
@@ -3533,6 +3555,7 @@ def save_temporal_options(
             datetime.strptime(since_date_val, "%Y-%m-%d")
         except ValueError:
             return templates.TemplateResponse(
+                request,
                 "partials/error_message.html",
                 {
                     "request": request,
@@ -3568,6 +3591,7 @@ def refresh_wiki_cache(
         return _create_login_redirect(request)
     if not validate_login_csrf_token(request, csrf_token):
         return templates.TemplateResponse(
+            request,
             "partials/error_message.html",
             {"request": request, "error": "Invalid CSRF token"},
             status_code=400,
@@ -3772,6 +3796,7 @@ def golden_repo_details(
         csrf_token = get_csrf_token_from_cookie(request) or generate_csrf_token()
 
         response = templates.TemplateResponse(
+            request,
             "partials/golden_repos_list.html",
             {
                 "request": request,
@@ -3831,6 +3856,7 @@ def golden_repos_list_partial(request: Request):
         categories = []
 
     response = templates.TemplateResponse(
+        request,
         "partials/golden_repos_list.html",
         {
             "request": request,
@@ -3860,6 +3886,7 @@ def _render_details_error(
     error, allowing htmx to swap the message into the details cell.
     """
     return templates.TemplateResponse(
+        request,
         "partials/details_error.html",
         {
             "request": request,
@@ -3961,6 +3988,7 @@ def golden_repo_details_partial(request: Request, alias: str):
         csrf_token = get_csrf_token_from_cookie(request)
         categories = _get_repo_category_service().list_categories()
         return templates.TemplateResponse(
+            request,
             "partials/golden_repo_details.html",
             {
                 "request": request,
@@ -4241,6 +4269,7 @@ def _create_repos_page_response(
     deactivating_map = _build_deactivating_map()
 
     response = templates.TemplateResponse(
+        request,
         "repos.html",
         {
             "request": request,
@@ -4328,6 +4357,7 @@ def repos_list_partial(
     paginated_repos, total_pages, current_page = _paginate_repos(filtered_repos, page)
 
     response = templates.TemplateResponse(
+        request,
         "partials/repos_list.html",
         {
             "request": request,
@@ -4378,6 +4408,7 @@ def repo_details(
         csrf_token = get_csrf_token_from_cookie(request) or generate_csrf_token()
 
         response = templates.TemplateResponse(
+            request,
             "partials/repos_list.html",
             {
                 "request": request,
@@ -4760,6 +4791,7 @@ def _create_jobs_page_response(
     )
 
     response = templates.TemplateResponse(
+        request,
         "jobs.html",
         {
             "request": request,
@@ -4835,6 +4867,7 @@ def jobs_list_partial(
     )
 
     response = templates.TemplateResponse(
+        request,
         "partials/jobs_list.html",
         {
             "request": request,
@@ -5030,6 +5063,7 @@ def _create_query_page_response(
     query_history = _get_session_query_history(session.username)
 
     response = templates.TemplateResponse(
+        request,
         "query.html",
         {
             "request": request,
@@ -5565,6 +5599,7 @@ def query_results_partial(request: Request):
     csrf_token = generate_csrf_token()
 
     response = templates.TemplateResponse(
+        request,
         "partials/query_results.html",
         {
             "request": request,
@@ -5809,6 +5844,7 @@ def query_results_partial_post(
     # Validate required fields
     if not query_text or not query_text.strip():
         return templates.TemplateResponse(
+            request,
             "partials/query_results.html",
             {
                 "request": request,
@@ -5821,6 +5857,7 @@ def query_results_partial_post(
 
     if not repository:
         return templates.TemplateResponse(
+            request,
             "partials/query_results.html",
             {
                 "request": request,
@@ -5997,6 +6034,7 @@ def query_results_partial_post(
 
     csrf_token_new = generate_csrf_token()
     response = templates.TemplateResponse(
+        request,
         "partials/query_results.html",
         {
             "request": request,
@@ -7558,6 +7596,7 @@ def _create_config_page_response(
         logger.warning("Failed to fetch golden repos for config dropdown: %s", e)
 
     response = templates.TemplateResponse(
+        request,
         "config.html",
         {
             "request": request,
@@ -7639,6 +7678,7 @@ def _build_gitlab_repos_response(
     csrf_token = get_csrf_token_from_cookie(request) or generate_csrf_token()
 
     response = templates.TemplateResponse(
+        request,
         "partials/gitlab_repos.html",
         {
             "request": request,
@@ -7681,6 +7721,7 @@ def _build_github_repos_response(
     csrf_token = get_csrf_token_from_cookie(request) or generate_csrf_token()
 
     response = templates.TemplateResponse(
+        request,
         "partials/github_repos.html",
         {
             "request": request,
@@ -7713,6 +7754,7 @@ def auto_discovery_page(request: Request):
 
     csrf_token = get_csrf_token_from_cookie(request) or generate_csrf_token()
     response = templates.TemplateResponse(
+        request,
         "auto_discovery.html",
         {
             "request": request,
@@ -7734,6 +7776,7 @@ def analytics_export_page(request: Request):
 
     csrf_token = get_csrf_token_from_cookie(request) or generate_csrf_token()
     response = templates.TemplateResponse(
+        request,
         "analytics_export.html",
         {
             "request": request,
@@ -8767,6 +8810,7 @@ def clear_query_embedding_cache_table(
     config["query_embedding_cache"]["total_cached_entries"] = new_count
     csrf_token_new = generate_csrf_token()
     return templates.TemplateResponse(
+        request,
         "partials/qec_display.html",
         {
             "request": request,
@@ -9012,6 +9056,7 @@ def config_section_partial(
     gitlab_token_data = token_manager.get_token("gitlab")
 
     response = templates.TemplateResponse(
+        request,
         "partials/config_section.html",
         {
             "request": request,
@@ -10237,6 +10282,7 @@ def logs_page(
 
     # Render template
     response = templates.TemplateResponse(
+        request,
         "logs.html",
         {
             "request": request,
@@ -10336,6 +10382,7 @@ def logs_list_partial(
 
     # Render partial template
     response = templates.TemplateResponse(
+        request,
         "partials/logs_list.html",
         {
             "request": request,
@@ -10487,6 +10534,7 @@ def unified_login_page(
 
     # Create response with CSRF token in signed cookie
     response = templates.TemplateResponse(
+        request,
         "unified_login.html",
         {
             "request": request,
@@ -10576,6 +10624,7 @@ def unified_login_submit(
             sso_enabled = oidc_routes.oidc_manager.is_enabled()
 
         error_response = templates.TemplateResponse(
+            request,
             "unified_login.html",
             {
                 "request": request,
@@ -10916,14 +10965,12 @@ def _get_last_scan_time(
         conn = DatabaseConnectionManager.get_instance(str(db_path)).get_connection()
         cursor = conn.cursor()
         cursor.row_factory = sqlite3.Row
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT started_at
             FROM self_monitoring_scans
             ORDER BY started_at DESC
             LIMIT 1
-            """
-        )
+            """)
         row = cursor.fetchone()
         return row["started_at"] if row else None
     except Exception as e:
@@ -11004,13 +11051,11 @@ def _get_scan_status(
     try:
         conn = DatabaseConnectionManager.get_instance(str(db_path)).get_connection()
         cursor = conn.cursor()
-        cursor.execute(
-            """
+        cursor.execute("""
             SELECT COUNT(*)
             FROM self_monitoring_scans
             WHERE completed_at IS NULL
-            """
-        )
+            """)
         count = cursor.fetchone()[0]
         return "Running..." if count > 0 else "Idle"
     except Exception as e:
@@ -11069,6 +11114,7 @@ def _create_self_monitoring_page_response(
 
     csrf_token = generate_csrf_token()
     response = templates.TemplateResponse(
+        request,
         "self_monitoring.html",
         {
             "request": request,

--- a/tests/unit/global_repos/test_regex_search_lazy_build.py
+++ b/tests/unit/global_repos/test_regex_search_lazy_build.py
@@ -1,0 +1,122 @@
+"""Tests for the lazy trigram-index background rebuild (EVO-64221).
+
+When a regex search finds no compatible index, a one-shot background build is
+kicked off so the index self-heals before the next scheduled golden-repo refresh.
+Guarded by an in-progress flag, a cooldown, and an env toggle.
+"""
+
+import threading
+import time
+
+import pytest
+
+import code_indexer.global_repos.regex_search as rs
+
+
+@pytest.fixture(autouse=True)
+def _reset_lazy_state(monkeypatch):
+    monkeypatch.delenv("CIDX_TRIGRAM_LAZY_BUILD", raising=False)
+    with rs._lazy_build_lock:
+        rs._lazy_build_in_progress.clear()
+        rs._lazy_build_last_attempt.clear()
+    yield
+    with rs._lazy_build_lock:
+        rs._lazy_build_in_progress.clear()
+        rs._lazy_build_last_attempt.clear()
+
+
+def _patch_build(monkeypatch, record, event=None):
+    def fake_build(self, repo_path, file_list=None):
+        record.append(repo_path)
+        if event is not None:
+            event.set()
+        return 0
+
+    monkeypatch.setattr(
+        "code_indexer.global_repos.trigram_index_manager.TrigramIndexManager.build",
+        fake_build,
+    )
+
+
+def test_triggers_background_build(tmp_path, monkeypatch):
+    calls = []
+    done = threading.Event()
+    _patch_build(monkeypatch, calls, done)
+    rs._maybe_trigger_lazy_index_build(tmp_path)
+    assert done.wait(5), "background build was not started"
+    assert calls == [tmp_path]
+
+
+def test_skipped_within_cooldown(tmp_path, monkeypatch):
+    calls = []
+    _patch_build(monkeypatch, calls)
+    rs._lazy_build_last_attempt[str(tmp_path)] = time.monotonic()  # recent attempt
+    rs._maybe_trigger_lazy_index_build(tmp_path)
+    time.sleep(0.2)
+    assert calls == []  # backed off
+
+
+def test_skipped_when_in_progress(tmp_path, monkeypatch):
+    calls = []
+    _patch_build(monkeypatch, calls)
+    rs._lazy_build_in_progress.add(str(tmp_path))  # a build is "running"
+    rs._maybe_trigger_lazy_index_build(tmp_path)
+    time.sleep(0.2)
+    assert calls == []
+
+
+def test_disabled_by_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("CIDX_TRIGRAM_LAZY_BUILD", "0")
+    calls = []
+    _patch_build(monkeypatch, calls)
+    rs._maybe_trigger_lazy_index_build(tmp_path)
+    time.sleep(0.2)
+    assert calls == []
+
+
+def test_build_failure_is_swallowed_and_clears_in_progress(tmp_path, monkeypatch):
+    done = threading.Event()
+
+    def boom(self, repo_path, file_list=None):
+        try:
+            raise RuntimeError("build blew up")
+        finally:
+            done.set()
+
+    monkeypatch.setattr(
+        "code_indexer.global_repos.trigram_index_manager.TrigramIndexManager.build",
+        boom,
+    )
+    rs._maybe_trigger_lazy_index_build(tmp_path)
+    assert done.wait(5)
+    # give the finally-block a moment to run after build raises
+    for _ in range(50):
+        with rs._lazy_build_lock:
+            if str(tmp_path) not in rs._lazy_build_in_progress:
+                break
+        time.sleep(0.02)
+    with rs._lazy_build_lock:
+        assert str(tmp_path) not in rs._lazy_build_in_progress  # cleared on failure
+
+
+def test_single_build_under_concurrent_triggers(tmp_path, monkeypatch):
+    calls = []
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_build(self, repo_path, file_list=None):
+        calls.append(repo_path)
+        started.set()
+        release.wait(5)  # hold the "build" so a second trigger overlaps it
+        return 0
+
+    monkeypatch.setattr(
+        "code_indexer.global_repos.trigram_index_manager.TrigramIndexManager.build",
+        slow_build,
+    )
+    rs._maybe_trigger_lazy_index_build(tmp_path)
+    assert started.wait(5)
+    rs._maybe_trigger_lazy_index_build(tmp_path)  # while first still running
+    release.set()
+    time.sleep(0.2)
+    assert calls == [tmp_path]  # exactly one build despite two triggers

--- a/tests/unit/global_repos/test_regex_search_multiline.py
+++ b/tests/unit/global_repos/test_regex_search_multiline.py
@@ -55,9 +55,11 @@ def _make_capture_ripgrep():
         timeout_seconds,
         multiline=False,
         pcre2=False,
+        candidate_files=None,
     ):
         captured["multiline"] = multiline
         captured["pcre2"] = pcre2
+        captured["candidate_files"] = candidate_files
         return [], 0
 
     return captured, mock_ripgrep

--- a/tests/unit/global_repos/test_regex_search_trigram_prefilter.py
+++ b/tests/unit/global_repos/test_regex_search_trigram_prefilter.py
@@ -1,0 +1,106 @@
+"""Integration tests: trigram pre-filter must not change regex search results.
+
+The pre-filter is an optimization; for every pattern the results with the
+trigram index present must be IDENTICAL to a full working-tree scan. These tests
+build a repo, capture the full-scan baseline, then assert the indexed run
+matches it exactly (same files + lines).
+"""
+
+import shutil
+
+import pytest
+
+from code_indexer.global_repos.regex_search import RegexSearchService
+from code_indexer.global_repos.trigram_index_manager import TrigramIndexManager
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("rg") is None, reason="ripgrep required for regex search"
+)
+
+
+def _build_repo(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "src" / "auth").mkdir(parents=True)
+    (repo / "src" / "auth" / "LSAuthenticator.java").write_text(
+        "package auth;\npublic class LSAuthenticator {\n  void login() {}\n}\n"
+    )
+    (repo / "src" / "auth" / "TokenAuthenticator.java").write_text(
+        "public class TokenAuthenticator extends Base {}\n"
+    )
+    (repo / "src" / "Widget.java").write_text(
+        "public class Widget { int authenticateCount; }\n"
+    )
+    (repo / "README.md").write_text("This project has authentication and widgets.\n")
+    (repo / "notes.txt").write_text("nothing to see, just prose about cats\n")
+    return repo
+
+
+def _index(repo):
+    mgr = TrigramIndexManager(repo / ".code-indexer" / "trigram_index")
+    mgr.build(repo)
+    return mgr
+
+
+def _key(result):
+    return sorted((m.file_path, m.line_number) for m in result.matches)
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "Authenticator",  # literal, index-eligible
+        r"class\s+\w*Authenticator",  # regex with required literals
+        r"authenticate\w*",  # partial-token literal (token index would miss)
+        "public class Widget",  # spaced literal
+        "TokenAuthenticator|LSAuthenticator",  # alternation -> pre-filter bails
+        "zzzznotpresentanywhere",  # no matches
+        r"a.c",  # too short -> pre-filter bails, still correct
+    ],
+)
+async def test_prefilter_matches_full_scan(tmp_path, pattern):
+    repo = _build_repo(tmp_path)
+    svc = RegexSearchService(repo)
+
+    # baseline: no trigram index -> full scan
+    assert not (repo / ".code-indexer" / "trigram_index").exists()
+    baseline = await svc.search(pattern, max_results=1000)
+
+    # with trigram index -> pre-filtered scan
+    _index(repo)
+    svc2 = RegexSearchService(repo)
+    indexed = await svc2.search(pattern, max_results=1000)
+
+    assert _key(indexed) == _key(baseline), (
+        f"pre-filter changed results for {pattern!r}: "
+        f"baseline={_key(baseline)} indexed={_key(indexed)}"
+    )
+
+
+async def test_prefilter_used_when_index_present(tmp_path):
+    """Sanity: a selective literal returns the expected files via the index."""
+    repo = _build_repo(tmp_path)
+    _index(repo)
+    svc = RegexSearchService(repo)
+    result = await svc.search("Authenticator", max_results=1000)
+    files = {m.file_path for m in result.matches}
+    assert files == {
+        "src/auth/LSAuthenticator.java",
+        "src/auth/TokenAuthenticator.java",
+    }
+
+
+async def test_binary_file_with_match_not_missed(tmp_path):
+    """A match inside an un-indexed (binary) file must still be found."""
+    repo = tmp_path / "repo"
+    (repo).mkdir()
+    # embed a text-y match inside a file with a NUL byte (treated as binary at
+    # index time -> always-candidate). ripgrep with -a would search it; default
+    # rg treats it as binary. Use a file that is text but has a high-byte to
+    # exercise the latin-1 path instead, guaranteeing a real match.
+    (repo / "weird.txt").write_bytes(
+        "class OddAuthenticator\n".encode("latin-1") + b"\xff\n"
+    )
+    _index(repo)
+    svc = RegexSearchService(repo)
+    result = await svc.search("OddAuthenticator", max_results=1000)
+    assert {m.file_path for m in result.matches} == {"weird.txt"}

--- a/tests/unit/global_repos/test_regex_search_trigram_prefilter.py
+++ b/tests/unit/global_repos/test_regex_search_trigram_prefilter.py
@@ -96,6 +96,20 @@ async def test_prefilter_used_when_index_present(tmp_path):
     }
 
 
+async def test_non_ascii_match_not_dropped_by_prefilter(tmp_path):
+    """Regression: a pattern with a non-ASCII literal must still find the file
+    that genuinely contains it. The ASCII-only index formerly over-pruned because
+    a required trigram spanning the non-ASCII char had zero document frequency."""
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src" / "menu.py").write_text("label = 'café table'\n")
+    (repo / "src" / "other.py").write_text("label = 'plain table'\n")
+    _index(repo)
+    svc = RegexSearchService(repo)
+    result = await svc.search("café table", max_results=1000)
+    assert {m.file_path for m in result.matches} == {"src/menu.py"}
+
+
 async def test_binary_file_with_match_not_missed(tmp_path):
     """A match inside an un-indexed (binary) file must still be found."""
     repo = tmp_path / "repo"

--- a/tests/unit/global_repos/test_regex_search_trigram_prefilter.py
+++ b/tests/unit/global_repos/test_regex_search_trigram_prefilter.py
@@ -18,6 +18,13 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_lazy_build(monkeypatch):
+    # These tests build the index explicitly; disable the background lazy rebuild
+    # so it does not race the explicit build on the same repo.
+    monkeypatch.setenv("CIDX_TRIGRAM_LAZY_BUILD", "0")
+
+
 def _build_repo(tmp_path):
     repo = tmp_path / "repo"
     (repo / "src" / "auth").mkdir(parents=True)

--- a/tests/unit/global_repos/test_regex_trigram.py
+++ b/tests/unit/global_repos/test_regex_trigram.py
@@ -86,6 +86,31 @@ class TestExtractRequiredTrigrams:
         )
         assert extract_required_trigrams("FOOBAR") == trigrams("foobar")
 
+    def test_non_ascii_literal_uses_only_ascii_subruns(self):
+        # "café" (accented e): the index stores printable-ASCII trigrams only, so
+        # a trigram spanning the non-ASCII char ("afé") would have zero document
+        # frequency and wrongly prune every indexed file. Only the ASCII sub-run
+        # "caf" is a valid required trigram.
+        assert extract_required_trigrams("café") == {"caf"}
+
+    def test_non_ascii_splits_run_into_subruns(self):
+        # "naïve string" -> ASCII sub-runs "na" (too short) and "ve string".
+        assert extract_required_trigrams("naïve string") == trigrams("ve string")
+
+    def test_non_ascii_leaving_no_long_ascii_run_returns_none(self):
+        # "aébc" -> ASCII sub-runs "a","bc": none >= 3 -> no safe constraint.
+        assert extract_required_trigrams("aébc") is None
+
+    def test_required_trigrams_are_always_index_storable_ascii(self):
+        # Whatever the pattern, every required trigram must be printable ASCII so
+        # it can actually exist in the (ASCII-only) index.
+        for pat in ["naïve string", "résumévalue", "café table"]:
+            req = extract_required_trigrams(pat)
+            if req is None:
+                continue
+            for t in req:
+                assert all(0x20 <= ord(c) <= 0x7E for c in t), (pat, t)
+
 
 # ---------------------------------------------------------------------------
 # Correctness property: for a pattern that yields trigrams, EVERY string that
@@ -107,6 +132,9 @@ _PROPERTY_CASES = [
     ("abcd?efg", ["abcefg", "abcdefg"]),
     (r"\d{3}xyzzy", ["123xyzzy", "  999xyzzy!"]),
     (r"get\w+Value", ["getFooValue", "getValue"[:0] + "getBarValue"]),
+    # non-ASCII literal: only the ASCII sub-run constrains, and it must remain a
+    # necessary condition for every match.
+    ("café table", ["a café table here", "café table"]),
 ]
 
 

--- a/tests/unit/global_repos/test_regex_trigram.py
+++ b/tests/unit/global_repos/test_regex_trigram.py
@@ -1,0 +1,125 @@
+"""Tests for regex -> required-trigram analysis (index-assisted regex).
+
+The overriding requirement is CORRECTNESS: the derived trigram set must be a
+*necessary* condition for a match, so a candidate filter built from it can never
+exclude a real match. The property test at the bottom enforces exactly that.
+"""
+
+import re
+
+import pytest
+
+from code_indexer.global_repos.regex_trigram import (
+    extract_required_trigrams,
+    trigrams,
+)
+
+
+class TestTrigrams:
+    def test_basic(self):
+        assert trigrams("abcd") == {"abc", "bcd"}
+
+    def test_too_short(self):
+        assert trigrams("ab") == set()
+        assert trigrams("") == set()
+
+
+class TestExtractRequiredTrigrams:
+    def test_simple_literal(self):
+        assert extract_required_trigrams("Authenticator") == trigrams("authenticator")
+
+    def test_two_required_literals_are_anded(self):
+        got = extract_required_trigrams(r"class\s+\w*Authenticator")
+        assert got == trigrams("class") | trigrams("authenticator")
+
+    def test_star_atom_is_not_required(self):
+        # \w* contributes nothing; only the fixed literals do
+        assert extract_required_trigrams(r"\w*Authenticator") == trigrams(
+            "authenticator"
+        )
+
+    def test_optional_last_char_trimmed(self):
+        # colou?r -> "colo" is guaranteed ("u" optional), "r" alone too short
+        assert extract_required_trigrams("colou?r") == trigrams("colo")
+
+    def test_plus_quantified_char_not_in_run(self):
+        # ab+c -> a, (b+), c : no fixed run of length >= 3 -> None
+        assert extract_required_trigrams("ab+c") is None
+
+    def test_counted_quantifier_breaks_run(self):
+        assert extract_required_trigrams("abc{2}defgh") == trigrams("defgh")
+
+    def test_char_class_breaks_run(self):
+        # "foo" and "barbaz" are both required (the class is between them)
+        assert extract_required_trigrams(r"foo[0-9]+barbaz") == (
+            trigrams("foo") | trigrams("barbaz")
+        )
+
+    def test_escaped_metachar_is_literal(self):
+        # \. is a literal dot -> "abc.def" contiguous
+        assert extract_required_trigrams(r"abc\.def") == trigrams("abc.def")
+
+    def test_escaped_class_breaks_run(self):
+        # \d is a class, not a literal
+        assert extract_required_trigrams(r"ab\dcd") is None  # no run >= 3
+
+    def test_dot_and_anchors_break_runs(self):
+        assert extract_required_trigrams(r"^foobar.baz$") == (
+            trigrams("foobar") | trigrams("baz")
+        )
+
+    def test_alternation_bails(self):
+        assert extract_required_trigrams("foobar|bazqux") is None
+
+    def test_group_bails(self):
+        assert extract_required_trigrams("(foobar)+baz") is None
+
+    def test_short_pattern_none(self):
+        assert extract_required_trigrams("ab") is None
+        assert extract_required_trigrams(r"a.b") is None
+        assert extract_required_trigrams("") is None
+
+    def test_case_insensitive_lowercased(self):
+        # trigrams always lowercased regardless of flag
+        assert extract_required_trigrams("FOOBAR", case_insensitive=True) == trigrams(
+            "foobar"
+        )
+        assert extract_required_trigrams("FOOBAR") == trigrams("foobar")
+
+
+# ---------------------------------------------------------------------------
+# Correctness property: for a pattern that yields trigrams, EVERY string that
+# matches the pattern must contain ALL of those trigrams (lowercased). If this
+# ever fails, the pre-filter could drop a real match.
+# ---------------------------------------------------------------------------
+
+_PROPERTY_CASES = [
+    # (pattern, [strings that match it])
+    (r"class\s+\w*Authenticator", ["class LSAuthenticator", "class  XyzAuthenticator"]),
+    ("Authenticator", ["myAuthenticator", "AuthenticatorImpl"]),
+    ("colou?r", ["color", "colour", "the color red", "a colour here"]),
+    (r"foo[0-9]+barbaz", ["foo1barbaz", "foo12345barbaz here"]),
+    (r"abc\.def", ["xabc.defy", "abc.def"]),
+    ("abc{2}defgh", ["abccdefgh", "zabccdefghq"]),
+    (r"^foobar.baz$", ["foobarxbaz", "foobar baz"]),
+    # adversarial optionality: a naive "longest literal run" would false-negate
+    ("a?bcdef", ["bcdef", "abcdef", "xxabcdefyy"]),
+    ("abcd?efg", ["abcefg", "abcdefg"]),
+    (r"\d{3}xyzzy", ["123xyzzy", "  999xyzzy!"]),
+    (r"get\w+Value", ["getFooValue", "getValue"[:0] + "getBarValue"]),
+]
+
+
+@pytest.mark.parametrize("pattern,samples", _PROPERTY_CASES)
+def test_required_trigrams_are_necessary(pattern, samples):
+    req = extract_required_trigrams(pattern)
+    if req is None:
+        pytest.skip("no trigram constraint derived for this pattern")
+    for s in samples:
+        assert re.search(pattern, s), f"bad sample: {s!r} does not match {pattern!r}"
+        have = trigrams(s.lower())
+        missing = req - have
+        assert not missing, (
+            f"NECESSARY-CONDITION VIOLATION: matching string {s!r} is missing "
+            f"required trigrams {missing} for pattern {pattern!r}"
+        )

--- a/tests/unit/global_repos/test_trigram_index_manager.py
+++ b/tests/unit/global_repos/test_trigram_index_manager.py
@@ -92,6 +92,45 @@ class TestBuildQuery:
     def test_exists_false_without_build(self, tmp_path):
         assert _mgr(tmp_path).exists() is False
 
+
+class TestSchemaVersionGuard:
+    """An index whose on-disk schema does not match this build must be reported
+    as absent so the caller full-scans and a rebuild regenerates it -- instead of
+    the query failing on a missing table/column."""
+
+    def _built(self, tmp_path):
+        repo = _repo(tmp_path)
+        mgr = _mgr(tmp_path)
+        mgr.build(repo, file_list=["auth.java"])
+        return mgr
+
+    def test_current_index_exists(self, tmp_path):
+        assert self._built(tmp_path).exists() is True
+
+    def test_wrong_schema_version_is_absent(self, tmp_path):
+        import sqlite3
+
+        mgr = self._built(tmp_path)
+        with sqlite3.connect(mgr.db_path) as conn:
+            conn.execute("UPDATE meta SET value = 999999 WHERE key = 'schema_version'")
+        assert mgr.exists() is False  # version mismatch -> rebuild
+
+    def test_missing_schema_stamp_is_absent(self, tmp_path):
+        import sqlite3
+
+        mgr = self._built(tmp_path)
+        with sqlite3.connect(mgr.db_path) as conn:
+            conn.execute("DELETE FROM meta WHERE key = 'schema_version'")
+        assert mgr.exists() is False  # pre-stamp/old format -> rebuild
+
+    def test_missing_table_is_absent(self, tmp_path):
+        import sqlite3
+
+        mgr = self._built(tmp_path)
+        with sqlite3.connect(mgr.db_path) as conn:
+            conn.execute("DROP TABLE meta")
+        assert mgr.exists() is False  # missing table -> caught -> rebuild
+
     def test_rebuild_is_atomic_and_replaces(self, tmp_path):
         repo = _repo(tmp_path)
         mgr = _mgr(tmp_path)

--- a/tests/unit/global_repos/test_trigram_index_manager.py
+++ b/tests/unit/global_repos/test_trigram_index_manager.py
@@ -89,23 +89,6 @@ class TestBuildQuery:
         assert set(mgr.query(trigrams("OddAuthenticator"))) == {"bin.dat"}
         assert "bin.dat" not in mgr.query(trigrams("zzzznotpresent"))
 
-    def test_bucket_mask_prunes_cross_line_scatter(self, tmp_path):
-        # A file where the required trigrams appear only on DIFFERENT, far-apart
-        # lines cannot contain a default (line-oriented) match, so the bucket-mask
-        # AND drops it -- while a file with them on the SAME line is kept.
-        repo = tmp_path / "repo"
-        repo.mkdir()
-        (repo / "together.txt").write_text("public enum Color {}\n")
-        apart = ["public class A"] + ["filler line"] * 200 + ["enum B"]
-        (repo / "apart.txt").write_text("\n".join(apart))
-        mgr = _mgr(tmp_path)
-        mgr.build(repo, file_list=["together.txt", "apart.txt"])
-
-        req = trigrams("public") | trigrams("enum")
-        cands = set(mgr.query(req))
-        assert "together.txt" in cands  # same line -> shared bucket -> kept
-        assert "apart.txt" not in cands  # far apart -> disjoint buckets -> pruned
-
     def test_exists_false_without_build(self, tmp_path):
         assert _mgr(tmp_path).exists() is False
 

--- a/tests/unit/global_repos/test_trigram_index_manager.py
+++ b/tests/unit/global_repos/test_trigram_index_manager.py
@@ -1,0 +1,105 @@
+"""Tests for TrigramIndexManager (build + query).
+
+Correctness focus: query() must return a superset of files that could match --
+files with all required trigrams, plus any file that could not be indexed.
+"""
+
+import shutil
+
+import pytest
+
+from code_indexer.global_repos.regex_trigram import trigrams
+from code_indexer.global_repos.trigram_index_manager import TrigramIndexManager
+
+
+def _repo(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "a").mkdir(parents=True)
+    (repo / "auth.java").write_text("public class LSAuthenticator {}")
+    (repo / "a" / "other.py").write_text("def authenticate(): pass")
+    (repo / "readme.md").write_text("nothing relevant here at all")
+    return repo
+
+
+def _mgr(tmp_path):
+    return TrigramIndexManager(tmp_path / "idx")
+
+
+class TestBuildQuery:
+    def test_build_and_query_finds_containing_files(self, tmp_path):
+        repo = _repo(tmp_path)
+        mgr = _mgr(tmp_path)
+        n = mgr.build(repo, file_list=["auth.java", "a/other.py", "readme.md"])
+        assert n == 3
+        assert mgr.exists()
+
+        # "authenticator" trigrams -> only auth.java
+        cands = mgr.query(trigrams("authenticator"))
+        assert cands == ["auth.java"]
+
+        # "authenticate" trigrams -> only other.py
+        cands = mgr.query(trigrams("authenticate"))
+        assert set(cands) == {"a/other.py"}
+
+    def test_query_requires_all_trigrams(self, tmp_path):
+        repo = _repo(tmp_path)
+        mgr = _mgr(tmp_path)
+        mgr.build(repo, file_list=["auth.java", "a/other.py", "readme.md"])
+        # combine trigrams from two different files -> no single file has both
+        combined = trigrams("authenticator") | trigrams("relevant")
+        assert mgr.query(combined) == []
+
+    def test_empty_required_returns_none(self, tmp_path):
+        repo = _repo(tmp_path)
+        mgr = _mgr(tmp_path)
+        mgr.build(repo, file_list=["auth.java"])
+        assert mgr.query(set()) is None
+
+    def test_binary_and_large_files_are_always_candidates(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "bin.dat").write_bytes(b"\x00\x01\x02binaryauthenticator\x00")
+        (repo / "big.txt").write_text("x" * (6 * 1024 * 1024))  # > 5MB
+        (repo / "code.txt").write_text("class Widget")
+        mgr = _mgr(tmp_path)
+        mgr.build(repo, file_list=["bin.dat", "big.txt", "code.txt"])
+
+        # a query that matches none of the indexed content must STILL include the
+        # un-indexed binary + large files (they might contain a match)
+        cands = mgr.query(trigrams("zzzznotpresent"))
+        assert set(cands) == {"bin.dat", "big.txt"}
+
+        # an indexed file with the trigrams is added on top
+        cands = mgr.query(trigrams("widget"))
+        assert set(cands) == {"bin.dat", "big.txt", "code.txt"}
+
+    def test_exists_false_without_build(self, tmp_path):
+        assert _mgr(tmp_path).exists() is False
+
+    def test_rebuild_is_atomic_and_replaces(self, tmp_path):
+        repo = _repo(tmp_path)
+        mgr = _mgr(tmp_path)
+        mgr.build(repo, file_list=["auth.java"])
+        assert mgr.query(trigrams("authenticator")) == ["auth.java"]
+        # rebuild with a different file set
+        mgr.build(repo, file_list=["readme.md"])
+        assert mgr.query(trigrams("authenticator")) == []
+        assert set(mgr.query(trigrams("relevant"))) == {"readme.md"}
+
+
+@pytest.mark.skipif(shutil.which("rg") is None, reason="ripgrep not installed")
+class TestRgEnumeration:
+    def test_build_via_rg_files(self, tmp_path):
+        repo = _repo(tmp_path)
+        # .ignore is honored by ripgrep regardless of git (a real golden repo is
+        # a git repo where .gitignore applies identically for build + search).
+        (repo / ".ignore").write_text("ignored/\n")
+        (repo / "ignored").mkdir()
+        (repo / "ignored" / "secret.java").write_text("class LSAuthenticator")
+        mgr = _mgr(tmp_path)
+        mgr.build(repo)  # no file_list -> rg --files enumeration
+        # authenticator appears in auth.java (tracked) and ignored/secret.java
+        # (ignored). rg --files excludes the ignored one.
+        cands = mgr.query(trigrams("authenticator"))
+        assert "auth.java" in cands
+        assert "ignored/secret.java" not in cands

--- a/tests/unit/global_repos/test_trigram_index_manager.py
+++ b/tests/unit/global_repos/test_trigram_index_manager.py
@@ -89,6 +89,23 @@ class TestBuildQuery:
         assert set(mgr.query(trigrams("OddAuthenticator"))) == {"bin.dat"}
         assert "bin.dat" not in mgr.query(trigrams("zzzznotpresent"))
 
+    def test_bucket_mask_prunes_cross_line_scatter(self, tmp_path):
+        # A file where the required trigrams appear only on DIFFERENT, far-apart
+        # lines cannot contain a default (line-oriented) match, so the bucket-mask
+        # AND drops it -- while a file with them on the SAME line is kept.
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "together.txt").write_text("public enum Color {}\n")
+        apart = ["public class A"] + ["filler line"] * 200 + ["enum B"]
+        (repo / "apart.txt").write_text("\n".join(apart))
+        mgr = _mgr(tmp_path)
+        mgr.build(repo, file_list=["together.txt", "apart.txt"])
+
+        req = trigrams("public") | trigrams("enum")
+        cands = set(mgr.query(req))
+        assert "together.txt" in cands  # same line -> shared bucket -> kept
+        assert "apart.txt" not in cands  # far apart -> disjoint buckets -> pruned
+
     def test_exists_false_without_build(self, tmp_path):
         assert _mgr(tmp_path).exists() is False
 

--- a/tests/unit/global_repos/test_trigram_index_manager.py
+++ b/tests/unit/global_repos/test_trigram_index_manager.py
@@ -142,6 +142,80 @@ class TestSchemaVersionGuard:
         assert set(mgr.query(trigrams("relevant"))) == {"readme.md"}
 
 
+class TestBuildAtomicity:
+    """A build publishes atomically and never leaves a partial index behind, so a
+    concurrent build on a shared (NFS, cluster-mode) index dir cannot clobber
+    another's in-progress database and publish a partially-populated index that
+    would pass exists() and silently drop matches."""
+
+    def test_failed_build_keeps_prior_index_and_leaves_no_temp(self, tmp_path):
+        import code_indexer.global_repos.trigram_index_manager as tim
+
+        repo = _repo(tmp_path)
+        mgr = _mgr(tmp_path)
+        mgr.build(repo, file_list=["auth.java"])
+        assert mgr.query(trigrams("lsauthenticator")) == ["auth.java"]
+
+        def boom(_abs_path):
+            raise RuntimeError("disk full mid-build")
+
+        orig = tim.TrigramIndexManager._file_trigrams
+        tim.TrigramIndexManager._file_trigrams = staticmethod(boom)
+        try:
+            with pytest.raises(RuntimeError):
+                mgr.build(repo, file_list=["a/other.py"])
+        finally:
+            tim.TrigramIndexManager._file_trigrams = staticmethod(orig)
+
+        # the previously-published index is untouched (no partial replace)...
+        assert mgr.query(trigrams("lsauthenticator")) == ["auth.java"]
+        # ...and the failed build cleaned up its unique temp file.
+        assert list((tmp_path / "idx").glob("*.db.building")) == []
+
+    def test_concurrent_builds_publish_a_valid_index(self, tmp_path):
+        import threading
+        import time
+
+        import code_indexer.global_repos.trigram_index_manager as tim
+
+        repo = _repo(tmp_path)
+        mgr = _mgr(tmp_path)
+
+        # Slow the per-file work so the three builds genuinely overlap against the
+        # same index dir (each must use its own temp file).
+        real = tim.TrigramIndexManager._file_trigrams
+
+        def slow(abs_path):
+            time.sleep(0.02)
+            return real(abs_path)
+
+        tim.TrigramIndexManager._file_trigrams = staticmethod(slow)
+        errors: list = []
+
+        def run():
+            try:
+                mgr.build(repo, file_list=["auth.java", "a/other.py", "readme.md"])
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        try:
+            threads = [threading.Thread(target=run) for _ in range(3)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+        finally:
+            tim.TrigramIndexManager._file_trigrams = staticmethod(real)
+
+        assert errors == []
+        # the published index is complete and valid -- not a clobbered partial.
+        assert mgr.exists()
+        assert "auth.java" in mgr.query(trigrams("lsauthenticator"))
+        assert "a/other.py" in mgr.query(trigrams("authenticate"))
+        # no leftover in-progress temp files.
+        assert list((tmp_path / "idx").glob("*.db.building")) == []
+
+
 @pytest.mark.skipif(shutil.which("rg") is None, reason="ripgrep not installed")
 class TestRgEnumeration:
     def test_build_via_rg_files(self, tmp_path):

--- a/tests/unit/global_repos/test_trigram_index_manager.py
+++ b/tests/unit/global_repos/test_trigram_index_manager.py
@@ -33,21 +33,20 @@ class TestBuildQuery:
         assert n == 3
         assert mgr.exists()
 
-        # "authenticator" trigrams -> only auth.java
-        cands = mgr.query(trigrams("authenticator"))
-        assert cands == ["auth.java"]
+        # Superset guarantee: the file that truly contains the string is always a
+        # candidate (ripgrep does the exact match over the candidates).
+        assert "auth.java" in mgr.query(trigrams("LSAuthenticator"))
+        assert "a/other.py" in mgr.query(trigrams("authenticate"))
+        # a file that clearly lacks the (rare) trigrams is excluded
+        assert "readme.md" not in mgr.query(trigrams("LSAuthenticator"))
 
-        # "authenticate" trigrams -> only other.py
-        cands = mgr.query(trigrams("authenticate"))
-        assert set(cands) == {"a/other.py"}
-
-    def test_query_requires_all_trigrams(self, tmp_path):
+    def test_query_excludes_files_lacking_rare_trigrams(self, tmp_path):
         repo = _repo(tmp_path)
         mgr = _mgr(tmp_path)
         mgr.build(repo, file_list=["auth.java", "a/other.py", "readme.md"])
-        # combine trigrams from two different files -> no single file has both
-        combined = trigrams("authenticator") | trigrams("relevant")
-        assert mgr.query(combined) == []
+        # a distinctive string present in no file -> its rare trigrams post to
+        # nothing, so no indexed file is a candidate
+        assert mgr.query(trigrams("zqxjwkbvfp")) == []
 
     def test_empty_required_returns_none(self, tmp_path):
         repo = _repo(tmp_path)

--- a/tests/unit/global_repos/test_trigram_index_manager.py
+++ b/tests/unit/global_repos/test_trigram_index_manager.py
@@ -40,6 +40,14 @@ class TestBuildQuery:
         # a file that clearly lacks the (rare) trigrams is excluded
         assert "readme.md" not in mgr.query(trigrams("LSAuthenticator"))
 
+    def test_query_requires_all_trigrams(self, tmp_path):
+        repo = _repo(tmp_path)
+        mgr = _mgr(tmp_path)
+        mgr.build(repo, file_list=["auth.java", "a/other.py", "readme.md"])
+        # trigrams drawn from two different files -> no single file has them all
+        combined = trigrams("LSAuthenticator") | trigrams("relevant")
+        assert mgr.query(combined) == []
+
     def test_query_excludes_files_lacking_rare_trigrams(self, tmp_path):
         repo = _repo(tmp_path)
         mgr = _mgr(tmp_path)
@@ -54,23 +62,32 @@ class TestBuildQuery:
         mgr.build(repo, file_list=["auth.java"])
         assert mgr.query(set()) is None
 
-    def test_binary_and_large_files_are_always_candidates(self, tmp_path):
+    def test_large_files_are_always_candidates(self, tmp_path):
         repo = tmp_path / "repo"
         repo.mkdir()
-        (repo / "bin.dat").write_bytes(b"\x00\x01\x02binaryauthenticator\x00")
-        (repo / "big.txt").write_text("x" * (6 * 1024 * 1024))  # > 5MB
+        (repo / "big.txt").write_text("x" * (6 * 1024 * 1024))  # > 5MB -> unindexed
         (repo / "code.txt").write_text("class Widget")
         mgr = _mgr(tmp_path)
-        mgr.build(repo, file_list=["bin.dat", "big.txt", "code.txt"])
+        mgr.build(repo, file_list=["big.txt", "code.txt"])
 
-        # a query that matches none of the indexed content must STILL include the
-        # un-indexed binary + large files (they might contain a match)
-        cands = mgr.query(trigrams("zzzznotpresent"))
-        assert set(cands) == {"bin.dat", "big.txt"}
+        # a query matching nothing indexed must STILL include the large (unindexed)
+        # file, which ripgrep would still scan
+        assert set(mgr.query(trigrams("zzzznotpresent"))) == {"big.txt"}
+        # an indexed match plus the always-candidate large file
+        assert set(mgr.query(trigrams("widget"))) == {"big.txt", "code.txt"}
 
-        # an indexed file with the trigrams is added on top
-        cands = mgr.query(trigrams("widget"))
-        assert set(cands) == {"bin.dat", "big.txt", "code.txt"}
+    def test_binary_files_are_indexed_and_searchable(self, tmp_path):
+        # A file with NUL bytes still holds searchable text (ripgrep matches it),
+        # so it is trigram-indexed -- selectable by its content, prunable when
+        # its trigrams are absent -- NOT an opaque always-candidate.
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "bin.dat").write_bytes(b"\x00\x01class OddAuthenticator\x00\xff")
+        (repo / "other.txt").write_text("nothing relevant to see")
+        mgr = _mgr(tmp_path)
+        mgr.build(repo, file_list=["bin.dat", "other.txt"])
+        assert set(mgr.query(trigrams("OddAuthenticator"))) == {"bin.dat"}
+        assert "bin.dat" not in mgr.query(trigrams("zzzznotpresent"))
 
     def test_exists_false_without_build(self, tmp_path):
         assert _mgr(tmp_path).exists() is False

--- a/tests/unit/server/repositories/test_activated_repos_cluster.py
+++ b/tests/unit/server/repositories/test_activated_repos_cluster.py
@@ -87,8 +87,7 @@ class SqlitePoolAdapter:
         self._create_schema()
 
     def _create_schema(self):
-        self._conn.execute(
-            """
+        self._conn.execute("""
             CREATE TABLE IF NOT EXISTS activated_repos (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 username TEXT NOT NULL,
@@ -105,8 +104,7 @@ class SqlitePoolAdapter:
                 metadata_json TEXT,
                 UNIQUE(username, user_alias)
             )
-        """
-        )
+        """)
         self._conn.commit()
 
     @contextmanager
@@ -365,3 +363,61 @@ class TestMetadataPgOperations:
         aliases = {r["user_alias"] for r in all_repos}
         assert "r1" in aliases
         assert "r2" in aliases
+
+
+class TestActivatedStorageSharedWarning:
+    """set_shared_repos_dir must warn when activated-repos is on a different
+    filesystem than golden-repos (multi-pod 404 misconfiguration)."""
+
+    def _mgr(self, tmp_path):
+        return ActivatedRepoManager(data_dir=str(tmp_path / "local"))
+
+    def test_warns_when_activated_on_different_device(self, tmp_path, caplog):
+        import logging
+        from unittest.mock import patch
+        from src.code_indexer.server.repositories import (
+            activated_repo_manager as arm_mod,
+        )
+
+        shared = tmp_path / "shared"
+        (shared / "golden-repos").mkdir(parents=True)
+        mgr = self._mgr(tmp_path)
+
+        class _St:
+            def __init__(self, dev):
+                self.st_dev = dev
+
+        def fake_stat(path, *a, **k):
+            # golden on one device, activated on another
+            return _St(1 if "golden-repos" in str(path) else 2)
+
+        with patch.object(arm_mod.os, "stat", side_effect=fake_stat):
+            with caplog.at_level(logging.WARNING):
+                mgr.set_shared_repos_dir(str(shared))
+
+        assert any(
+            "different filesystem" in r.message or "404 on the others" in r.message
+            for r in caplog.records
+        ), "expected a shared-storage misconfiguration warning"
+
+    def test_no_warning_when_same_device(self, tmp_path, caplog):
+        import logging
+        from unittest.mock import patch
+        from src.code_indexer.server.repositories import (
+            activated_repo_manager as arm_mod,
+        )
+
+        shared = tmp_path / "shared"
+        (shared / "golden-repos").mkdir(parents=True)
+        mgr = self._mgr(tmp_path)
+
+        class _St:
+            st_dev = 42  # same device for everything
+
+        with patch.object(arm_mod.os, "stat", return_value=_St()):
+            with caplog.at_level(logging.WARNING):
+                mgr.set_shared_repos_dir(str(shared))
+
+        assert not any("different filesystem" in r.message for r in caplog.records), (
+            "must not warn when both dirs share a device"
+        )

--- a/tests/unit/server/routers/test_repos_files_endpoint.py
+++ b/tests/unit/server/routers/test_repos_files_endpoint.py
@@ -25,7 +25,6 @@ from tests.unit.server.routers.inline_routes_test_helpers import (
     _patch_closure,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures and helpers
 # ---------------------------------------------------------------------------
@@ -106,3 +105,60 @@ def test_repos_files_path_traversal_returns_400(test_client, tmp_path):
 
         r2 = test_client.get("/api/repos/myrepo2/files?path=/etc/passwd")
         assert r2.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Recursive listing (one call instead of N per-directory round-trips)
+# ---------------------------------------------------------------------------
+
+
+def _nested_repo(tmp_path):
+    repo_dir = tmp_path / "deep"
+    (repo_dir / "a" / "b" / "c").mkdir(parents=True)
+    (repo_dir / "top.txt").write_text("t")
+    (repo_dir / "a" / "one.py").write_text("1")
+    (repo_dir / "a" / "b" / "two.py").write_text("2")
+    (repo_dir / "a" / "b" / "c" / "three.py").write_text("3")
+    return repo_dir
+
+
+def test_repos_files_recursive_returns_full_tree(test_client, tmp_path):
+    """recursive=true returns the whole subtree in one response."""
+    repo_dir = _nested_repo(tmp_path)
+    with arm_mock({"user_alias": "deep"}, str(repo_dir)):
+        response = test_client.get("/api/repos/deep/files?recursive=true")
+
+    assert response.status_code == 200
+    data = response.json()
+    paths = {f["path"] for f in data["files"]}
+    # deep files reachable without per-directory calls
+    assert "a/b/c/three.py" in paths
+    assert "a/one.py" in paths
+    assert data["truncated"] is False
+    assert data["count"] == len(data["files"])
+
+
+def test_repos_files_recursive_max_depth_prunes(test_client, tmp_path):
+    """max_depth bounds how far recursion descends."""
+    repo_dir = _nested_repo(tmp_path)
+    with arm_mock({"user_alias": "deep"}, str(repo_dir)):
+        response = test_client.get("/api/repos/deep/files?recursive=true&max_depth=1")
+
+    assert response.status_code == 200
+    paths = {f["path"] for f in response.json()["files"]}
+    assert "top.txt" in paths
+    assert "a" in paths  # the dir entry at depth 1
+    assert "a/one.py" not in paths  # depth 2 not descended
+    assert "a/b/c/three.py" not in paths
+
+
+def test_repos_files_recursive_limit_truncates(test_client, tmp_path):
+    """limit caps entries and flags truncated."""
+    repo_dir = _nested_repo(tmp_path)
+    with arm_mock({"user_alias": "deep"}, str(repo_dir)):
+        response = test_client.get("/api/repos/deep/files?recursive=true&limit=2")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["truncated"] is True
+    assert len(data["files"]) == 2

--- a/tests/unit/server/services/test_scip_query_service.py
+++ b/tests/unit/server/services/test_scip_query_service.py
@@ -1647,3 +1647,79 @@ class TestAliasNormalizationBug661:
             scip_files = service.find_scip_files()
 
             assert len(scip_files) == 3
+
+
+class TestAnalyzeImpactScoping:
+    """analyze_impact must scope to the requested repo and early-out when it has
+    no SCIP index, instead of scanning every golden repo (perf bug: 48s empty)."""
+
+    def _service(self):
+        from code_indexer.server.services.scip_query_service import SCIPQueryService
+
+        return SCIPQueryService(
+            golden_repos_dir="/data/golden-repos", access_filtering_service=None
+        )
+
+    def test_early_out_when_no_index_for_alias(self):
+        """No .scip.db for the alias -> empty result WITHOUT invoking the composite."""
+        from unittest.mock import patch
+
+        service = self._service()
+        with (
+            patch.object(service, "find_scip_files", return_value=[]) as mock_find,
+            patch(
+                "code_indexer.scip.query.composites.analyze_impact"
+            ) as mock_composite,
+        ):
+            result = service.analyze_impact(
+                "LSAuthenticator", depth=3, repository_alias="evolution-global"
+            )
+
+        mock_find.assert_called_once_with(
+            repository_alias="evolution-global", username=None
+        )
+        mock_composite.assert_not_called()  # the expensive scan must be skipped
+        assert result["total_affected"] == 0
+        assert result["affected_symbols"] == []
+        assert result["affected_files"] == []
+        assert result["target_symbol"] == "LSAuthenticator"
+
+    def test_scopes_composite_to_project_scip_dir(self):
+        """When an index exists, the composite is pointed at the repo's own
+        .code-indexer/scip dir, not the whole golden-repos root."""
+        from unittest.mock import patch
+        from code_indexer.scip.query.composites import ImpactAnalysisResult
+
+        service = self._service()
+        scip_file = Path("/data/golden-repos/evolution/.code-indexer/scip/idx.scip.db")
+        empty = ImpactAnalysisResult(
+            target_symbol="X",
+            target_location=None,
+            depth_analyzed=3,
+            affected_symbols=[],
+            affected_files=[],
+            truncated=False,
+            total_affected=0,
+        )
+        # analyze_impact is imported inside the method from composites, so patch
+        # it on the composites module (its definition site).
+        with (
+            patch.object(service, "find_scip_files", return_value=[scip_file]),
+            patch(
+                "code_indexer.scip.query.composites.analyze_impact",
+                return_value=empty,
+            ) as mock_composite,
+        ):
+            service.analyze_impact("X", depth=3, repository_alias="evolution-global")
+
+        # composite called with the scoped .code-indexer/scip dir
+        called_dir = mock_composite.call_args.args[1]
+        assert called_dir == Path("/data/golden-repos/evolution/.code-indexer/scip")
+
+    def test_scip_dir_for_files_finds_code_indexer_scip(self):
+        from code_indexer.server.services.scip_query_service import SCIPQueryService
+
+        files = [Path("/data/golden-repos/evo/.code-indexer/scip/sub/a.scip.db")]
+        assert SCIPQueryService._scip_dir_for_files(files) == Path(
+            "/data/golden-repos/evo/.code-indexer/scip"
+        )

--- a/tests/unit/server/test_logging_utils.py
+++ b/tests/unit/server/test_logging_utils.py
@@ -55,3 +55,44 @@ def test_sanitize_sensitive_data():
 
     # None should be handled
     assert sanitize_for_logging(None) is None
+
+
+class TestMaskUrlCredentials:
+    """mask_url_credentials strips embedded clone credentials before a repo URL
+    is exposed in an API response."""
+
+    def test_masks_oauth2_token(self):
+        from code_indexer.server.logging_utils import mask_url_credentials
+
+        masked = mask_url_credentials(
+            "https://oauth2:glpat-SECRET123@gitlab.com/org/repo.git"
+        )
+        assert masked == "https://***@gitlab.com/org/repo.git"
+        assert "glpat" not in masked
+        assert "SECRET123" not in masked
+
+    def test_masks_user_password(self):
+        from code_indexer.server.logging_utils import mask_url_credentials
+
+        assert (
+            mask_url_credentials("https://user:pass@github.com/a/b.git")
+            == "https://***@github.com/a/b.git"
+        )
+
+    def test_leaves_credential_free_url_unchanged(self):
+        from code_indexer.server.logging_utils import mask_url_credentials
+
+        for url in (
+            "https://gitlab.com/org/repo.git",
+            "local://myalias",
+            "git@github.com:org/repo.git",  # scp-form, no scheme -> username, not a secret
+        ):
+            assert mask_url_credentials(url) == url
+
+    def test_idempotent_and_non_string_safe(self):
+        from code_indexer.server.logging_utils import mask_url_credentials
+
+        once = mask_url_credentials("https://oauth2:tok@gitlab.com/x.git")
+        assert mask_url_credentials(once) == once  # masking twice is a no-op
+        assert mask_url_credentials(None) is None
+        assert mask_url_credentials(123) == 123

--- a/tests/unit/server/test_shard_cache_gating.py
+++ b/tests/unit/server/test_shard_cache_gating.py
@@ -1,0 +1,55 @@
+"""Shard-aware index-cache gating in the query managers.
+
+Semantic (single-repo) fails OPEN: solo mode caches every repo. Multi/omni
+fan-out stays cache-OFF in solo mode (Bug #881) and only warms the cache for
+OWNED repos under sharding. Both must tolerate __new__-built instances.
+"""
+
+from unittest.mock import MagicMock
+
+from code_indexer.server.query.semantic_query_manager import SemanticQueryManager
+from code_indexer.server.multi.multi_search_service import MultiSearchService
+
+
+def _sem():
+    return SemanticQueryManager.__new__(SemanticQueryManager)
+
+
+def _multi():
+    return MultiSearchService.__new__(MultiSearchService)
+
+
+def _ownership(owned: set):
+    o = MagicMock()
+    o.owns.side_effect = lambda alias: alias in owned
+    return o
+
+
+# ---- semantic: fail-open ----
+
+
+def test_semantic_solo_caches_every_repo():
+    m = _sem()  # __new__, no _shard_ownership set -> getattr default None
+    assert m._owns_for_cache("any-repo") is True
+
+
+def test_semantic_sharded_caches_only_owned():
+    m = _sem()
+    m.set_shard_ownership(_ownership({"repo-a"}))
+    assert m._owns_for_cache("repo-a") is True
+    assert m._owns_for_cache("repo-b") is False
+
+
+# ---- multi: cache-off in solo, on for owned ----
+
+
+def test_multi_solo_never_caches():
+    m = _multi()  # __new__ -> getattr default None
+    assert m._owns_for_cache("any-repo") is False
+
+
+def test_multi_sharded_caches_only_owned():
+    m = _multi()
+    m.set_shard_ownership(_ownership({"repo-a"}))
+    assert m._owns_for_cache("repo-a") is True
+    assert m._owns_for_cache("repo-b") is False

--- a/tests/unit/server/test_shard_replicas_config.py
+++ b/tests/unit/server/test_shard_replicas_config.py
@@ -1,0 +1,29 @@
+"""shard_replicas must be configurable and default to functional sharding.
+
+With replicas >= node count, every node owns every repo (no sharding). The
+default must be 1 so a 2+ node cluster shards out of the box.
+"""
+
+from code_indexer.server.utils.config_manager import ClusterConfig
+from code_indexer.server.services.shard_ownership import ShardOwnership
+
+
+def test_cluster_config_shard_replicas_default_is_one():
+    assert ClusterConfig().shard_replicas == 1
+
+
+def test_replicas_one_distributes_ownership_on_two_nodes():
+    nodes = ["nodeA", "nodeB"]
+    a = ShardOwnership("nodeA", lambda: nodes, replicas=1)
+    b = ShardOwnership("nodeB", lambda: nodes, replicas=1)
+    # every alias is owned by exactly one of the two nodes
+    for alias in ["r1-global", "r2-global", "r3", "r4"]:
+        assert a.owns(alias) != b.owns(alias), alias
+
+
+def test_replicas_ge_nodecount_makes_everyone_own_everything():
+    nodes = ["nodeA", "nodeB"]
+    a = ShardOwnership("nodeA", lambda: nodes, replicas=2)
+    b = ShardOwnership("nodeB", lambda: nodes, replicas=2)
+    for alias in ["r1", "r2"]:
+        assert a.owns(alias) and b.owns(alias), alias

--- a/tests/unit/test_scip_query_composites.py
+++ b/tests/unit/test_scip_query_composites.py
@@ -643,3 +643,42 @@ class TestTraceCallChainMaxDepthValidation:
 
         # Should succeed (no exception) and return valid result
         assert result is not None
+
+
+class TestAnalyzeImpactEarlyOut:
+    """analyze_impact must skip the BFS dependents traversal when the target
+    symbol has no definition (perf: unresolved symbol -> guaranteed-empty)."""
+
+    def test_no_definition_skips_bfs(self, tmp_path):
+        with (
+            patch(
+                "code_indexer.scip.query.composites._find_target_definition",
+                return_value=None,
+            ),
+            patch(
+                "code_indexer.scip.query.composites._bfs_traverse_dependents"
+            ) as mock_bfs,
+        ):
+            result = analyze_impact("DoesNotExist", tmp_path, depth=3)
+
+        mock_bfs.assert_not_called()  # expensive pass skipped
+        assert result.total_affected == 0
+        assert result.affected_symbols == []
+        assert result.target_location is None
+
+    def test_definition_found_runs_bfs(self, tmp_path):
+        sentinel_loc = MagicMock()
+        with (
+            patch(
+                "code_indexer.scip.query.composites._find_target_definition",
+                return_value=sentinel_loc,
+            ),
+            patch(
+                "code_indexer.scip.query.composites._bfs_traverse_dependents",
+                return_value=[],
+            ) as mock_bfs,
+        ):
+            result = analyze_impact("RealSymbol", tmp_path, depth=2)
+
+        mock_bfs.assert_called_once()  # traversal runs when a definition exists
+        assert result.target_location is sentinel_loc

--- a/tests/unit/test_shard_ownership.py
+++ b/tests/unit/test_shard_ownership.py
@@ -1,0 +1,118 @@
+"""Unit tests for repo-shard ownership (HRW) -- Phase 0 of C6 sharding."""
+
+from code_indexer.server.services.shard_ownership import (
+    ShardOwnership,
+    compute_owners,
+)
+
+NODES = [f"node-{i}" for i in range(6)]
+
+
+def test_compute_owners_deterministic_and_top_r():
+    a = compute_owners("repo-x", NODES, replicas=2)
+    b = compute_owners("repo-x", NODES, replicas=2)
+    assert a == b  # deterministic
+    assert len(a) == 2
+    assert set(a).issubset(set(NODES))
+
+
+def test_compute_owners_replicas_clamped():
+    assert len(compute_owners("r", NODES, replicas=0)) == 1  # clamped up to 1
+    assert (
+        compute_owners("r", NODES, replicas=99)
+        == sorted(compute_owners("r", NODES, replicas=99))
+        or True
+    )  # all nodes when replicas exceeds cluster size
+    assert set(compute_owners("r", NODES, replicas=99)) == set(NODES)
+    assert compute_owners("r", [], replicas=2) == []
+
+
+def test_every_alias_owned_by_exactly_r_nodes():
+    # The union of per-node ownership decisions must equal the R designated owners.
+    for i in range(200):
+        alias = f"repo-{i}"
+        designated = set(compute_owners(alias, NODES, replicas=2))
+        owning = {
+            n for n in NODES if ShardOwnership(n, lambda: NODES, replicas=2).owns(alias)
+        }
+        assert owning == designated
+        assert len(owning) == 2
+
+
+def test_distribution_is_balanced():
+    # Over many aliases, each node should own roughly total*R/N of them.
+    counts = {n: 0 for n in NODES}
+    total = 3000
+    for i in range(total):
+        for owner in compute_owners(f"repo-{i}", NODES, replicas=2):
+            counts[owner] += 1
+    expected = total * 2 / len(NODES)  # 1000
+    for n, c in counts.items():
+        assert 0.8 * expected < c < 1.2 * expected, (n, c, expected)
+
+
+def test_removing_a_node_only_reassigns_its_aliases():
+    # HRW property: dropping a node reshuffles only aliases that node owned.
+    remaining = NODES[:-1]
+    dropped = NODES[-1]
+    changed = 0
+    for i in range(1000):
+        alias = f"repo-{i}"
+        before = compute_owners(alias, NODES, replicas=2)
+        after = compute_owners(alias, remaining, replicas=2)
+        if dropped not in before:
+            # Aliases the dropped node did not own must be unchanged.
+            assert before == after, alias
+        else:
+            changed += 1
+    assert changed > 0  # sanity: the dropped node did own some aliases
+
+
+def test_owns_solo_and_empty_fail_open():
+    assert ShardOwnership("only", lambda: ["only"]).owns("r") is True  # 1 node
+    assert ShardOwnership("n", lambda: []).owns("r") is True  # empty -> fail open
+    assert ShardOwnership("n", lambda: NODES).owns("") is True  # empty alias
+
+
+def test_owns_fails_open_on_provider_error():
+    def boom():
+        raise RuntimeError("db down")
+
+    # Provider raises -> node set empty+self -> single node -> owns everything.
+    assert ShardOwnership("n", boom).owns("repo-x") is True
+
+
+def test_self_is_always_in_the_ring():
+    # Even if the provider omits this node (stale heartbeat), it still participates
+    # and can own aliases rather than disowning everything.
+    others = ["a", "b", "c"]
+    so = ShardOwnership("me", lambda: others, replicas=2)
+    owned = [f"r{i}" for i in range(300) if so.owns(f"r{i}")]
+    assert len(owned) > 0
+
+
+def test_snapshot_reports_identity_replicas_and_nodes():
+    so = ShardOwnership("node-2", lambda: NODES, replicas=3)
+    snap = so.snapshot()
+    assert snap["node_id"] == "node-2"
+    assert snap["replicas"] == 3
+    assert set(snap["active_nodes"]) == set(NODES)
+
+
+def test_active_nodes_cached_within_refresh_window():
+    calls = {"n": 0}
+
+    def provider():
+        calls["n"] += 1
+        return NODES
+
+    clock = {"t": 100.0}
+    so = ShardOwnership(
+        "node-0", provider, refresh_seconds=5.0, time_fn=lambda: clock["t"]
+    )
+    for _ in range(10):
+        so.owns("repo-x")
+    assert calls["n"] == 1  # cached; provider hit once
+    clock["t"] = 106.0  # advance past the refresh window
+    so.owns("repo-x")
+    assert calls["n"] == 2

--- a/tests/unit/test_shard_prewarm.py
+++ b/tests/unit/test_shard_prewarm.py
@@ -1,0 +1,73 @@
+"""Unit tests for C6 rebalance pre-warming (ShardPrewarmService.run_once)."""
+
+from code_indexer.server.services.shard_prewarm_service import ShardPrewarmService
+
+
+class _Own:
+    def __init__(self, owned):
+        self._owned = set(owned)
+
+    def owns(self, alias):
+        return alias in self._owned
+
+
+def test_warms_owned_repos_only_once():
+    warmed = []
+    svc = ShardPrewarmService(_Own(["a", "b"]), lambda: ["a", "b", "c"], warmed.append)
+    svc.run_once()
+    assert sorted(warmed) == ["a", "b"]  # 'c' not owned -> not warmed
+    svc.run_once()  # already warmed -> no repeat
+    assert sorted(warmed) == ["a", "b"]
+
+
+def test_membership_change_warms_newly_owned():
+    warmed = []
+    own = _Own(["a"])
+    svc = ShardPrewarmService(own, lambda: ["a", "b"], warmed.append)
+    svc.run_once()
+    assert warmed == ["a"]
+    own._owned = {"a", "b"}  # membership shift -> now owns b
+    svc.run_once()
+    assert sorted(warmed) == ["a", "b"]
+
+
+def test_drops_no_longer_owned_and_rewarms_on_return():
+    warmed = []
+    own = _Own(["a"])
+    svc = ShardPrewarmService(own, lambda: ["a"], warmed.append)
+    svc.run_once()
+    assert warmed == ["a"]
+    own._owned = set()  # lost ownership
+    svc.run_once()
+    assert warmed == ["a"]  # nothing new; 'a' forgotten from warmed set
+    own._owned = {"a"}  # regained
+    svc.run_once()
+    assert warmed == ["a", "a"]  # re-warmed
+
+
+def test_solo_mode_is_noop():
+    warmed = []
+    ShardPrewarmService(None, lambda: ["a"], warmed.append).run_once()
+    assert warmed == []
+
+
+def test_warm_failure_is_caught_and_retried_next_cycle():
+    calls = []
+
+    def warm(alias):
+        calls.append(alias)
+        raise RuntimeError("boom")
+
+    svc = ShardPrewarmService(_Own(["a"]), lambda: ["a"], warm)
+    svc.run_once()  # must not raise; 'a' not added to warmed
+    assert calls == ["a"]
+    svc.run_once()  # retried
+    assert calls == ["a", "a"]
+
+
+def test_repos_provider_error_is_caught():
+    def boom():
+        raise RuntimeError("db down")
+
+    # Must not raise even if the repo listing fails.
+    ShardPrewarmService(_Own(["a"]), boom, lambda a: None).run_once()

--- a/tests/unit/test_shard_router.py
+++ b/tests/unit/test_shard_router.py
@@ -1,0 +1,219 @@
+"""Unit tests for the C6 Phase 1 internal shard router."""
+
+from contextlib import contextmanager
+
+import pytest
+
+from code_indexer.server.services.shard_router import ShardRouter, FORWARD_HEADER
+
+
+class FakeOwnership:
+    def __init__(self, owned, owners):
+        self._owned = owned
+        self._owners = owners
+
+    def owns(self, alias):
+        return self._owned
+
+    def owners_of(self, alias):
+        return list(self._owners)
+
+
+class FakeResponse:
+    def __init__(self, payload, raise_exc=None):
+        self._payload = payload
+        self._raise = raise_exc
+        self.posted = None
+
+    def raise_for_status(self):
+        if self._raise:
+            raise self._raise
+
+    def json(self):
+        return self._payload
+
+
+class FakeClient:
+    def __init__(self, response, record):
+        self._response = response
+        self._record = record
+
+    def post(self, url, json=None, headers=None):
+        self._record["url"] = url
+        self._record["json"] = json
+        self._record["headers"] = headers
+        return self._response
+
+
+class FakeHttpFactory:
+    def __init__(self, response, record):
+        self._response = response
+        self._record = record
+
+    @contextmanager
+    def create_sync_client(self, timeout=None):
+        self._record["timeout"] = timeout
+        yield FakeClient(self._response, self._record)
+
+
+def _router(ownership, addresses, response=None, record=None):
+    record = record if record is not None else {}
+    return ShardRouter(
+        node_id="me",
+        shard_ownership=ownership,
+        node_addresses_provider=lambda: addresses,
+        http_client_factory=FakeHttpFactory(response, record),
+    )
+
+
+def test_solo_mode_serves_locally():
+    r = _router(None, {})
+    assert r.target_for("repo") is None
+
+
+def test_owned_serves_locally():
+    r = _router(FakeOwnership(owned=True, owners=["me"]), {"me": "1.1.1.1:8090"})
+    assert r.target_for("repo") is None
+
+
+def test_not_owned_forwards_to_owner_with_address():
+    r = _router(
+        FakeOwnership(owned=False, owners=["peer", "me"]),
+        {"peer": "2.2.2.2:8090", "me": "1.1.1.1:8090"},
+    )
+    assert r.target_for("repo") == "2.2.2.2:8090"
+
+
+def test_not_owned_but_no_reachable_owner_serves_locally():
+    # Owner has no registered address -> fail open to local.
+    r = _router(FakeOwnership(owned=False, owners=["peer"]), {"me": "1.1.1.1:8090"})
+    assert r.target_for("repo") is None
+
+
+def test_unknown_ownership_serves_locally():
+    r = _router(FakeOwnership(owned=False, owners=[]), {"peer": "2.2.2.2:8090"})
+    assert r.target_for("repo") is None
+
+
+def test_address_provider_error_serves_locally():
+    def boom():
+        raise RuntimeError("db down")
+
+    router = ShardRouter(
+        "me", FakeOwnership(False, ["peer"]), boom, FakeHttpFactory(None, {})
+    )
+    assert router.target_for("repo") is None
+
+
+def test_forward_posts_with_loopguard_and_auth_and_returns_json():
+    record = {}
+    resp = FakeResponse({"results": [], "total_results": 0})
+    r = _router(FakeOwnership(False, ["peer"]), {"peer": "2.2.2.2:8090"}, resp, record)
+    out = r.forward("2.2.2.2:8090", {"query_text": "x"}, "Bearer tok")
+    assert out == {"results": [], "total_results": 0}
+    assert record["url"] == "http://2.2.2.2:8090/api/query"
+    assert record["json"] == {"query_text": "x"}
+    assert record["headers"][FORWARD_HEADER] == "1"
+    assert record["headers"]["Authorization"] == "Bearer tok"
+
+
+def test_forward_propagates_http_error():
+    resp = FakeResponse({}, raise_exc=RuntimeError("502"))
+    r = _router(FakeOwnership(False, ["peer"]), {"peer": "2.2.2.2:8090"}, resp, {})
+    with pytest.raises(RuntimeError):
+        r.forward("2.2.2.2:8090", {"q": 1}, None)
+
+
+def test_forward_omits_auth_when_absent():
+    record = {}
+    resp = FakeResponse({"ok": True})
+    r = _router(FakeOwnership(False, ["peer"]), {"peer": "2.2.2.2:8090"}, resp, record)
+    r.forward("2.2.2.2:8090", {}, None)
+    assert "Authorization" not in record["headers"]
+    assert record["headers"][FORWARD_HEADER] == "1"
+
+
+def test_forward_uses_path_param():
+    record = {}
+    resp = FakeResponse({"ok": True})
+    r = _router(FakeOwnership(False, ["peer"]), {"peer": "2.2.2.2:8090"}, resp, record)
+    r.forward("2.2.2.2:8090", {}, None, path="/api/query/multi")
+    assert record["url"] == "http://2.2.2.2:8090/api/query/multi"
+
+
+class PerAliasOwnership:
+    """Ownership stub with per-alias control (owns() and owners_of())."""
+
+    def __init__(self, owned, owners_map):
+        self._owned = set(owned)
+        self._owners = owners_map
+
+    def owns(self, alias):
+        return alias in self._owned
+
+    def owners_of(self, alias):
+        return list(self._owners.get(alias, []))
+
+
+def test_group_by_owner_partitions_local_and_remote():
+    # me owns 'a'; 'b'->peer1, 'c'->peer2; 'd' owned by peerX which has no address
+    own = PerAliasOwnership({"a"}, {"b": ["peer1"], "c": ["peer2"], "d": ["peerX"]})
+    addrs = {"peer1": "1.1.1.1:8090", "peer2": "2.2.2.2:8090"}  # no peerX
+    r = ShardRouter("me", own, lambda: addrs, FakeHttpFactory(None, {}))
+    local, groups = r.group_by_owner(["a", "b", "c", "d"])
+    # 'a' owned locally; 'd' has no reachable owner -> fail open to local
+    assert set(local) == {"a", "d"}
+    assert groups == {"1.1.1.1:8090": ["b"], "2.2.2.2:8090": ["c"]}
+
+
+def test_group_by_owner_all_local_when_solo():
+    r = _router(None, {})  # no ownership -> solo
+    local, groups = r.group_by_owner(["a", "b", "c"])
+    assert local == ["a", "b", "c"]
+    assert groups == {}
+
+
+def test_group_by_owner_groups_multiple_repos_per_owner():
+    own = PerAliasOwnership(set(), {"b": ["peer1"], "c": ["peer1"], "d": ["peer2"]})
+    addrs = {"peer1": "1.1.1.1:8090", "peer2": "2.2.2.2:8090"}
+    r = ShardRouter("me", own, lambda: addrs, FakeHttpFactory(None, {}))
+    local, groups = r.group_by_owner(["b", "c", "d"])
+    assert local == []
+    assert groups == {"1.1.1.1:8090": ["b", "c"], "2.2.2.2:8090": ["d"]}
+
+
+def test_forward_increments_counters():
+    r = _router(
+        FakeOwnership(False, ["peer"]), {"peer": "2.2.2.2:8090"}, FakeResponse({})
+    )
+    r.forward("2.2.2.2:8090", {}, None)
+    assert r._forwards == 1
+    assert r._forward_failures == 0
+    r2 = _router(
+        FakeOwnership(False, ["peer"]),
+        {"peer": "2.2.2.2:8090"},
+        FakeResponse({}, raise_exc=RuntimeError("boom")),
+    )
+    with pytest.raises(RuntimeError):
+        r2.forward("2.2.2.2:8090", {}, None)
+    assert r2._forwards == 1
+    assert r2._forward_failures == 1
+
+
+def test_stats_reports_identity_ring_and_counters():
+    from code_indexer.server.services.shard_ownership import ShardOwnership
+
+    so = ShardOwnership("me", lambda: ["me", "peer"], replicas=2)
+    r = ShardRouter(
+        "me",
+        so,
+        lambda: {"me": "1.1.1.1:8090", "peer": "2.2.2.2:8090"},
+        FakeHttpFactory(None, {}),
+    )
+    s = r.stats()
+    assert s["node_id"] == "me"
+    assert s["replicas"] == 2
+    assert set(s["active_nodes"]) == {"me", "peer"}
+    assert s["node_addresses"] == {"me": "1.1.1.1:8090", "peer": "2.2.2.2:8090"}
+    assert s["forwards"] == 0
+    assert s["forward_failures"] == 0


### PR DESCRIPTION
## Scope

This branch started as opt-in HRW repo sharding and grew into a **cluster-mode hardening bundle** — the sharding work plus six correctness/robustness fixes and one new feature (trigram-assisted regex), all surfaced by exercising every code-search tool against the **Evolution monolith at real scale** (`evolution-global`, ~30.5k files, 14 GB working tree on fsx-ontap NFS) on a multi-pod EKS cluster.

**14 commits / 35 files.** Three logical parts:

1. **HRW repo sharding** (original scope) — see section below.
2. **Six cluster-mode fixes** found during Evo-scale testing.
3. **Trigram-index-assisted regex** — a new substring-safe pre-filter.

> ⚠️ **No CI is configured on this repo, so nothing here was machine-verified.** Verification is the local test suite (**1531 passed**, `ruff` + `mypy` clean) plus the live Evo-scale checks described per-section. Reviewers should weigh that.

---

## Results — before / after (verified at Evo scale)

Mapping the original bottleneck report to what was measured after the fixes on `evolution-global`. Honest about what was a clean win, what was structural, and where the reported number didn't reproduce.

### Concurrency / throughput collapse (fts search — the headline issue)

| | Reported (prod, single node) | Measured now |
|---|---|---|
| Throughput | **~0.5 rps**, 504-storm collapse at ~15 concurrent | **1 node ~12 rps** ceiling · **3 nodes ~20 rps**, **0 collapse / 0 504s** |
| Latency under load | degrades to failure | 1 node p50 231 → 1,227 ms as load rises; **3 nodes p50 639 ms** @ c=16 |

Multipod + admission is the fix: a single node still saturates (~12 rps, climbing latency = the reported symptom), adding nodes raises throughput and halves latency, and nothing 504-collapses.

### Per-tool bottlenecks

| Tool | Reported | Baseline measured | After fix | Note |
|---|---|---|---|---|
| **scip_impact** | — | **48–61 s** | **39 ms** | clean win — scanned *all* repos → scoped + early-out |
| **regex_search** | search collapse | **30 s → 408 timeout** | **200, completes ~13–20 s** | ripgrep + trigram pre-filter; correct (0 false negatives). *Not yet sub-second — see Part 3 caveat.* |
| **browse_directory** | **90 s** | **~59 s** (12.7k sequential calls) | **1 call** (recursive endpoint) | structural — N round-trips → one response |
| **web UI (login/admin)** | 500 | 500 (Starlette 1.x) | **200** | 50 `TemplateResponse` calls migrated |
| **get_branches** | **23 s** | ~11 ms (once activated) | ~11 ms | did **not** reproduce the 23 s |
| **list_files** (one level) | **30 s** | ~5–12 ms | ~5–12 ms | did **not** reproduce; the 30 s was likely recursive → browse fix |
| **scip_context/def/refs** | **31 s** | ~30 ms but **0 results** | ~30 ms | not a latency bug — **Evo has no SCIP index** (opt-in, never enabled) |
| query_semantic | — | 368 ms hot / 1.46 s cold | 368 ms | already fine |

**Caveats:** three reported numbers (`get_branches` 23 s, `list_files` 30 s, `scip_context` 31 s) did not reproduce at magnitude — the test cluster has faster local NVMe + warm caches than the contended prod box, and Evo has no SCIP index (fast-but-empty, not slow). Flagged rather than claimed as wins. The two biggest real regressions — **scip_impact (48 s → 39 ms)** and **the fts throughput collapse (0.5 → 20 rps, no 504s)** — are clean, large, verified wins.

---

## Part 2 — Cluster-mode fixes (Evo-scale testing)

Each is independently useful; each has unit tests.

1. **`regex_search` 30 s timeout → ripgrep missing from the image.** `RegexSearchService` prefers `rg` but silently fell back to a linear `grep -r` over the whole working tree; on a 14 GB NFS tree that always hit the timeout. Install `ripgrep` in the runtime image (own layer, cache-friendly) + warn-once on the grep fallback. *(The residual NFS-scan cost is addressed by Part 3.)*
2. **`scip_impact` 48–61 s → unscoped scan.** `analyze_impact` ignored the `project` arg and scanned **every** golden repo's `.scip.db` twice with a depth-N CTE, even for repos with no SCIP index. Scope to `find_scip_files(project)` with an empty early-out, point the composite at the repo's own `.code-indexer/scip`, and skip the BFS when the symbol has no definition. Live: **48 s → 39 ms**.
3. **Web UI fully down (login/admin 500) → Starlette 1.x.** Starlette 1.x dropped the old-style `TemplateResponse(name, context)`; 50 call sites passed the context dict where the template name is now expected → `TypeError: unhashable type: 'dict'` on every HTML page. Migrated all 50 to `TemplateResponse(request, name, context)` (valid on both Starlette 0.x and 1.x). Live: `/login` → 200.
4. **Recursive repo listing.** `GET /api/repos/{alias}/files` was one level per call — a full tree of a 12.7k-dir repo took ~59 s (thousands of round-trips). Added `recursive`/`max_depth`/`limit` for a single depth-bounded response.
5. **Cluster activated-repo locality guard.** In multi-pod mode a per-user repo activated on one pod is invisible to the others when `activated-repos` sits on pod-local disk (only `golden-repos` mounted on shared RWX) → browse/branch/content 404 on ~(N−1)/N of requests. The code already routes to shared storage; added a **startup guard** that warns loudly when the two dirs are on different filesystems (a deployment-mount misconfig). *(HRW-forwarding was deliberately **not** used here — ownership is for global-repo index caches, not activation location.)*
6. **Credential masking in repo URLs.** Golden-repo clone URLs embed an OAuth PAT and were returned verbatim by the listing endpoint and `GoldenRepo.to_dict`. Added `mask_url_credentials()` applied at both. *(The exposed Evolution PAT should be rotated operationally.)*

---

## Part 3 — Trigram-index-assisted regex

`/api/regex/search` scans the whole working tree with ripgrep; on a large NFS-backed repo that is I/O-bound (~18–32 s) and tips over the 30 s timeout. The Tantivy FTS index is **token-based** and cannot serve arbitrary substring/regex safely (proven: a token like `Authenticator` matches, but a mid-token substring `uthenticato` returns 0). So this adds a **substring-safe trigram index**.

- **`regex_trigram.extract_required_trigrams`** — derives the trigrams every match *must* contain (a **necessary** condition); returns `None` (→ full scan) when it cannot prove one (alternation, groups, short/wildcard patterns). It never narrows unsafely.
- **`TrigramIndexManager`** — SQLite `trigram → files` index at `.code-indexer/trigram_index/`; unindexable files (binary/large) are recorded as **always-candidates** so matches in them are never missed. Memory-frugal build (periodic-commit + `fsync`, disk temp store, bounded cache).
- **`RegexSearchService`** — when the index exists, ripgrep searches only the candidate files (full regex fidelity preserved); otherwise a full scan. A document-frequency table lets the query drop non-discriminating common trigrams.
- **Build integration** — built at index time in `refresh_scheduler`, right after `cidx index --fts`.

**Correctness — rigorously enforced, and the whole point:** a necessary-condition property test in `test_regex_trigram`, and `test_regex_search_trigram_prefilter` asserts results are **identical with and without the index** across literal / regex / partial-token / alternation / no-match patterns (ripgrep filters the superset). Live Evo-scale verification against a ground-truth full `rg` scan: **0 false negatives** on `class\s+\w*Authenticator` (5=5), `public\s+enum\s+\w+` (574=574), `synchronized\s+\w+\s+get` (62=62).

> ⚠️ **Honest perf caveat: this is ~2–3× (a 30 s timeout now *completes* in ~13–20 s), NOT sub-second.** File-level trigram intersection yields several thousand candidates because large Java files contain every one of these trigrams *scattered* (not contiguously) — an inherent property of file-level trigram indexing. Getting to sub-second needs covering-index / compressed-posting-list work (rarest-first intersection) or bounding indexed file size. **Tracked as a follow-up**; the value shipped here is *correctness + no-more-timeouts*, not a finished speed win.

Memory: the first build OOM-killed the 3 GiB pod; the frugal build now peaks at **~44 MB** for all 30,526 files (~157 s, ~625 MB db).

---

## Part 1 — HRW repo sharding (original scope)

### What
Opt-in **HRW (rendezvous-hash) repo sharding** for cluster mode. Today's cluster mode is symmetric — every pod may cache every repo, so per-pod index-cache memory grows with the *total* repo count and adding replicas doesn't help. This adds a fail-open sharding layer so each pod caches/serves only the repos it **owns**, bounding per-pod memory when the working set exceeds one pod's RAM (the dimension symmetric replicas can't scale).

### How
- **`shard_ownership`** — deterministic HRW ownership over the live node set (from `node_heartbeat.get_active_nodes`). No coordination; every node computes the same owners. Fail-open (owns-everything) on any error / single-node.
- **`shard_router`** — when a single-repo query lands on a non-owner, forward it to an owner pod (which has the index hot) and return that response. Loop-guarded; fails open to local serving.
- **`shard_prewarm`** — best-effort warming of newly-owned repos after a membership change.
- **Cache gating** — `SemanticQueryManager` / `MultiSearchService` only populate the shared HNSW cache for owned repos (`_owns_for_cache`); non-owned repos load-and-discard.
- **`node_heartbeat`** — records `hostname`/`port` (from `POD_IP`/`CIDX_PORT`) + `get_node_addresses()` so the router can reach owner pods.
- **Config** — `cluster.sharding_enabled` (default **off**) and `cluster.shard_replicas` (default **1** — each repo on exactly one node; raise for owner redundancy on larger clusters).

### Safety
Entirely **opt-in and fail-open**: with `sharding_enabled=false` (default) behavior is byte-for-byte unchanged — no `shard_router` on `app.state`, `_owns_for_cache` returns cache-everything, queries serve locally. Any wiring/routing error degrades to today's symmetric behavior.

### Validation
- Unit tests for HRW ownership, router targeting, prewarm, cache gating, config, and the replicas semantics.
- **Live on a 2/3-replica EKS cluster** (Postgres/Aurora-backed registry + shared RWX storage): deterministic ownership agreement across pods, routable pod addresses, `target_for` -> owner, pod-to-pod reachability, and an **end-to-end cross-pod forward returning real semantic results**.

### Note
`shard_replicas` defaults to 1 deliberately: an earlier hardcoded `replicas=2` made every node own every repo on <=2-node clusters (silent no-op). Requires `shard_replicas < node count` to shard.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
