### PR TITLE
fix(EVO-64245): report partially-built collections as unhealthy

### DIFF
--- a/src/code_indexer/server/services/repository_health_aggregator.py
+++ b/src/code_indexer/server/services/repository_health_aggregator.py
@@ -9,6 +9,10 @@ repository_health.py::get_repository_health and activated_repos.py::get_health:
 - discover_health_collections: scan a `.code-indexer/index` directory for every
   collection subdirectory containing an hnsw_index.bin, classifying its index
   type (semantic/temporal/multimodal).
+- discover_incomplete_collections: scan the same directory for the partially
+  built collections discover_health_collections cannot see -- vector shards on
+  disk but no hnsw_index.bin (EVO-64245). They are reported unhealthy rather
+  than silently skipped, which previously made a broken index look healthy.
 - get_shared_health_service: ONE HNSWHealthService singleton (5-minute TTL)
   shared by both routers, replacing activated_repos.py's previous
   fresh-cache-less-instance-per-request pattern. HNSWHealthService guards its
@@ -102,6 +106,44 @@ def _to_collection_health_result(
     )
 
 
+def _classify_index_type(collection_name: str) -> str:
+    """Classify a collection's index type from its directory name.
+
+    Substring classification, exactly as both routers previously did:
+    "temporal" in name.lower() -> "temporal", "multimodal" in name.lower() ->
+    "multimodal", else "semantic".
+
+    Args:
+        collection_name: Collection directory name (e.g. "voyage-code-3").
+
+    Returns:
+        "temporal", "multimodal", or "semantic".
+    """
+    name_lower = collection_name.lower()
+    if "temporal" in name_lower:
+        return "temporal"
+    if "multimodal" in name_lower:
+        return "multimodal"
+    return "semantic"
+
+
+def collection_has_vector_shards(collection_dir: Path) -> bool:
+    """Return True if the collection holds at least one vector shard.
+
+    Vector shards (``vector_*.json``) are written incrementally during
+    indexing and live in nested subdirectories, so rglob is required. Their
+    presence means indexing populated the collection -- as opposed to a
+    genuinely empty / never-indexed collection directory, which has none.
+
+    Args:
+        collection_dir: Path to a single collection directory.
+
+    Returns:
+        True if any vector_*.json shard exists anywhere under collection_dir.
+    """
+    return next(collection_dir.rglob("vector_*.json"), None) is not None
+
+
 def discover_health_collections(
     index_base_path: Path,
 ) -> List[Tuple[str, str, Path]]:
@@ -112,10 +154,7 @@ def discover_health_collections(
 
     Returns:
         List of (collection_name, index_type, hnsw_file_path) tuples, sorted
-        by collection_name for deterministic ordering. index_type is
-        classified by substring exactly as both routers previously did:
-        "temporal" in name.lower() -> "temporal", "multimodal" in
-        name.lower() -> "multimodal", else "semantic".
+        by collection_name for deterministic ordering.
 
     Raises:
         ValueError: If index_base_path is None.
@@ -135,18 +174,89 @@ def discover_health_collections(
         if not hnsw_file.exists():
             continue
 
-        collection_name = collection_dir.name
-        name_lower = collection_name.lower()
-        if "temporal" in name_lower:
-            index_type = "temporal"
-        elif "multimodal" in name_lower:
-            index_type = "multimodal"
-        else:
-            index_type = "semantic"
-
-        discovered.append((collection_name, index_type, hnsw_file))
+        discovered.append(
+            (
+                collection_dir.name,
+                _classify_index_type(collection_dir.name),
+                hnsw_file,
+            )
+        )
 
     return discovered
+
+
+def discover_incomplete_collections(index_base_path: Path) -> List[Path]:
+    """Scan for collections that hold vector shards but no HNSW graph.
+
+    Such a collection is partially built: indexing wrote the shards but was
+    interrupted (OOM/crash/timeout) before ``hnsw_index.bin`` was renamed into
+    place. It is populated yet permanently unqueryable until rebuilt.
+    discover_health_collections() skips it -- it has no hnsw_index.bin to check
+    -- so on its own the repository reports healthy-with-zero-collections, a
+    false green that hides a broken index.
+
+    A collection directory with neither shards nor a graph is genuinely empty /
+    never indexed and is NOT returned here, so this does not false-alarm.
+
+    Args:
+        index_base_path: Path to `.code-indexer/index` directory.
+
+    Returns:
+        Collection directories with shards but no hnsw_index.bin, sorted by
+        name for deterministic ordering.
+
+    Raises:
+        ValueError: If index_base_path is None.
+    """
+    if index_base_path is None:
+        raise ValueError("index_base_path must not be None")
+
+    if not (index_base_path.exists() and index_base_path.is_dir()):
+        return []
+
+    incomplete: List[Path] = []
+    for collection_dir in sorted(index_base_path.iterdir(), key=lambda p: p.name):
+        if not collection_dir.is_dir():
+            continue
+        if (collection_dir / "hnsw_index.bin").exists():
+            continue
+        if collection_has_vector_shards(collection_dir):
+            incomplete.append(collection_dir)
+
+    return incomplete
+
+
+def build_incomplete_collection_result(
+    collection_dir: Path,
+) -> CollectionHealthResult:
+    """Build the unhealthy result for a partially-built collection.
+
+    There is no graph to load, so every liveness flag is False and the errors
+    list carries the rebuild instruction.
+
+    Args:
+        collection_dir: A collection directory with shards but no HNSW graph.
+
+    Returns:
+        A CollectionHealthResult with valid=False and a clear rebuild reason.
+    """
+    return CollectionHealthResult(
+        collection_name=collection_dir.name,
+        index_type=_classify_index_type(collection_dir.name),
+        valid=False,
+        file_exists=False,
+        readable=False,
+        loadable=False,
+        # No graph exists, so there is nothing to count orphans in -- None
+        # (unknown), not 0 (checked and clean).
+        orphan_count=None,
+        errors=[
+            "Vector shards present but HNSW graph missing (hnsw_index.bin) — "
+            "indexing was interrupted before the graph was built. "
+            "Rebuild needed: cidx index --rebuild-index"
+        ],
+        check_duration_ms=0.0,
+    )
 
 
 # Bug #1394: ONE shared HNSWHealthService instance with the 5-minute TTL
@@ -224,25 +334,36 @@ def compute_repository_health(
         return _empty_repository_health_result(repo_alias)
 
     discovered = discover_health_collections(index_base_path)
-    if not discovered:
+    incomplete = discover_incomplete_collections(index_base_path)
+    if not discovered and not incomplete:
         return _empty_repository_health_result(repo_alias)
-
-    batch_results = check_health_batch(
-        health_service,
-        [str(path) for _name, _index_type, path in discovered],
-        force_refresh=force_refresh,
-        max_workers=max_workers,
-    )
 
     collections: List[CollectionHealthResult] = []
     any_from_cache = False
-    for collection_name, index_type, hnsw_file in discovered:
-        health_result = batch_results[str(hnsw_file)]
-        if health_result.from_cache:
-            any_from_cache = True
-        collections.append(
-            _to_collection_health_result(collection_name, index_type, health_result)
+
+    if discovered:
+        batch_results = check_health_batch(
+            health_service,
+            [str(path) for _name, _index_type, path in discovered],
+            force_refresh=force_refresh,
+            max_workers=max_workers,
         )
+        for collection_name, index_type, hnsw_file in discovered:
+            health_result = batch_results[str(hnsw_file)]
+            if health_result.from_cache:
+                any_from_cache = True
+            collections.append(
+                _to_collection_health_result(collection_name, index_type, health_result)
+            )
+
+    # A partially-built collection has no graph to health-check, so it never
+    # reaches check_health_batch; report it directly as unhealthy instead of
+    # letting it vanish from the result (see discover_incomplete_collections).
+    collections.extend(
+        build_incomplete_collection_result(collection_dir)
+        for collection_dir in incomplete
+    )
+    collections.sort(key=lambda c: c.collection_name)
 
     healthy_count = sum(1 for c in collections if c.valid)
     unhealthy_count = len(collections) - healthy_count

--- a/tests/unit/server/services/test_repository_health_aggregator_incomplete.py
+++ b/tests/unit/server/services/test_repository_health_aggregator_incomplete.py
@@ -1,0 +1,179 @@
+"""
+EVO-64245: a partially-built collection must be reported unhealthy.
+
+Indexing writes ``vector_*.json`` shards incrementally and only renames
+``hnsw_index.bin`` into place at the very end. If it is interrupted in between
+(OOM/crash/timeout), the collection is left populated but permanently
+unqueryable. discover_health_collections() cannot see such a collection -- it
+has no graph to check -- so the repository previously reported
+healthy-with-zero-collections: a false green over a broken index.
+
+A collection directory with neither shards nor a graph is genuinely empty /
+never indexed and must still be skipped, so the fix does not false-alarm.
+
+Real on-disk hnswlib indexes and real shard files -- no mocking.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import hnswlib
+import numpy as np
+
+from code_indexer.server.services.repository_health_aggregator import (
+    build_incomplete_collection_result,
+    collection_has_vector_shards,
+    compute_repository_health,
+    discover_health_collections,
+    discover_incomplete_collections,
+    get_shared_health_service,
+)
+
+DIM = 16
+
+
+def _build_real_index(path: Path, num_elements: int = 20) -> None:
+    """Build and save a small, genuinely valid on-disk HNSW index."""
+    rng = np.random.RandomState(3)
+    vectors = rng.randn(num_elements, DIM).astype(np.float32)
+
+    index = hnswlib.Index(space="l2", dim=DIM)
+    index.init_index(max_elements=num_elements, ef_construction=100, M=8)
+    index.add_items(vectors, np.arange(num_elements))
+    index.save_index(str(path))
+
+
+def _write_shard(collection_dir: Path, *, nested: bool = True) -> Path:
+    """Write one vector shard, nested as real indexing lays them out."""
+    shard_dir = collection_dir / "99" / "66" if nested else collection_dir
+    shard_dir.mkdir(parents=True, exist_ok=True)
+    shard = shard_dir / "vector_b4f6.json"
+    shard.write_text('{"id": "1", "vector": [0.1, 0.2]}')
+    return shard
+
+
+class TestCollectionHasVectorShards:
+    def test_finds_shard_nested_in_subdirectories(self, tmp_path: Path):
+        collection = tmp_path / "voyage-code-3"
+        collection.mkdir()
+        _write_shard(collection, nested=True)
+
+        assert collection_has_vector_shards(collection) is True
+
+    def test_finds_shard_at_top_level(self, tmp_path: Path):
+        collection = tmp_path / "voyage-code-3"
+        collection.mkdir()
+        _write_shard(collection, nested=False)
+
+        assert collection_has_vector_shards(collection) is True
+
+    def test_empty_collection_has_no_shards(self, tmp_path: Path):
+        collection = tmp_path / "voyage-code-3"
+        collection.mkdir()
+
+        assert collection_has_vector_shards(collection) is False
+
+
+class TestDiscoverIncompleteCollections:
+    def test_shards_without_graph_are_incomplete(self, tmp_path: Path):
+        index_base = tmp_path / "index"
+        collection = index_base / "voyage-code-3"
+        collection.mkdir(parents=True)
+        _write_shard(collection)
+
+        assert discover_incomplete_collections(index_base) == [collection]
+        # The graph-based scan cannot see it -- that is the whole problem.
+        assert discover_health_collections(index_base) == []
+
+    def test_complete_collection_is_not_incomplete(self, tmp_path: Path):
+        index_base = tmp_path / "index"
+        collection = index_base / "voyage-code-3"
+        collection.mkdir(parents=True)
+        _write_shard(collection)
+        _build_real_index(collection / "hnsw_index.bin")
+
+        assert discover_incomplete_collections(index_base) == []
+
+    def test_empty_collection_is_not_incomplete(self, tmp_path: Path):
+        index_base = tmp_path / "index"
+        (index_base / "voyage-code-3").mkdir(parents=True)
+
+        assert discover_incomplete_collections(index_base) == []
+
+    def test_missing_index_dir_returns_empty(self, tmp_path: Path):
+        assert discover_incomplete_collections(tmp_path / "nope") == []
+
+
+class TestBuildIncompleteCollectionResult:
+    def test_result_is_unhealthy_and_names_the_rebuild(self, tmp_path: Path):
+        collection = tmp_path / "code-indexer-temporal"
+        collection.mkdir()
+
+        result = build_incomplete_collection_result(collection)
+
+        assert result.collection_name == "code-indexer-temporal"
+        assert result.index_type == "temporal"
+        assert result.valid is False
+        assert result.file_exists is False
+        assert result.readable is False
+        assert result.loadable is False
+        assert any("HNSW graph missing" in err for err in result.errors)
+        assert any("--rebuild-index" in err for err in result.errors)
+
+
+class TestComputeRepositoryHealthWithIncompleteCollection:
+    def test_partial_collection_makes_repository_unhealthy(self, tmp_path: Path):
+        index_base = tmp_path / "index"
+        collection = index_base / "voyage-code-3"
+        collection.mkdir(parents=True)
+        _write_shard(collection)
+
+        result = compute_repository_health(
+            "backend", index_base, get_shared_health_service()
+        )
+
+        assert result.overall_healthy is False
+        assert result.total_collections == 1
+        assert result.healthy_count == 0
+        assert result.unhealthy_count == 1
+        assert result.collections[0].collection_name == "voyage-code-3"
+        assert result.collections[0].valid is False
+        assert any("HNSW graph missing" in err for err in result.collections[0].errors)
+
+    def test_healthy_and_partial_collections_reported_together(self, tmp_path: Path):
+        index_base = tmp_path / "index"
+
+        healthy = index_base / "aaa-healthy"
+        healthy.mkdir(parents=True)
+        _build_real_index(healthy / "hnsw_index.bin")
+
+        partial = index_base / "zzz-partial"
+        partial.mkdir(parents=True)
+        _write_shard(partial)
+
+        result = compute_repository_health(
+            "backend", index_base, get_shared_health_service(), force_refresh=True
+        )
+
+        assert result.total_collections == 2
+        assert result.healthy_count == 1
+        assert result.unhealthy_count == 1
+        assert result.overall_healthy is False
+        # Deterministic ordering is preserved across both discovery sources.
+        assert [c.collection_name for c in result.collections] == [
+            "aaa-healthy",
+            "zzz-partial",
+        ]
+
+    def test_empty_collection_still_reports_healthy(self, tmp_path: Path):
+        index_base = tmp_path / "index"
+        (index_base / "voyage-code-3").mkdir(parents=True)
+
+        result = compute_repository_health(
+            "backend", index_base, get_shared_health_service()
+        )
+
+        assert result.overall_healthy is True
+        assert result.total_collections == 0
+        assert result.collections == []


### PR DESCRIPTION
## Problem

Indexing writes `vector_*.json` shards incrementally and only renames `hnsw_index.bin` into place at the very end. If it is interrupted in between (OOM, crash, or a timeout during an HNSW rebuild), the collection is left **populated but permanently unqueryable** until rebuilt.

`discover_health_collections()` cannot see such a collection — it scans for `hnsw_index.bin`, which is precisely the file that is missing. So `compute_repository_health()` discovered zero collections and returned the empty, `overall_healthy=True` result: **a repository with a broken index reported healthy**, on both the `repository_health` and `activated_repos` surfaces.

## Fix

`discover_incomplete_collections()` finds collection directories that have vector shards but no HNSW graph (`rglob` — real indexing nests shards several levels deep). `compute_repository_health()` now reports them through `build_incomplete_collection_result()`, which marks them `valid=False` and names the remedy:

> Vector shards present but HNSW graph missing (hnsw_index.bin) — indexing was interrupted before the graph was built. Rebuild needed: `cidx index --rebuild-index`

Fixing this in the shared aggregator (rather than in one router) covers both endpoints at once.

A collection directory with **neither** shards nor a graph is genuinely empty / never indexed and is still skipped, so this does not false-alarm.

The index-type classification is extracted to `_classify_index_type()` so the new result builder reuses it instead of duplicating the substring rules. `orphan_count` is explicitly `None` (unknown — there is no graph to count orphans in), not `0` (checked and clean).

## Verification

Against a **real running cidx server** with a genuinely indexed repo (real Voyage embeddings, real HNSW graph):

- Baseline: `overall_healthy: true`, 1 valid collection.
- Delete `hnsw_index.bin`, leave the shards (an interrupted rebuild): `overall_healthy: false`, `unhealthy_count: 1`, with the rebuild error above.
- Same state with the fix reverted: `overall_healthy: true, total_collections: 0` — the false green this fixes.
- A genuinely empty collection still reports healthy with zero collections.

## Tests

11 new tests (real on-disk hnswlib indexes and real shard files, no mocking). All 32 existing repository-health tests still pass; the full `tests/unit/server/routers/` suite goes from 651 to 675 passing with no new failures (3 failures on that suite are pre-existing on `development` and unrelated: provider-health and debug route registration).