### PR TITLE
fix(tests): route-registration assertions are blind to included routers on FastAPI 0.13x

### DIFF
--- a/tests/unit/server/routers/test_admin_provider_health_endpoint.py
+++ b/tests/unit/server/routers/test_admin_provider_health_endpoint.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
-
+from tests.utils.route_registration import route_paths
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -142,8 +142,7 @@ class TestProviderHealthEndpointAuth:
 
     def test_endpoint_route_exists(self, app_with_router):
         """Router registers /admin/provider-health route."""
-        routes = [r.path for r in app_with_router.routes]
-        assert "/admin/provider-health" in routes
+        assert "/admin/provider-health" in route_paths(app_with_router)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/routers/test_admin_provider_health_reset_state_endpoint.py
+++ b/tests/unit/server/routers/test_admin_provider_health_reset_state_endpoint.py
@@ -31,7 +31,7 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi import status as http_status
 from fastapi.testclient import TestClient
-
+from tests.utils.route_registration import find_route
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -120,13 +120,10 @@ class TestResetStateRouteRegistered:
 
         Checks both path and method to reject misconfigured GET-only routes.
         """
-        matching = [
-            r
-            for r in app_with_router.routes
-            if getattr(r, "path", None) == "/admin/provider-health/reset-state"
-        ]
-        assert matching, "Route /admin/provider-health/reset-state is not registered"
-        route = matching[0]
+        route = find_route(app_with_router, "/admin/provider-health/reset-state")
+        assert (
+            route is not None
+        ), "Route /admin/provider-health/reset-state is not registered"
         assert "POST" in route.methods, (
             f"Route /admin/provider-health/reset-state is registered but not for POST; "
             f"methods={route.methods}"

--- a/tests/unit/server/routers/test_admin_provider_health_reset_state_endpoint.py
+++ b/tests/unit/server/routers/test_admin_provider_health_reset_state_endpoint.py
@@ -121,9 +121,9 @@ class TestResetStateRouteRegistered:
         Checks both path and method to reject misconfigured GET-only routes.
         """
         route = find_route(app_with_router, "/admin/provider-health/reset-state")
-        assert (
-            route is not None
-        ), "Route /admin/provider-health/reset-state is not registered"
+        assert route is not None, (
+            "Route /admin/provider-health/reset-state is not registered"
+        )
         assert "POST" in route.methods, (
             f"Route /admin/provider-health/reset-state is registered but not for POST; "
             f"methods={route.methods}"

--- a/tests/unit/server/routers/test_debug_routes_registration.py
+++ b/tests/unit/server/routers/test_debug_routes_registration.py
@@ -8,6 +8,7 @@ Verifies that debug_router is exported from debug_routes and that both
 
 import pytest
 from fastapi.testclient import TestClient
+from tests.utils.route_registration import route_paths
 
 
 class TestDebugRouterRegistration:
@@ -55,10 +56,10 @@ class TestDebugRouterRegistration:
         """debug_router must be included in the FastAPI app."""
         from code_indexer.server.app import app
 
-        app_paths = {route.path for route in app.routes}
-        assert "/debug/memory-snapshot" in app_paths, (
-            f"debug router not registered. App paths sample: {list(app_paths)[:30]}"
-        )
+        app_paths = route_paths(app)
+        assert (
+            "/debug/memory-snapshot" in app_paths
+        ), f"debug router not registered. App paths sample: {list(app_paths)[:30]}"
 
 
 @pytest.mark.slow

--- a/tests/unit/server/routers/test_debug_routes_registration.py
+++ b/tests/unit/server/routers/test_debug_routes_registration.py
@@ -57,9 +57,9 @@ class TestDebugRouterRegistration:
         from code_indexer.server.app import app
 
         app_paths = route_paths(app)
-        assert (
-            "/debug/memory-snapshot" in app_paths
-        ), f"debug router not registered. App paths sample: {list(app_paths)[:30]}"
+        assert "/debug/memory-snapshot" in app_paths, (
+            f"debug router not registered. App paths sample: {list(app_paths)[:30]}"
+        )
 
 
 @pytest.mark.slow

--- a/tests/utils/route_registration.py
+++ b/tests/utils/route_registration.py
@@ -1,0 +1,96 @@
+"""
+Helpers for asserting that a route is registered on a FastAPI app.
+
+Why this exists
+---------------
+Scanning ``app.routes`` directly and reading ``route.path`` USED to see every
+route, because ``include_router()`` copied the sub-router's routes into the
+app's own route list. As of FastAPI 0.13x (``fastapi>=0.116.0`` resolves to it,
+and it is what the server actually runs) ``include_router()`` instead appends a
+single ``fastapi.routing._IncludedRouter`` object per inclusion, which holds the
+sub-router in ``.original_router`` and its mount prefix in ``.include_context``.
+
+``_IncludedRouter`` has NO ``.path``, so the old pattern breaks in two ways:
+
+1. ``[r.path for r in app.routes]`` raises ``AttributeError``.
+2. ``[getattr(r, "path", None) for r in app.routes]`` does NOT raise -- it just
+   silently misses every included route. On this app that is the difference
+   between seeing **80** paths and the real **395**: a route-registration
+   assertion written that way can pass while asserting almost nothing.
+
+The routes are still registered and served -- only this introspection changed.
+These helpers walk into ``_IncludedRouter`` so the assertions see the whole app
+again, and they stay correct on older FastAPI (where there is nothing to walk
+into) because they simply read ``.path`` when it is present.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Optional, Set
+
+
+def iter_routes(routes: Iterable[Any]) -> List[Any]:
+    """Flatten a FastAPI/Starlette route list, descending into included routers.
+
+    Args:
+        routes: ``app.routes`` (or any nested router's ``.routes``).
+
+    Returns:
+        Every leaf route object (those carrying a ``.path``), with included
+        routers expanded. Leaf objects are returned as-is so callers can still
+        inspect ``.methods``, ``.name``, etc.
+    """
+    flat: List[Any] = []
+    for route in routes:
+        if getattr(route, "path", None) is not None:
+            flat.append(route)
+            continue
+
+        # FastAPI >= 0.13x: include_router() appends an _IncludedRouter holding
+        # the original APIRouter plus the prefix it was mounted under.
+        original = getattr(route, "original_router", None)
+        if original is not None:
+            flat.extend(iter_routes(getattr(original, "routes", [])))
+    return flat
+
+
+def route_paths(app_or_router: Any) -> Set[str]:
+    """Return every registered path on an app/router, including included routers.
+
+    Prefixes from ``include_router(prefix=...)`` are applied, so the paths match
+    what a client would actually call.
+    """
+    return {
+        prefix + route.path
+        for prefix, route in _iter_prefixed(getattr(app_or_router, "routes", []))
+    }
+
+
+def find_route(app_or_router: Any, path: str) -> Optional[Any]:
+    """Return the leaf route registered at ``path``, or None.
+
+    Use when the assertion needs more than existence -- e.g. checking
+    ``route.methods`` to reject a misconfigured GET-only endpoint.
+    """
+    for prefix, route in _iter_prefixed(getattr(app_or_router, "routes", [])):
+        if prefix + route.path == path:
+            return route
+    return None
+
+
+def _iter_prefixed(routes: Iterable[Any], prefix: str = "") -> List[Any]:
+    """Yield (accumulated_prefix, leaf_route) pairs."""
+    out: List[Any] = []
+    for route in routes:
+        if getattr(route, "path", None) is not None:
+            out.append((prefix, route))
+            continue
+
+        original = getattr(route, "original_router", None)
+        if original is None:
+            continue
+
+        context = getattr(route, "include_context", None)
+        sub_prefix = getattr(context, "prefix", "") or ""
+        out.extend(_iter_prefixed(getattr(original, "routes", []), prefix + sub_prefix))
+    return out


### PR DESCRIPTION
## Problem

Three tests fail on a fresh install of `development`:

```
AttributeError: '_IncludedRouter' object has no attribute 'path'
  test_admin_provider_health_endpoint::test_endpoint_route_exists
  test_admin_provider_health_reset_state_endpoint::test_reset_state_route_exists_with_post_method
  test_debug_routes_registration::test_debug_router_registered_in_app
```

Scanning `app.routes` and reading `route.path` used to see every route, because `include_router()` copied the sub-router's routes into the app's own list. As of **FastAPI 0.13x** — which `fastapi>=0.116.0` resolves to today, and which the server actually runs (I confirmed `fastapi 0.139.0 / starlette 1.3.1` inside our deployed pod) — `include_router()` appends a single `fastapi.routing._IncludedRouter` per inclusion instead, holding the sub-router in `.original_router` and its mount prefix in `.include_context`. `_IncludedRouter` has no `.path`.

**The routes are still registered and served.** Only this introspection changed — this is a test-visibility bug, not a runtime one. (I grepped: no production code scans `app.routes` for `.path`.)

## The silent half is the dangerous half

The `AttributeError` is loud. But the *defensive* spelling of the same pattern —

```python
[getattr(r, "path", None) for r in app.routes]
```

— does **not** raise. It quietly skips every included route. On this app that is the difference between seeing **80** paths and the real **395**:

```
app.routes types: {'APIRoute': 74, '_IncludedRouter': 43, 'Route': 4, 'Mount': 2}
naive scan:  80 paths
flattened:  395 paths
```

So a route-registration assertion written that way can pass while asserting almost nothing. Worth fixing before someone "fixes" the three failures that way.

## Fix

Add `tests/utils/route_registration.py` (`route_paths` / `find_route` / `iter_routes`), which descends into `_IncludedRouter` and applies the include prefix so paths match what a client would actually call. It stays correct on older FastAPI, where there is nothing to descend into and `.path` is simply read as before — so this is not a version bump in disguise.

`find_route()` returns the leaf route object, so the reset-state test can still assert on `.methods` and reject a misconfigured GET-only endpoint (it was doing more than an existence check).

## Tests

`tests/unit/server/routers/`: **654 passed** (was 651 passed / 3 failed). ruff + black clean.

No `src/` changes.