### PR TITLE
fix(EVO-64244): HNSW cache — no negative-cache of missing index + invalidate on rebuild

### DIFF
--- a/src/code_indexer/server/cache/hnsw_index_cache.py
+++ b/src/code_indexer/server/cache/hnsw_index_cache.py
@@ -255,6 +255,10 @@ class HNSWIndexCacheEntry:
     last_accessed: datetime = field(default_factory=datetime.now)
     access_count: int = 0
     index_size_bytes: int = 0
+    # EVO-64244 Facet 2: st_mtime of hnsw_index.bin captured at load time.
+    # None when the index_file path was not supplied (mtime check disabled),
+    # letting a later on-disk rebuild invalidate this stale in-RAM entry.
+    index_file_mtime: Optional[float] = None
 
     def record_access(self) -> None:
         """
@@ -373,6 +377,7 @@ class HNSWIndexCache:
         self,
         repo_path: str,
         loader: Callable[[], Tuple[Any, Dict[int, str]]],
+        index_file: Optional[Path] = None,
     ) -> Tuple[Any, Dict[int, str]]:
         """
         Get cached HNSW index or load if not cached (AC1: Cache Implementation).
@@ -383,10 +388,21 @@ class HNSWIndexCache:
         - AC3: Access refreshes TTL
         - AC5: Thread-safe operations with deduplication
 
+        EVO-64244: a loader that returns (None, id_mapping) — because
+        hnsw_index.bin does not exist yet (repo mid-(re)index) — is never
+        cached, so a later query re-runs the loader and picks up the built
+        index without waiting for TTL/restart. When index_file is provided,
+        a cache HIT is also invalidated if the on-disk index was rebuilt
+        (newer mtime), since hnswlib has no in-place reload.
+
         Args:
             repo_path: Repository path (cache key)
             loader: Function to load index if not cached
                     Returns (hnsw_index, id_mapping)
+            index_file: Optional path to hnsw_index.bin. When supplied, its
+                    st_mtime is stored on load and re-checked on every HIT so a
+                    rebuilt index invalidates the stale in-RAM object. Default
+                    None preserves the original behavior (no mtime check).
 
         Returns:
             Tuple of (hnsw_index, id_mapping)
@@ -416,6 +432,31 @@ class HNSWIndexCache:
                         # Evict expired entry and fall through to load
                         logger.debug(
                             f"Cache entry expired for {repo_path}, reloading",
+                            extra={"correlation_id": get_correlation_id()},
+                        )
+                        del self._cache[repo_path]
+                        self._eviction_count += 1
+                        # Fall through (no return here)
+                    elif entry.hnsw_index is None:
+                        # EVO-64244 Facet 1: never serve a negatively-cached
+                        # (None) index. If one somehow exists, treat it as a
+                        # miss so the loader re-runs and picks up a now-built
+                        # index rather than returning None for the full TTL.
+                        logger.debug(
+                            f"Cache entry for {repo_path} holds a None index, reloading",
+                            extra={"correlation_id": get_correlation_id()},
+                        )
+                        del self._cache[repo_path]
+                        self._eviction_count += 1
+                        # Fall through (no return here)
+                    elif index_file is not None and self._index_file_is_newer(
+                        index_file, entry.index_file_mtime
+                    ):
+                        # EVO-64244 Facet 2: the on-disk index was rebuilt after
+                        # this entry was cached (atomic replace bumps mtime).
+                        # hnswlib has no in-place reload, so evict and reload.
+                        logger.debug(
+                            f"On-disk index newer than cached entry for {repo_path}, reloading",
                             extra={"correlation_id": get_correlation_id()},
                         )
                         del self._cache[repo_path]
@@ -463,6 +504,19 @@ class HNSWIndexCache:
         try:
             hnsw_index, id_mapping = loader()
 
+            # EVO-64244 Facet 1: never negatively-cache a missing index.
+            # load_index() returns None when hnsw_index.bin does not exist yet
+            # (e.g. a repo mid-(re)index). Caching that None would serve
+            # "index not found" for the full TTL even after the graph is built.
+            # Return it directly WITHOUT storing an entry; the finally block
+            # still releases the sentinel/Event so waiters re-run the loader.
+            if hnsw_index is None:
+                logger.debug(
+                    f"Loader returned no HNSW index for {repo_path}, not caching",
+                    extra={"correlation_id": get_correlation_id()},
+                )
+                return None, id_mapping
+
             # Capture real index memory footprint.
             # Bug #881 Phase 4: also add sys.getsizeof(id_mapping) so the cache
             # size cap accounts for the Python dict held alongside the native index.
@@ -476,6 +530,20 @@ class HNSWIndexCache:
                 )
             index_size_bytes += sys.getsizeof(id_mapping)
 
+            # EVO-64244 Facet 2: capture the on-disk index mtime so a later
+            # rebuild (atomic replace of hnsw_index.bin) invalidates this entry
+            # on the next HIT. Guarded: a missing file / OSError leaves it None
+            # (mtime check simply disabled for this entry) rather than crashing.
+            index_file_mtime: Optional[float] = None
+            if index_file is not None:
+                try:
+                    index_file_mtime = os.stat(index_file).st_mtime
+                except OSError as e:
+                    logger.debug(
+                        f"Could not stat index file {index_file} for mtime tracking: {e}",
+                        extra={"correlation_id": get_correlation_id()},
+                    )
+
             # Store result in cache (acquire lock for dict write)
             with self._cache_lock:
                 entry = HNSWIndexCacheEntry(
@@ -484,6 +552,7 @@ class HNSWIndexCache:
                     repo_path=repo_path,
                     ttl_minutes=self.config.ttl_minutes,
                     index_size_bytes=index_size_bytes,
+                    index_file_mtime=index_file_mtime,
                 )
                 entry.record_access()
                 self._cache[repo_path] = entry
@@ -503,6 +572,34 @@ class HNSWIndexCache:
             with self._cache_lock:
                 self._loading.pop(repo_path, None)
             event.set()  # Wake ALL waiters (outside lock)
+
+    def _index_file_is_newer(
+        self, index_file: Path, cached_mtime: Optional[float]
+    ) -> bool:
+        """Return True if the on-disk index file is newer than the cached entry.
+
+        Used by get_or_load (EVO-64244 Facet 2) to detect a rebuilt index and
+        invalidate the stale in-RAM object. A None cached_mtime (entry stored
+        without mtime tracking) or any stat failure (missing file, OSError)
+        returns False so the cached entry is still served rather than crashing.
+
+        Args:
+            index_file: Path to hnsw_index.bin on disk.
+            cached_mtime: st_mtime captured when the entry was loaded, or None.
+
+        Returns:
+            True if the file's current mtime is strictly newer than cached_mtime.
+        """
+        if cached_mtime is None:
+            return False
+        try:
+            return os.stat(index_file).st_mtime > cached_mtime
+        except OSError as e:
+            logger.debug(
+                f"Could not stat index file {index_file} for staleness check: {e}",
+                extra={"correlation_id": get_correlation_id()},
+            )
+            return False
 
     def invalidate(self, repo_path: str) -> None:
         """

--- a/src/code_indexer/storage/filesystem_vector_store.py
+++ b/src/code_indexer/storage/filesystem_vector_store.py
@@ -2716,9 +2716,14 @@ class FilesystemVectorStore:
                     id_mapping = hnsw_manager._load_id_mapping(collection_path)
                     return index, id_mapping
 
-                # Get or load from cache
+                # Get or load from cache.
+                # EVO-64244 Facet 2: pass the concrete hnsw_index.bin path so a
+                # rebuilt index (atomic replace on re-index) invalidates the
+                # stale in-RAM cache entry instead of being served for the TTL.
                 hnsw_index, _cached_id_mapping = self.hnsw_index_cache.get_or_load(
-                    cache_key, hnsw_loader
+                    cache_key,
+                    hnsw_loader,
+                    index_file=collection_path / hnsw_manager.INDEX_FILENAME,
                 )
             else:
                 # No cache - load directly (original behavior).

--- a/tests/unit/server/cache/test_hnsw_negative_cache_evo64244.py
+++ b/tests/unit/server/cache/test_hnsw_negative_cache_evo64244.py
@@ -1,0 +1,167 @@
+"""
+Tests for EVO-64244: HNSWIndexCache must not negatively-cache a missing index.
+
+Facet 1 (critical): a loader that returns (None, id_mapping) because
+hnsw_index.bin does not exist yet must NOT be stored in the cache. A later
+query whose loader now returns a real index must pick it up immediately,
+without waiting for the TTL to expire or the pod to restart.
+
+Facet 2: a successfully-cached real index goes stale when the repo is
+re-indexed (hnsw_index.bin is atomically replaced). When get_or_load is
+given the index_file path, a newer on-disk mtime on a cache HIT must
+invalidate the stale in-RAM object and reload.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from code_indexer.server.cache.hnsw_index_cache import (
+    HNSWIndexCache,
+    HNSWIndexCacheConfig,
+)
+
+
+class TestHNSWNegativeCacheEVO64244(unittest.TestCase):
+    """get_or_load must never serve a negatively-cached (None) index."""
+
+    def setUp(self) -> None:
+        config = HNSWIndexCacheConfig(ttl_minutes=10.0, cleanup_interval_seconds=60)
+        self.cache = HNSWIndexCache(config=config)
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.repo_path = str(Path(self.tmpdir.name) / "collection")
+
+    def tearDown(self) -> None:
+        self.cache.stop_background_cleanup()
+        self.tmpdir.cleanup()
+
+    def _real_index(self, size: int = 1000) -> MagicMock:
+        index = MagicMock()
+        index.index_file_size.return_value = size
+        return index
+
+    def test_none_index_not_cached_then_real_index_served(self) -> None:
+        """A loader returning (None, ...) is not cached; the next call reloads.
+
+        Facet 1: first the index is missing (loader -> None); nothing is
+        cached. On the second call the graph is built (loader -> real index)
+        and it is returned immediately, proving the None was never cached.
+        """
+        calls = {"n": 0}
+        real_index = self._real_index()
+
+        def loader():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return None, {0: "v0"}
+            return real_index, {0: "v0"}
+
+        idx, mapping = self.cache.get_or_load(self.repo_path, loader)
+        self.assertIsNone(idx)
+        self.assertEqual(mapping, {0: "v0"})
+        # The None result must NOT have been stored.
+        self.assertEqual(self.cache.get_stats().cached_repositories, 0)
+
+        # Index is now built: a second call re-runs the loader and serves it.
+        idx2, _ = self.cache.get_or_load(self.repo_path, loader)
+        self.assertIs(idx2, real_index)
+        self.assertEqual(calls["n"], 2)
+        self.assertEqual(self.cache.get_stats().cached_repositories, 1)
+
+    def test_real_index_cached_and_served_on_hit(self) -> None:
+        """A real index is cached; a second call is served without reloading."""
+        calls = {"n": 0}
+        real_index = self._real_index()
+
+        def loader():
+            calls["n"] += 1
+            return real_index, {0: "v0"}
+
+        idx, _ = self.cache.get_or_load(self.repo_path, loader)
+        idx2, _ = self.cache.get_or_load(self.repo_path, loader)
+        self.assertIs(idx, real_index)
+        self.assertIs(idx2, real_index)
+        self.assertEqual(calls["n"], 1)  # served from cache on the second call
+
+    def test_newer_ondisk_mtime_triggers_reload(self) -> None:
+        """Facet 2: a rebuilt (newer-mtime) on-disk index invalidates the entry."""
+        index_file = Path(self.tmpdir.name) / "hnsw_index.bin"
+        index_file.write_bytes(b"v1")
+        old_time = time.time() - 100
+        os.utime(index_file, (old_time, old_time))
+
+        calls = {"n": 0}
+        index_v1 = self._real_index(1000)
+        index_v2 = self._real_index(2000)
+
+        def loader():
+            calls["n"] += 1
+            return (index_v1 if calls["n"] == 1 else index_v2), {0: "v0"}
+
+        idx1, _ = self.cache.get_or_load(
+            self.repo_path, loader, index_file=index_file
+        )
+        self.assertIs(idx1, index_v1)
+        self.assertEqual(calls["n"], 1)
+
+        # Repo re-indexed: on-disk file is atomically replaced (newer mtime).
+        new_time = time.time() + 100
+        os.utime(index_file, (new_time, new_time))
+
+        idx2, _ = self.cache.get_or_load(
+            self.repo_path, loader, index_file=index_file
+        )
+        self.assertIs(idx2, index_v2)  # stale entry evicted and reloaded
+        self.assertEqual(calls["n"], 2)
+
+    def test_unchanged_mtime_serves_cached_entry(self) -> None:
+        """Facet 2: an unchanged on-disk mtime keeps serving the cached entry."""
+        index_file = Path(self.tmpdir.name) / "hnsw_index.bin"
+        index_file.write_bytes(b"v1")
+
+        calls = {"n": 0}
+        real_index = self._real_index()
+
+        def loader():
+            calls["n"] += 1
+            return real_index, {0: "v0"}
+
+        idx1, _ = self.cache.get_or_load(
+            self.repo_path, loader, index_file=index_file
+        )
+        idx2, _ = self.cache.get_or_load(
+            self.repo_path, loader, index_file=index_file
+        )
+        self.assertIs(idx1, real_index)
+        self.assertIs(idx2, real_index)
+        self.assertEqual(calls["n"], 1)  # no reload when mtime is unchanged
+
+    def test_missing_index_file_does_not_crash_on_hit(self) -> None:
+        """Facet 2: a missing index_file on HIT falls back to the cached entry."""
+        index_file = Path(self.tmpdir.name) / "does_not_exist.bin"
+
+        calls = {"n": 0}
+        real_index = self._real_index()
+
+        def loader():
+            calls["n"] += 1
+            return real_index, {0: "v0"}
+
+        idx1, _ = self.cache.get_or_load(
+            self.repo_path, loader, index_file=index_file
+        )
+        idx2, _ = self.cache.get_or_load(
+            self.repo_path, loader, index_file=index_file
+        )
+        self.assertIs(idx1, real_index)
+        self.assertIs(idx2, real_index)  # served cached, no crash
+        self.assertEqual(calls["n"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes **EVO-64244**. Follow-up to #1339 (the HNSW-cache fix landed on the branch after #1339 merged, so it needs its own PR).

`HNSWIndexCache.get_or_load` returned `HNSW index not found` for up to the 10-min cache TTL (or until a pod restart) after a repo finished (re)indexing, even though `hnsw_index.bin` was on disk.

1. **Negative caching** — a loader returning `(None, id_mapping)` (index not built yet) was cached and served for the full TTL. Now `None` is returned without caching, and a stored `None` is treated as a miss on hit.
2. **Stale after rebuild** — the in-RAM index outlived an on-disk rebuild (hnswlib has no in-place reload, unlike the FTS cache's `tantivy.reload()`). `get_or_load` now takes an optional `index_file`, stores its `st_mtime`, and invalidates the entry on hit when the on-disk mtime is newer. Wired at the sole `FilesystemVectorStore` caller via `collection_path / INDEX_FILENAME`; guarded so a missing file never crashes.

5 new tests; backward compatible (`index_file` defaults `None`); 39 HNSW-cache regression pass; ruff clean.