### PR TITLE
fix(EVO-64385): register a global-repo refresh once, not twice (cluster refresh was 100% broken)

### DIFF
--- a/src/code_indexer/global_repos/refresh_scheduler.py
+++ b/src/code_indexer/global_repos/refresh_scheduler.py
@@ -1610,9 +1610,19 @@ class RefreshScheduler:
 
         # Story #482 PATH C: Use a named function (not a lambda) so
         # BackgroundJobManager can detect and inject progress_callback.
+        #
+        # EVO-64385: tracked_by_caller=True — submit_job() below claims
+        # (global_repo_refresh, alias_name) in the job tracker (Bug #1065), and
+        # that row holds the idx_active_job_per_repo slot for the whole run. The
+        # worker must NOT register a second job for the same pair or it collides
+        # with its own parent row and the refresh is marked failed before it
+        # starts.
         def _refresh_worker(progress_callback=None):
             return self._execute_refresh(
-                alias_name, force_reset=force_reset, progress_callback=progress_callback
+                alias_name,
+                force_reset=force_reset,
+                progress_callback=progress_callback,
+                tracked_by_caller=True,
             )
 
         job_id: str = self.background_job_manager.submit_job(
@@ -1637,7 +1647,11 @@ class RefreshScheduler:
         self._execute_refresh(alias_name)
 
     def _execute_refresh(
-        self, alias_name: str, force_reset: bool = False, progress_callback=None
+        self,
+        alias_name: str,
+        force_reset: bool = False,
+        progress_callback=None,
+        tracked_by_caller: bool = False,
     ) -> Dict[str, Any]:
         """
         Execute refresh for a repository (called by BackgroundJobManager).
@@ -1657,6 +1671,11 @@ class RefreshScheduler:
             force_reset: When True, skip change detection and call
                 updater.update(force_reset=True) to force-reset the repo to the
                 remote branch before indexing (Story #272 AC3/AC4).
+            tracked_by_caller: True when this refresh already runs under a
+                BackgroundJobManager job, whose submit_job() has ALREADY claimed
+                (global_repo_refresh, alias_name) in the job tracker. Registering
+                again here would insert a SECOND active row for the same pair --
+                see the EVO-64385 note below.
 
         Returns:
             Dict with success status and details for BackgroundJobManager tracking
@@ -1667,15 +1686,31 @@ class RefreshScheduler:
         # Bug #935: Register in-flight refresh with JobTracker so drain-status
         # sees it and the auto-updater waits before restarting.
         # Guard with is not None — CLI mode has no tracker.
+        #
+        # EVO-64385: ...but ONLY when nobody has registered us already. When this
+        # refresh runs under a BackgroundJobManager job, submit_job() (Bug #1065)
+        # has already called register_job_if_no_conflict() for the SAME
+        # (operation_type="global_repo_refresh", repo_alias=alias_name) pair, and
+        # that row occupies the idx_active_job_per_repo partial unique index. A
+        # second registration here collides with our own parent row: postgres
+        # raises 23505, the raw error escapes this function, and
+        # BackgroundJobManager marks the whole refresh FAILED -- so the refresh
+        # never runs at all (observed in cluster mode: every scheduled refresh
+        # failed and last_refresh froze for days). The outer job IS the
+        # cluster-visible active job Bug #935 wanted drain-status to see, so let
+        # it own the registration AND the complete/fail lifecycle below.
         _tracker_job_id = f"refresh-{alias_name}"
-        if self._job_tracker is not None:
-            self._job_tracker.register_job(
+        # The tracker WE own: None in CLI mode (no tracker at all) and None when
+        # the caller already registered this refresh (tracked_by_caller).
+        _tracker = None if tracked_by_caller else self._job_tracker
+        if _tracker is not None:
+            _tracker.register_job(
                 _tracker_job_id,
                 operation_type="global_repo_refresh",
                 username="system",
                 repo_alias=alias_name,
             )
-            self._job_tracker.update_status(_tracker_job_id, status="running")
+            _tracker.update_status(_tracker_job_id, status="running")
 
         # Bug #935: track whether the refresh raised so the finally block can
         # call fail_job (raised) vs complete_job (all normal exits incl. early returns).
@@ -2319,14 +2354,18 @@ class RefreshScheduler:
 
         finally:
             # Bug #935: always unregister from JobTracker (finally runs on return AND raise).
-            if self._job_tracker is not None:
+            # EVO-64385: only for the job WE registered. When tracked_by_caller,
+            # `refresh-{alias}` was never inserted by us and the outer
+            # BackgroundJobManager job owns its own completion -- completing or
+            # failing it here would touch a job that is not ours.
+            if _tracker is not None:
                 if _tracker_raised:
-                    self._job_tracker.fail_job(
+                    _tracker.fail_job(
                         _tracker_job_id,
                         error=f"refresh failed for {alias_name}",
                     )
                 else:
-                    self._job_tracker.complete_job(_tracker_job_id)
+                    _tracker.complete_job(_tracker_job_id)
 
     def _index_source(
         self,

--- a/tests/unit/global_repos/test_refresh_scheduler_background_jobs.py
+++ b/tests/unit/global_repos/test_refresh_scheduler_background_jobs.py
@@ -176,9 +176,14 @@ class TestRefreshSchedulerBackgroundJobManagerIntegration:
             # Execute the lambda
             submitted_func()
 
-            # Verify _execute_refresh was called with correct alias
+            # Verify _execute_refresh was called with correct alias.
+            # EVO-64385: the worker runs under the job submit_job already claimed,
+            # so it must tell _execute_refresh not to register a second one.
             mock_execute.assert_called_once_with(
-                "test-repo-global", force_reset=False, progress_callback=None
+                "test-repo-global",
+                force_reset=False,
+                progress_callback=None,
+                tracked_by_caller=True,
             )
 
     def test_execute_refresh_raises_exception_on_timeout(

--- a/tests/unit/global_repos/test_refresh_scheduler_double_registration_64385.py
+++ b/tests/unit/global_repos/test_refresh_scheduler_double_registration_64385.py
@@ -1,0 +1,181 @@
+"""
+EVO-64385: one logical refresh must claim the active-job slot exactly ONCE.
+
+In cluster (postgres) mode, scheduled global-repo refresh was failing on EVERY
+run -- last_refresh had been frozen since 2026-07-10 on the test cluster -- with:
+
+    duplicate key value violates unique constraint "idx_active_job_per_repo"
+    DETAIL: Key (operation_type, repo_alias)=(global_repo_refresh, click-global)
+            already exists.
+
+The duplicate is the job's OWN parent row. Two guards, added by two different
+bugs, overlap:
+
+  1. BackgroundJobManager.submit_job() (Bug #1065) calls
+     register_job_if_no_conflict(job_id=<uuid>, "global_repo_refresh", <alias>),
+     which INSERTs the row that occupies the idx_active_job_per_repo slot.
+  2. The worker then runs _execute_refresh(), which (Bug #935) registers a
+     SECOND JobTracker job ("refresh-<alias>") for the SAME
+     (operation_type, repo_alias) pair -- and collides with row 1.
+
+The partial unique index rejects the second insert, the raw DB error escapes
+_execute_refresh(), and BackgroundJobManager marks the job FAILED. The refresh
+work never runs at all.
+
+Fix: the outer submit_job row IS the cluster-visible active job that Bug #935
+wanted drain-status to see, so a refresh running under a BackgroundJobManager
+job must not register its own tracker job (nor complete/fail it -- that is the
+outer job's lifecycle). A refresh invoked DIRECTLY (CLI, refresh_repo(),
+exit_write_mode) has no outer job and must still register, exactly as before.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from code_indexer.config import ConfigManager
+from code_indexer.global_repos.cleanup_manager import CleanupManager
+from code_indexer.global_repos.query_tracker import QueryTracker
+from code_indexer.global_repos.refresh_scheduler import RefreshScheduler
+
+
+@pytest.fixture
+def golden_repos_dir(tmp_path):
+    d = tmp_path / ".code-indexer" / "golden_repos"
+    d.mkdir(parents=True)
+    return d
+
+
+def _make_scheduler(tmp_path, golden_repos_dir, background_job_manager=None):
+    query_tracker = QueryTracker()
+    return RefreshScheduler(
+        golden_repos_dir=str(golden_repos_dir),
+        config_source=ConfigManager(tmp_path / ".code-indexer" / "config.json"),
+        query_tracker=query_tracker,
+        cleanup_manager=CleanupManager(query_tracker),
+        job_tracker=MagicMock(),
+        background_job_manager=background_job_manager,
+    )
+
+
+class _FakeBackgroundJobManager:
+    """Stands in for BackgroundJobManager: claims the slot, then runs the worker.
+
+    submit_job() is where the FIRST (and only legitimate) registration of
+    (global_repo_refresh, alias) happens -- mirroring Bug #1065's atomic claim.
+    """
+
+    def __init__(self, job_tracker):
+        self._job_tracker = job_tracker
+        self.claimed = []
+
+    def submit_job(self, operation_type, func, repo_alias=None, **kwargs):
+        # The atomic claim that takes the idx_active_job_per_repo slot.
+        self.claimed.append((operation_type, repo_alias))
+        self._job_tracker.register_job_if_no_conflict(
+            job_id="job-uuid-1",
+            operation_type=operation_type,
+            username="system",
+            repo_alias=repo_alias,
+        )
+        func()  # run the worker inline, as the real manager's thread would
+        return "job-uuid-1"
+
+
+class TestRefreshUnderAnOuterJobRegistersOnlyOnce:
+    def test_worker_does_not_register_a_second_tracker_job(
+        self, tmp_path, golden_repos_dir
+    ):
+        """The submit_job claim already owns the slot; the worker must not re-claim it."""
+        tracker = MagicMock()
+        mgr = _FakeBackgroundJobManager(tracker)
+        scheduler = _make_scheduler(
+            tmp_path, golden_repos_dir, background_job_manager=mgr
+        )
+        scheduler._job_tracker = tracker
+
+        with patch.object(scheduler.alias_manager, "read_alias", return_value=None):
+            scheduler._submit_refresh_job("click-global")
+
+        # submit_job claimed the slot exactly once...
+        assert mgr.claimed == [("global_repo_refresh", "click-global")]
+        assert tracker.register_job_if_no_conflict.call_count == 1
+        # ...and the worker did NOT insert a second row for the same pair.
+        tracker.register_job.assert_not_called()
+
+    def test_worker_leaves_job_lifecycle_to_the_outer_job(
+        self, tmp_path, golden_repos_dir
+    ):
+        """complete_job/fail_job on 'refresh-<alias>' belong to the outer job, not us."""
+        tracker = MagicMock()
+        mgr = _FakeBackgroundJobManager(tracker)
+        scheduler = _make_scheduler(
+            tmp_path, golden_repos_dir, background_job_manager=mgr
+        )
+        scheduler._job_tracker = tracker
+
+        with patch.object(scheduler.alias_manager, "read_alias", return_value=None):
+            scheduler._submit_refresh_job("click-global")
+
+        tracker.complete_job.assert_not_called()
+        tracker.fail_job.assert_not_called()
+        tracker.update_status.assert_not_called()
+
+    def test_the_refresh_work_actually_runs(self, tmp_path, golden_repos_dir):
+        """The whole point: the refresh must EXECUTE, not be skipped or failed.
+
+        The reverted first attempt at EVO-64385 made every node stand down, so
+        no refresh ran at all. Assert the work is reached.
+        """
+        tracker = MagicMock()
+        mgr = _FakeBackgroundJobManager(tracker)
+        scheduler = _make_scheduler(
+            tmp_path, golden_repos_dir, background_job_manager=mgr
+        )
+        scheduler._job_tracker = tracker
+
+        with patch.object(
+            scheduler.alias_manager, "read_alias", return_value=None
+        ) as read_alias:
+            scheduler._submit_refresh_job("click-global")
+
+        read_alias.assert_called_once_with("click-global")
+
+
+class TestDirectRefreshStillRegistersItself:
+    """No outer job (CLI, refresh_repo(), exit_write_mode) -> Bug #935 still applies."""
+
+    def test_direct_execute_registers_and_completes(self, tmp_path, golden_repos_dir):
+        scheduler = _make_scheduler(
+            tmp_path, golden_repos_dir, background_job_manager=None
+        )
+        tracker = scheduler._job_tracker
+
+        with patch.object(scheduler.alias_manager, "read_alias", return_value=None):
+            result = scheduler._execute_refresh("click-global")
+
+        assert result["success"] is True
+        tracker.register_job.assert_called_once()
+        assert tracker.register_job.call_args[0][0] == "refresh-click-global"
+        tracker.update_status.assert_called_once()
+        tracker.complete_job.assert_called_once_with("refresh-click-global")
+        tracker.fail_job.assert_not_called()
+
+    def test_direct_execute_fails_the_tracker_job_on_error(
+        self, tmp_path, golden_repos_dir
+    ):
+        scheduler = _make_scheduler(
+            tmp_path, golden_repos_dir, background_job_manager=None
+        )
+        tracker = scheduler._job_tracker
+
+        with patch.object(
+            scheduler.alias_manager,
+            "read_alias",
+            side_effect=RuntimeError("disk read error"),
+        ):
+            with pytest.raises(RuntimeError, match="disk read error"):
+                scheduler._execute_refresh("click-global")
+
+        tracker.fail_job.assert_called_once()
+        tracker.complete_job.assert_not_called()

--- a/tests/unit/global_repos/test_refresh_scheduler_force_reset.py
+++ b/tests/unit/global_repos/test_refresh_scheduler_force_reset.py
@@ -17,7 +17,6 @@ from code_indexer.global_repos.refresh_scheduler import RefreshScheduler
 from code_indexer.global_repos.query_tracker import QueryTracker
 from code_indexer.global_repos.cleanup_manager import CleanupManager
 
-
 # ---------------------------------------------------------------------------
 # Fixtures (reuse pattern from test_refresh_scheduler_git_pull_location.py)
 # ---------------------------------------------------------------------------
@@ -496,8 +495,13 @@ class TestSubmitRefreshJobForceReset:
         ) as mock_execute:
             captured_funcs[0]()  # type: ignore[misc]
 
+        # EVO-64385: the worker runs under submit_job's already-claimed job,
+        # so it must tell _execute_refresh not to register a second one.
         mock_execute.assert_called_once_with(
-            alias_name, force_reset=True, progress_callback=None
+            alias_name,
+            force_reset=True,
+            progress_callback=None,
+            tracked_by_caller=True,
         )
 
     def test_submit_job_passes_force_reset_false_in_lambda(
@@ -539,8 +543,13 @@ class TestSubmitRefreshJobForceReset:
         ) as mock_execute:
             captured_funcs[0]()  # type: ignore[misc]
 
+        # EVO-64385: the worker runs under submit_job's already-claimed job,
+        # so it must tell _execute_refresh not to register a second one.
         mock_execute.assert_called_once_with(
-            alias_name, force_reset=False, progress_callback=None
+            alias_name,
+            force_reset=False,
+            progress_callback=None,
+            tracked_by_caller=True,
         )
 
     def test_submit_job_default_force_reset_is_false(
@@ -576,6 +585,11 @@ class TestSubmitRefreshJobForceReset:
             captured_funcs[0]()  # type: ignore[misc]
 
         # Default must be force_reset=False
+        # EVO-64385: the worker runs under submit_job's already-claimed job,
+        # so it must tell _execute_refresh not to register a second one.
         mock_execute.assert_called_once_with(
-            alias_name, force_reset=False, progress_callback=None
+            alias_name,
+            force_reset=False,
+            progress_callback=None,
+            tracked_by_caller=True,
         )


### PR DESCRIPTION
## Problem

In cluster (postgres) mode, **every** scheduled global-repo refresh failed at registration — so no repo refreshed at all. On our 2-pod test cluster `last_refresh` had been frozen for **4 days** and no pod ever logged `Starting refresh`:

```
global_repo_refresh (click-global) -- FAILED
  duplicate key value violates unique constraint "idx_active_job_per_repo"
  DETAIL: Key (operation_type, repo_alias)=(global_repo_refresh, click-global) already exists.
```

The duplicate is the job's **own parent row**. Two guards, added by two different bugs, overlap:

1. `BackgroundJobManager.submit_job()` (**Bug #1065**) calls `register_job_if_no_conflict(job_id=<uuid>, "global_repo_refresh", <alias>)`, inserting the row that occupies the `idx_active_job_per_repo` partial unique index for the whole run.
2. The worker then runs `_execute_refresh()`, which (**Bug #935**) registers a **second** JobTracker job (`refresh-<alias>`) for the **same** `(operation_type, repo_alias)` pair — colliding with the row its own submission just created.

Postgres raises `23505`, the raw error escapes `_execute_refresh()`, and `BackgroundJobManager` marks the refresh FAILED before any work starts. (It also flips `/health` to `degraded`, since that counts failed jobs — but the stale-index consequence is the real damage.)

This only bites where the partial unique index is enforced, i.e. the postgres/cluster path.

## Fix

The outer `submit_job` row **is** the cluster-visible active job that Bug #935 wanted drain-status to see. So a refresh running under a BackgroundJobManager job no longer registers its own tracker job — nor completes/fails it, since that lifecycle belongs to the outer job. `_refresh_worker` passes `tracked_by_caller=True`.

Refreshes invoked **directly** — CLI, `refresh_repo()`, `exit_write_mode` — have no outer job and still register exactly as before, so Bug #935's drain visibility is preserved on those paths.

## Verification

Verified on a live 2-pod cluster, against a deliberately strict bar: **absence of the error proves nothing** (an earlier attempt that made the loser "skip" produced zero errors and zero refreshes). Both had to hold:

**1. A pod actually starts the refresh:**
```
18:08:20  Starting refresh for click-global
18:08:20  Remote changes detected for .../golden-repos/click: 18 commit(s) to pull
18:08:26  Swapped alias click-global: ... -> .versioned/click/v_1784052504
```

**2. `last_refresh` advances:**
```
before: click-global last_refresh = 2026-07-10 20:20:46+00   (frozen 4 days)
after:  click-global last_refresh = 2026-07-14 18:08:26+00
```

Real work had to be manufactured to test this — the repo had no upstream changes, and the no-changes path legitimately returns early without touching `last_refresh` — so the clone was rewound 5 commits to force a genuine pull + reindex.

Also: **0** `idx_active_job_per_repo` violations across both pods, **0** failed jobs, `/health` healthy on both.

## Tests

5 new tests (worker registers once / leaves the outer job's lifecycle alone / **the work actually runs**; direct path still registers, and still fails the tracker job on a real error). 3 existing tests updated where the worker's `_execute_refresh` call args legitimately changed.

`tests/unit/global_repos/`: **1623 passed, 0 failed**. ruff, black, mypy clean.

(An earlier revision of this description claimed `test_refresh_scheduler_hnsw_orphan_forwarding_1388` was a pre-existing failure on `development`. That was wrong — my venv had stock PyPI `hnswlib` rather than the pinned LightspeedDMS fork with `repair_orphans()`, so it failed on every tree. With the correct hnswlib installed it passes on `development` and on this branch.)