### PR TITLE
fix(EVO-64228): index a golden repo in place when it is already at clone_path

### DIFF
--- a/src/code_indexer/server/repositories/golden_repo_manager.py
+++ b/src/code_indexer/server/repositories/golden_repo_manager.py
@@ -488,7 +488,16 @@ class GoldenRepoManager:
             if not clone_path:
                 return
             try:
-                if os.path.exists(clone_path):
+                if os.path.islink(clone_path):
+                    # EVO-64228: a symlink must be unlinked, never rmtree'd —
+                    # rmtree raises on a symlink and (if followed) could delete
+                    # its target. Unlink removes the stale link cleanly.
+                    os.unlink(clone_path)
+                    logging.info(
+                        "Bug #1218: removed orphaned clone symlink '%s' after registration failure",
+                        clone_path,
+                    )
+                elif os.path.exists(clone_path):
                     shutil.rmtree(clone_path)
                     logging.info(
                         "Bug #1218: removed orphaned clone '%s' after registration failure",
@@ -1411,6 +1420,17 @@ class GoldenRepoManager:
                     )
                 return clone_path
 
+            if os.path.realpath(source_path) == os.path.realpath(clone_path):
+                # EVO-64228: the source has already been materialized at clone_path
+                # (workspace-mcp provisions golden repos directly into golden_repos_dir on
+                # the shared volume), so it is already in place inside golden_repos_dir —
+                # index it as-is instead of copying a directory onto itself.
+                logging.info(
+                    "Golden repo already at clone_path; indexing in place: %s",
+                    clone_path,
+                )
+                return clone_path
+
             # Always use regular copy for golden repository registration
             # This avoids cross-device link issues that occur with CoW cloning
             shutil.copytree(source_path, clone_path, symlinks=True)
@@ -1609,7 +1629,12 @@ class GoldenRepoManager:
             return None  # Directory already removed
 
         try:
-            shutil.rmtree(str(clone_path_obj))
+            if os.path.islink(str(clone_path_obj)):
+                # EVO-64228: a symlink must be unlinked, never rmtree'd — rmtree
+                # raises on a symlink and (if followed) could delete its target.
+                os.unlink(str(clone_path_obj))
+            else:
+                shutil.rmtree(str(clone_path_obj))
             logging.info(f"Successfully cleaned up repository files: {clone_path_obj}")
             return True
         except (PermissionError, OSError) as fs_error:

--- a/src/code_indexer/server/repositories/golden_repo_manager.py
+++ b/src/code_indexer/server/repositories/golden_repo_manager.py
@@ -522,7 +522,14 @@ class GoldenRepoManager:
             try:
                 # Clone repository
                 clone_path = self._clone_repository(repo_url, alias, default_branch)
-                _clone_path_for_cleanup = clone_path
+                # EVO-64228 (review MAJOR): in index-in-place mode clone_path IS
+                # the source the caller materialized directly into
+                # golden_repos_dir on the shared volume -- cidx did NOT create
+                # it. Never register it for failure cleanup, or a later indexing
+                # / activation error would rmtree the caller's (workspace-mcp's)
+                # content. Only track a clone cidx actually made a copy of.
+                if not self._is_in_place_registration(repo_url, clone_path):
+                    _clone_path_for_cleanup = clone_path
 
                 # Bug #699: When no branch was specified, resolve the actual
                 # checked-out branch so metadata always stores a concrete value
@@ -1375,6 +1382,29 @@ class GoldenRepoManager:
             or repo_url.startswith("local://")
         )
 
+    def _is_in_place_registration(self, repo_url: str, clone_path: str) -> bool:
+        """True when repo_url is a local path already materialized AT clone_path.
+
+        In this case the golden repo was provisioned directly into
+        golden_repos_dir/{alias} (e.g. workspace-mcp writing into the shared RWX
+        volume), so cidx must index it IN PLACE (no copy) and must NEVER delete
+        it on failure cleanup -- the content is not cidx's to remove (EVO-64228).
+        Single source of truth for the "same-dir" predicate used by both the
+        copy short-circuit and the worker's cleanup guard.
+        """
+        if not self._is_local_path(repo_url):
+            return False
+        if repo_url.startswith("file://"):
+            source_path = repo_url[len("file://") :]
+        elif repo_url.startswith("local://"):
+            return False  # local:// has no external source to compare
+        else:
+            source_path = repo_url
+        try:
+            return os.path.realpath(source_path) == os.path.realpath(clone_path)
+        except OSError:
+            return False
+
     def _clone_local_repository_with_regular_copy(
         self, repo_url: str, clone_path: str
     ) -> str:
@@ -1420,7 +1450,7 @@ class GoldenRepoManager:
                     )
                 return clone_path
 
-            if os.path.realpath(source_path) == os.path.realpath(clone_path):
+            if self._is_in_place_registration(repo_url, clone_path):
                 # EVO-64228: the source has already been materialized at clone_path
                 # (workspace-mcp provisions golden repos directly into golden_repos_dir on
                 # the shared volume), so it is already in place inside golden_repos_dir —

--- a/tests/unit/server/repositories/test_golden_repo_manager_local_url.py
+++ b/tests/unit/server/repositories/test_golden_repo_manager_local_url.py
@@ -5,9 +5,11 @@ Tests that golden_repo_manager automatically creates target folders for local://
 URLs that point to non-existent paths.
 """
 
+import os
 import tempfile
 import shutil
 from pathlib import Path
+from unittest.mock import patch
 
 from code_indexer.server.repositories.golden_repo_manager import GoldenRepoManager
 
@@ -128,3 +130,114 @@ class TestGoldenRepoManagerLocalURLAutoCreate:
         assert Path(result_path).exists()
         assert (clone_path / "readme.txt").exists()
         assert (clone_path / "readme.txt").read_text() == "source content"
+
+
+class TestGoldenRepoManagerSameDirClone:
+    """Test cases for source == clone_path index-in-place (EVO-64228)."""
+
+    def setup_method(self):
+        """Set up test environment."""
+        self.temp_dirs = []
+
+    def teardown_method(self):
+        """Clean up test directories."""
+        for temp_dir in self.temp_dirs:
+            if temp_dir.exists():
+                shutil.rmtree(temp_dir)
+
+    def _create_temp_dir(self) -> Path:
+        """Create a temporary directory and track it for cleanup."""
+        temp_dir = Path(tempfile.mkdtemp())
+        self.temp_dirs.append(temp_dir)
+        return temp_dir
+
+    def test_source_equals_clone_path_indexes_in_place(self):
+        """
+        EVO-64228: Given a file:// URL whose source resolves to the SAME
+        directory as clone_path (workspace-mcp materialized the golden repo
+        directly into golden_repos_dir), when
+        _clone_local_repository_with_regular_copy runs, then it should return
+        clone_path in place WITHOUT copying a directory onto itself.
+        """
+        # Arrange
+        base_dir = self._create_temp_dir()
+        golden_repos_dir = base_dir / "golden_repos"
+        golden_repos_dir.mkdir()
+
+        # The repo already exists AT clone_path (materialized in place)
+        clone_path = golden_repos_dir / "repos" / "in-place-repo"
+        clone_path.mkdir(parents=True)
+        existing_file = clone_path / "readme.txt"
+        existing_file.write_text("in-place content")
+
+        manager = GoldenRepoManager(str(golden_repos_dir))
+
+        # Act - source IS clone_path (same directory)
+        repo_url = f"file://{clone_path}"
+
+        with patch.object(shutil, "copytree") as mock_copytree:
+            result_path = manager._clone_local_repository_with_regular_copy(
+                repo_url, str(clone_path)
+            )
+
+        # Assert - returns clone_path, never copied onto itself, dir untouched
+        assert result_path == str(clone_path)
+        mock_copytree.assert_not_called()
+        assert clone_path.is_dir()
+        assert (clone_path / "readme.txt").exists()
+        assert (clone_path / "readme.txt").read_text() == "in-place content"
+
+
+class TestGoldenRepoManagerCleanupSymlink:
+    """Test cases for cleanup unlinking symlinks instead of rmtree (EVO-64228)."""
+
+    def setup_method(self):
+        """Set up test environment."""
+        self.temp_dirs = []
+
+    def teardown_method(self):
+        """Clean up test directories."""
+        for temp_dir in self.temp_dirs:
+            if temp_dir.exists():
+                shutil.rmtree(temp_dir)
+
+    def _create_temp_dir(self) -> Path:
+        """Create a temporary directory and track it for cleanup."""
+        temp_dir = Path(tempfile.mkdtemp())
+        self.temp_dirs.append(temp_dir)
+        return temp_dir
+
+    def test_cleanup_failed_clone_unlinks_symlink(self):
+        """
+        EVO-64228: When the failed-clone path is a symlink, cleanup should
+        unlink the symlink itself and leave the symlink's target intact
+        (rmtree would raise on a symlink or delete its target).
+        """
+        # Arrange - a real target directory and a symlink pointing at it
+        base_dir = self._create_temp_dir()
+        golden_repos_dir = base_dir / "golden_repos"
+        golden_repos_dir.mkdir()
+
+        target_dir = base_dir / "real_target"
+        target_dir.mkdir()
+        target_file = target_dir / "keep.txt"
+        target_file.write_text("must survive")
+
+        clone_link = golden_repos_dir / "orphan-link"
+        os.symlink(str(target_dir), str(clone_link))
+        assert os.path.islink(str(clone_link))
+
+        manager = GoldenRepoManager(str(golden_repos_dir))
+
+        # Act - reach the nested _cleanup_failed_clone closure via add_golden_repo
+        # by invoking it directly is not exposed, so exercise the same guarded
+        # cleanup through _cleanup_filesystem which shares the unlink-not-rmtree
+        # behavior for the symlink case.
+        manager._cleanup_filesystem(clone_link)
+
+        # Assert - symlink removed, target and its contents survive
+        assert not os.path.islink(str(clone_link))
+        assert not clone_link.exists()
+        assert target_dir.is_dir()
+        assert target_file.exists()
+        assert target_file.read_text() == "must survive"

--- a/tests/unit/server/repositories/test_golden_repo_manager_local_url.py
+++ b/tests/unit/server/repositories/test_golden_repo_manager_local_url.py
@@ -187,6 +187,58 @@ class TestGoldenRepoManagerSameDirClone:
         assert (clone_path / "readme.txt").exists()
         assert (clone_path / "readme.txt").read_text() == "in-place content"
 
+    def test_in_place_registration_source_not_deleted_on_failure(self):
+        """
+        EVO-64228 (review MAJOR): the background worker registers clone_path for
+        failure cleanup so a partial clone/index gets rmtree'd. In index-in-place
+        mode clone_path IS the caller's source on the shared volume -- cidx did
+        not create it and must NOT delete it. The worker gates that registration
+        on `not _is_in_place_registration(...)`; this asserts the predicate that
+        gate depends on so a later indexing failure cannot destroy the source.
+        """
+        base_dir = self._create_temp_dir()
+        golden_repos_dir = base_dir / "golden_repos"
+        golden_repos_dir.mkdir()
+
+        # Source materialized directly at clone_path (workspace-mcp in-place).
+        clone_path = golden_repos_dir / "repos" / "in-place-repo"
+        clone_path.mkdir(parents=True)
+        (clone_path / "keep.txt").write_text("must survive")
+
+        # A DIFFERENT source dir that cidx really copied FROM (out-of-tree).
+        external_source = base_dir / "external-src"
+        external_source.mkdir()
+
+        manager = GoldenRepoManager(str(golden_repos_dir))
+
+        # In-place: source realpath == clone_path -> guarded (no cleanup).
+        assert (
+            manager._is_in_place_registration(f"file://{clone_path}", str(clone_path))
+            is True
+        )
+        assert (
+            manager._is_in_place_registration(str(clone_path), str(clone_path)) is True
+        )
+
+        # Real copy from an external source -> NOT in place, cleanup allowed.
+        assert (
+            manager._is_in_place_registration(
+                f"file://{external_source}", str(clone_path)
+            )
+            is False
+        )
+        # Remote and local:// scheme have no external source to protect.
+        assert (
+            manager._is_in_place_registration(
+                "https://example.com/x/y.git", str(clone_path)
+            )
+            is False
+        )
+        assert (
+            manager._is_in_place_registration("local://cidx-meta", str(clone_path))
+            is False
+        )
+
 
 class TestGoldenRepoManagerCleanupSymlink:
     """Test cases for cleanup unlinking symlinks instead of rmtree (EVO-64228)."""


### PR DESCRIPTION
## Problem

When a golden repo is provisioned directly into `golden_repos_dir/{alias}` by an external orchestrator (a shared RWX volume, so the registration source **is** `clone_path`), `add_golden_repo` did two harmful things:

1. **Copied a directory onto itself.** `_clone_local_repository_with_regular_copy` ran `copytree(source, clone_path)` even when `realpath(source) == realpath(clone_path)`.
2. **Deleted the caller's content on any failure.** `background_worker` registers the clone path for failure cleanup and `rmtree`s it if indexing or activation later fails. In the in-place case cidx did not create that directory — it is the caller's content on a shared volume — so a routine indexing failure destroyed data cidx never owned.

## Fix

`_is_in_place_registration(repo_url, clone_path)` is the single predicate for "the source is already materialized at clone_path" (`realpath` comparison; `local://` excluded — it has no external source). It drives both call sites:

- the copy short-circuit — index in place instead of copying a directory onto itself, mirroring the existing `local://` use-existing branch;
- the cleanup guard — only a clone cidx actually made a copy of is registered for failure cleanup, so a failed in-place registration leaves the caller's content untouched.

Also: a stale clone that is a **symlink** is now removed with `os.unlink()` rather than `shutil.rmtree()`, which raises on a symlink and could otherwise delete its target.

No security-confinement relaxation and no snapshot change (content is in-tree). The normal `file://` copy path (source != clone_path) is unchanged.

## Verification

Beyond the unit tests, this was exercised against a **real running cidx server** (real repo, real Voyage embeddings, real HNSW build):

- A repo materialized directly into `golden_repos_dir/{alias}` and registered with `repo_url = file://<that same path>` logs `Golden repo already at clone_path; indexing in place` and indexes successfully with no copy.
- When indexing **fails** on that same in-place registration, the caller's files come back bit-identical (same content hash, git history intact).
- Re-running the identical failure with the guard reverted: the directory is `rmtree`d and the content is destroyed — confirming the guard is what prevents the data loss.

## Tests

6 tests pass (`tests/unit/server/repositories/test_golden_repo_manager_local_url.py`); ruff, black, mypy clean.