### PR TITLE
fix(EVO-64222): fail-fast an invalid secondary embedding provider (don't wedge the index)

### DIFF
--- a/src/code_indexer/cli.py
+++ b/src/code_indexer/cli.py
@@ -4207,9 +4207,15 @@ def index(
             console.print(f"\n🔄 Indexing additional provider: {_extra_provider}")
             config.embedding_provider = _extra_provider  # type: ignore[assignment]
             _extra_embedding = EmbeddingProviderFactory.create(config, console)
-            if not _extra_embedding.health_check():
+            # Bug (EVO-64222): use a real authenticating probe (test_api=True)
+            # here rather than the shallow default (test_api=False, which passes
+            # whenever a key is merely present). A secondary provider with an
+            # invalid credential is skipped now, before its doomed pass would
+            # hang the already-complete primary index at ~99% retrying 401s.
+            if not _extra_embedding.health_check(test_api=True):
                 console.print(
-                    f"⚠️  {_extra_provider} health check failed — skipping",
+                    f"⚠️  {_extra_provider} health check failed "
+                    "(check its API credentials) — skipping",
                     style="yellow",
                 )
                 continue
@@ -8507,8 +8513,6 @@ def health(output_json: bool, quiet: bool, index_path: Optional[str]):
             console.print(f"  Min Inbound: {result.min_inbound}")
         if result.max_inbound is not None:
             console.print(f"  Max Inbound: {result.max_inbound}")
-        if result.orphan_count is not None:
-            console.print(f"  Orphan Count: {result.orphan_count}")
 
     # Errors (if any)
     if result.errors:

--- a/src/code_indexer/cli.py
+++ b/src/code_indexer/cli.py
@@ -8513,6 +8513,8 @@ def health(output_json: bool, quiet: bool, index_path: Optional[str]):
             console.print(f"  Min Inbound: {result.min_inbound}")
         if result.max_inbound is not None:
             console.print(f"  Max Inbound: {result.max_inbound}")
+        if result.orphan_count is not None:
+            console.print(f"  Orphan Count: {result.orphan_count}")
 
     # Errors (if any)
     if result.errors:

--- a/src/code_indexer/services/cohere_embedding.py
+++ b/src/code_indexer/services/cohere_embedding.py
@@ -317,6 +317,20 @@ class CohereEmbeddingProvider(EmbeddingProvider):
                 last_error = exc
                 response_obj = getattr(exc, "response", None)
                 status = getattr(response_obj, "status_code", None)
+                if status == HTTPStatus.UNAUTHORIZED:
+                    # Bug (EVO-64222): a 401 is an authentication failure, not a
+                    # transient error — it fails identically on every retry.
+                    # Raise immediately (before any back-off sleep) so a doomed
+                    # secondary-provider pass with an invalid key fails in
+                    # milliseconds per batch instead of sleeping max_retries ×
+                    # exponential backoff for every batch of every file.
+                    latency_ms = (time.time() - _start) * 1000
+                    ProviderHealthMonitor.get_instance().record_call(
+                        "cohere", latency_ms, success=False
+                    )
+                    raise ValueError(
+                        "Invalid Cohere API key. Check CO_API_KEY environment variable."
+                    )
                 if status == 429:
                     if not retry:
                         # Query path: propagate immediately so execute_with_backoff
@@ -364,16 +378,9 @@ class CohereEmbeddingProvider(EmbeddingProvider):
         ProviderHealthMonitor.get_instance().record_call(
             "cohere", latency_ms, success=False
         )
-        if last_error is not None:
-            response_obj = getattr(last_error, "response", None)
-            if (
-                response_obj is not None
-                and getattr(response_obj, "status_code", None)
-                == HTTPStatus.UNAUTHORIZED
-            ):
-                raise ValueError(
-                    "Invalid Cohere API key. Check CO_API_KEY environment variable."
-                )
+        # NOTE: a 401 (HTTPStatus.UNAUTHORIZED) never reaches this fall-through —
+        # it is raised as a ValueError immediately inside the retry loop above
+        # (Bug EVO-64222), so only genuine transient failures land here.
         raise RuntimeError(
             f"Cohere API request failed after {max_attempts} attempts: {last_error}"
         )

--- a/src/code_indexer/services/embedding_provider.py
+++ b/src/code_indexer/services/embedding_provider.py
@@ -99,8 +99,16 @@ class EmbeddingProvider(ABC):
         pass
 
     @abstractmethod
-    def health_check(self) -> bool:
+    def health_check(self, *, test_api: bool = False) -> bool:
         """Check if the embedding provider is healthy and accessible.
+
+        Args:
+            test_api: If False (default), only perform a shallow configuration
+                check (e.g. verify a key/model/endpoint is present). If True,
+                make a real authenticated API call so an invalid credential is
+                detected up front. Concrete providers that cannot distinguish a
+                real auth probe may accept-and-ignore this flag and return their
+                existing health result.
 
         Returns:
             True if provider is healthy, False otherwise

--- a/tests/unit/services/test_cohere_embedding.py
+++ b/tests/unit/services/test_cohere_embedding.py
@@ -455,6 +455,44 @@ class TestCohereErrorHandling401Bug595Issue2:
         assert "CO_API_KEY" in error_msg
         assert "Invalid" in error_msg or "invalid" in error_msg
 
+    def test_401_raises_value_error_immediately_without_retry_sleeps(
+        self, cohere_provider
+    ):
+        """Bug (EVO-64222): a 401 on the indexing path (retry=True) must raise
+        ValueError on the FIRST occurrence — before any back-off sleep — so a
+        doomed pass fails in milliseconds instead of retrying max_retries times.
+        """
+        import time
+        import httpx
+        from unittest.mock import MagicMock
+
+        mock_client_cls = MagicMock()
+        mock_instance = mock_client_cls.return_value
+        http_error = httpx.HTTPStatusError(
+            "401 Unauthorized",
+            request=type("Req", (), {})(),
+            response=type(
+                "Resp", (), {"status_code": 401, "text": "Unauthorized", "headers": {}}
+            )(),
+        )
+        mock_instance.post.side_effect = http_error
+
+        with patch("httpx.Client", mock_client_cls):
+            with patch.object(time, "sleep") as mock_sleep:
+                with pytest.raises(ValueError, match="CO_API_KEY"):
+                    cohere_provider._make_sync_request(["test"], retry=True)
+
+        # Exactly one request — no retry attempts for an auth failure.
+        assert mock_instance.post.call_count == 1, (
+            "401 was retried; it must raise immediately without retrying "
+            f"(post called {mock_instance.post.call_count} times)."
+        )
+        # No back-off sleep was performed.
+        assert mock_sleep.call_count == 0, (
+            "time.sleep was called on a 401; the auth failure must raise "
+            "before any exponential-backoff sleep."
+        )
+
 
 class TestCohereLoadModelSpecsFallbackBug595Issue3:
     """Bug #595 Issue 3: _load_model_specs() has no exception handling.

--- a/tests/unit/test_cli_multi_provider_index.py
+++ b/tests/unit/test_cli_multi_provider_index.py
@@ -4,10 +4,12 @@ Tests verify that:
 - get_embedding_providers() returns single-item list for backward compat repos
 - resolve_api_key() correctly gates which providers get indexed
 - providers missing API keys are skipped
+- a secondary provider whose authenticating health check fails (invalid key) is
+  skipped so the already-complete primary index is not hung at ~99% (EVO-64222)
 """
 
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
 class TestMultiProviderIndexGating:
@@ -93,3 +95,132 @@ class TestMultiProviderIndexGating:
 
         assert any("cohere" in r.message for r in caplog.records)
         assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+
+class TestSecondaryProviderInvalidKeySkipped:
+    """EVO-64222: an additional (secondary) provider whose authenticating
+    health check fails — e.g. an invalid Cohere key that returns 401 — must be
+    SKIPPED at the pre-check so the already-complete primary index finishes
+    instead of hanging at ~99% while the doomed secondary pass retries 401s."""
+
+    def _make_two_provider_index_mocks(self, primary_stats):
+        """Build the patch context managers to drive cli `index` through the
+        additional-providers loop with a voyage-ai primary (healthy) and a
+        cohere secondary whose health_check(test_api=True) returns False.
+
+        Returns (patches_tuple, handles_dict) so the test can both enter the
+        patches and assert against the underlying mocks.
+        """
+        mock_config = MagicMock()
+        mock_config.daemon = None  # disables daemon-delegation branch
+        mock_config.embedding_provider = "voyage-ai"
+        mock_config.codebase_dir = "/fake/codebase"
+        mock_config.get_embedding_providers.return_value = ["voyage-ai", "cohere"]
+        mock_config.vector_store = None
+
+        mock_config_manager = MagicMock()
+        mock_config_manager.load.return_value = mock_config
+
+        # Primary provider: shallow health_check() passes.
+        mock_primary = MagicMock()
+        mock_primary.health_check.return_value = True
+        mock_primary.get_provider_name.return_value = "voyage-ai"
+
+        # Secondary provider: authenticating health_check(test_api=True) fails
+        # (simulates an invalid Cohere key returning 401 on a real probe).
+        mock_secondary = MagicMock()
+        mock_secondary.health_check.return_value = False
+        mock_secondary.get_provider_name.return_value = "cohere"
+
+        mock_backend = MagicMock()
+        mock_backend.health_check.return_value = True
+        mock_backend.get_vector_store_client.return_value = MagicMock()
+
+        mock_smart_indexer = MagicMock()
+        mock_smart_indexer.smart_index.return_value = primary_stats
+        mock_smart_indexer.get_indexing_status.return_value = {
+            "status": "completed",
+            "can_resume": False,
+            "files_processed": primary_stats.files_processed,
+            "chunks_indexed": 0,
+        }
+        mock_smart_indexer.get_git_status.return_value = {
+            "git_available": False,
+            "project_id": "fake-project",
+        }
+        mock_smart_indexer.slot_tracker = None
+
+        create_patch = patch(
+            "code_indexer.cli.EmbeddingProviderFactory.create",
+            side_effect=[mock_primary, mock_secondary],
+        )
+        patches = (
+            # Satisfy the @require_mode("local") gate on `index` — CliRunner runs
+            # in a cwd without an initialized project, which would otherwise fail
+            # the command before the multi-provider loop is reached.
+            patch(
+                "code_indexer.disabled_commands.detect_current_mode",
+                return_value="local",
+            ),
+            patch(
+                "code_indexer.cli.ConfigManager.create_with_backtrack",
+                return_value=mock_config_manager,
+            ),
+            create_patch,
+            patch(
+                "code_indexer.cli.EmbeddingProviderFactory.resolve_api_key",
+                return_value="fake-key",
+            ),
+            patch(
+                "code_indexer.cli.BackendFactory.create",
+                return_value=mock_backend,
+            ),
+            patch(
+                "code_indexer.services.smart_indexer.SmartIndexer",
+                return_value=mock_smart_indexer,
+            ),
+        )
+        handles = {
+            "primary": mock_primary,
+            "secondary": mock_secondary,
+            "smart_indexer": mock_smart_indexer,
+        }
+        return patches, handles
+
+    def test_invalid_secondary_key_is_skipped_and_index_completes(self):
+        """Functional: `cidx index` with a healthy voyage-ai primary and a
+        cohere secondary whose authenticating health check fails must exit 0
+        (primary index intact), probe the secondary with test_api=True, and
+        never run the secondary's smart_index (it is skipped, not hung)."""
+        from click.testing import CliRunner
+
+        from code_indexer.cli import cli
+        from code_indexer.indexing.processor import ProcessingStats
+
+        stats = ProcessingStats(files_processed=5, failed_files=0, cancelled=False)
+        patches, handles = self._make_two_provider_index_mocks(stats)
+        runner = CliRunner()
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+        ):
+            result = runner.invoke(cli, ["index"])
+
+        # Primary index completed — no hang, clean exit.
+        assert result.exit_code == 0, (
+            f"cidx index exited {result.exit_code} (expected 0). An invalid "
+            "secondary key must be skipped, leaving the primary index usable. "
+            f"Output:\n{result.output}"
+        )
+        # The secondary was gated with an authenticating probe (EVO-64222 fix).
+        handles["secondary"].health_check.assert_called_once_with(test_api=True)
+        # Only the primary was actually indexed — the secondary was skipped,
+        # so smart_index ran exactly once (never for the doomed secondary).
+        assert handles["smart_indexer"].smart_index.call_count == 1, (
+            "smart_index ran more than once — the invalid secondary provider "
+            "was NOT skipped before its doomed indexing pass."
+        )


### PR DESCRIPTION
Fixes **EVO-64222** (Evo-scale finding on this fork). An invalid **secondary** embedding provider (Cohere via `CO_API_KEY`) hung the index job at ~99%: the primary (Voyage) index completed, then the additional-providers pass 401'd on every batch and retry-slept (max_retries × exponential backoff) for every batch of every file, with no join timeout (Bug #1218) — an indefinite hang on an already-complete index.

- **(a)** the additional-provider pre-check now uses an auth-validating `health_check(test_api=True)` (vs the shallow default that passes on a merely-present key), so an invalid secondary is **skipped with a warning and the job completes with the primary index usable**. Added the keyword-only `test_api` param to the `EmbeddingProvider` ABC so the generic call is type-safe (Voyage/Cohere already had it).
- **(c)** Cohere `_make_sync_request` classifies HTTP **401 as non-retryable** — raises immediately (no backoff) instead of retrying `max_retries` times. 429 unchanged.
- Did not re-add join timeouts (Bug #1218 removed them deliberately).

2 new tests (invalid-secondary skipped → job completes; 401 non-retryable, single call no sleep). ruff + py_compile clean.