### PR TITLE
feat: allow the LLM invocation to be supplied by a plugin

### DIFF
--- a/src/code_indexer/global_repos/llm_invoker_plugin.py
+++ b/src/code_indexer/global_repos/llm_invoker_plugin.py
@@ -1,0 +1,158 @@
+"""
+Pluggable LLM invocation: let a deployment supply its own agent backend.
+
+Why
+---
+Repo analysis (and the golden-repo registration lifecycle that depends on it)
+runs its prompt by shelling out to the ``claude`` CLI. That requires the CLI --
+and an API key -- to be present in whatever process/image runs the server.
+
+Some deployments cannot ship it there. A containerized/multi-pod server may be
+required to keep LLM execution inside a separate, sandboxed agent runner rather
+than inside the server image; and without the CLI on PATH every registration
+lifecycle job fails with ``exit 127``.
+
+This module lets such a deployment substitute its own invocation backend --
+e.g. one that submits the prompt to an external agent runner and returns the
+result -- WITHOUT patching the server. Nothing about the default behaviour
+changes: with no plugin configured, the built-in Claude CLI subprocess is used
+exactly as before.
+
+The contract
+------------
+A plugin is any callable with the same signature and return contract as
+``repo_analyzer.invoke_claude_cli``::
+
+    def invoke(
+        repo_path: str,
+        prompt: str,
+        shell_timeout_seconds: int,
+        outer_timeout_seconds: int,
+    ) -> tuple[bool, str]:
+        '''Return (True, output) on success, (False, error_message) on failure.'''
+
+It is called from a worker thread and MAY block for the duration of the
+timeouts -- the caller already blocks on a subprocess today, so a plugin that
+submits a job and polls for its result fits the existing threading model with
+no changes.
+
+Selecting a plugin (first match wins)
+-------------------------------------
+1. ``CIDX_LLM_INVOKER`` env var, as ``"package.module:callable"``.
+2. An entry point in the ``code_indexer.llm_invoker`` group::
+
+       [project.entry-points."code_indexer.llm_invoker"]
+       my_backend = "my_pkg.invoker:invoke"
+
+3. Nothing -- the built-in Claude CLI subprocess.
+
+Misconfiguration fails LOUD (``LlmInvokerPluginError``) rather than silently
+falling back to the CLI: a deployment that asked for a plugin because it must
+not execute the CLI locally would otherwise get exactly the behaviour it was
+trying to avoid, and only find out from a stack trace inside a background job.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from importlib import import_module
+from importlib.metadata import entry_points
+from typing import Callable, Optional, Tuple, cast
+
+logger = logging.getLogger(__name__)
+
+ENV_VAR = "CIDX_LLM_INVOKER"
+ENTRY_POINT_GROUP = "code_indexer.llm_invoker"
+
+# (repo_path, prompt, shell_timeout_seconds, outer_timeout_seconds) -> (ok, output)
+LlmInvoker = Callable[[str, str, int, int], Tuple[bool, str]]
+
+
+class LlmInvokerPluginError(RuntimeError):
+    """A plugin was configured but could not be loaded or is not callable."""
+
+
+# Resolved once per process. None = "not looked up yet"; the sentinel below
+# distinguishes that from "looked up, no plugin configured".
+_NO_PLUGIN = object()
+_cached: object = None
+
+
+def _load_from_path(spec: str) -> LlmInvoker:
+    """Load ``"package.module:callable"``."""
+    if ":" not in spec:
+        raise LlmInvokerPluginError(
+            f"{ENV_VAR}={spec!r} is not in 'package.module:callable' form"
+        )
+    module_name, _, attr = spec.partition(":")
+    try:
+        module = import_module(module_name)
+    except ImportError as exc:
+        raise LlmInvokerPluginError(
+            f"{ENV_VAR}={spec!r}: cannot import module {module_name!r}: {exc}"
+        ) from exc
+
+    invoker = getattr(module, attr, None)
+    if invoker is None:
+        raise LlmInvokerPluginError(
+            f"{ENV_VAR}={spec!r}: module {module_name!r} has no attribute {attr!r}"
+        )
+    if not callable(invoker):
+        raise LlmInvokerPluginError(f"{ENV_VAR}={spec!r}: {attr!r} is not callable")
+    return cast(LlmInvoker, invoker)
+
+
+def _load_from_entry_points() -> Optional[LlmInvoker]:
+    selected = next(iter(entry_points(group=ENTRY_POINT_GROUP)), None)
+    if selected is None:
+        return None
+
+    try:
+        invoker = selected.load()
+    except Exception as exc:  # noqa: BLE001 - surfaced as a config error
+        raise LlmInvokerPluginError(
+            f"entry point {selected.name!r} in group {ENTRY_POINT_GROUP!r} "
+            f"failed to load: {exc}"
+        ) from exc
+
+    if not callable(invoker):
+        raise LlmInvokerPluginError(
+            f"entry point {selected.name!r} in group {ENTRY_POINT_GROUP!r} "
+            "did not resolve to a callable"
+        )
+    return cast(LlmInvoker, invoker)
+
+
+def get_llm_invoker() -> Optional[LlmInvoker]:
+    """Return the configured plugin, or None to use the built-in Claude CLI.
+
+    Raises:
+        LlmInvokerPluginError: A plugin was configured but is unusable. Raised
+            rather than silently falling back to the CLI -- see module docstring.
+    """
+    global _cached
+    if _cached is not None:
+        return None if _cached is _NO_PLUGIN else cast(LlmInvoker, _cached)
+
+    spec = os.environ.get(ENV_VAR, "").strip()
+    invoker: Optional[LlmInvoker]
+    if spec:
+        invoker = _load_from_path(spec)
+        logger.info("LLM invoker plugin loaded from %s=%s", ENV_VAR, spec)
+    else:
+        invoker = _load_from_entry_points()
+        if invoker is not None:
+            logger.info(
+                "LLM invoker plugin loaded from entry-point group %r",
+                ENTRY_POINT_GROUP,
+            )
+
+    _cached = invoker if invoker is not None else _NO_PLUGIN
+    return invoker
+
+
+def reset_cache() -> None:
+    """Clear the resolved plugin. For tests."""
+    global _cached
+    _cached = None

--- a/src/code_indexer/global_repos/repo_analyzer.py
+++ b/src/code_indexer/global_repos/repo_analyzer.py
@@ -198,6 +198,22 @@ def invoke_claude_cli(
             f"shell_timeout_seconds ({shell_timeout_seconds})"
         )
 
+    # A deployment may substitute its own invocation backend -- e.g. one that
+    # hands the prompt to an external, sandboxed agent runner instead of
+    # executing the Claude CLI in this image. Checked AFTER validation (so a
+    # plugin gets the same guarantees the CLI does) and BEFORE anything that
+    # assumes a local CLI: MCP self-registration below shells out to `claude
+    # mcp`, which is exactly what a plugin deployment does not have.
+    # See llm_invoker_plugin for the contract and selection order.
+    from code_indexer.global_repos.llm_invoker_plugin import get_llm_invoker
+
+    _plugin = get_llm_invoker()
+    if _plugin is not None:
+        ok, out = _plugin(
+            repo_path, prompt, shell_timeout_seconds, outer_timeout_seconds
+        )
+        return ok, out
+
     # A10 (Story #885): centralized MCP self-registration at the subprocess boundary.
     # All Claude CLI call sites funnel through invoke_claude_cli, so registering here
     # guarantees exactly-once registration per process without duplicating the call

--- a/tests/unit/global_repos/test_llm_invoker_plugin.py
+++ b/tests/unit/global_repos/test_llm_invoker_plugin.py
@@ -1,0 +1,210 @@
+"""
+Pluggable LLM invocation: a deployment can supply its own agent backend.
+
+Repo analysis (and the golden-repo registration lifecycle built on it) executes
+its prompt by shelling out to the `claude` CLI. A deployment that cannot ship
+the CLI in the server image -- e.g. one that must keep LLM execution inside a
+separate sandboxed agent runner -- currently has no way to substitute a backend,
+and every registration lifecycle job dies with `exit 127`.
+
+These tests pin the seam:
+  * with no plugin configured, NOTHING changes (the CLI subprocess still runs);
+  * a plugin can be selected by env var or entry point, and fully replaces the
+    subprocess -- including the `claude mcp` self-registration that would
+    otherwise still require the CLI;
+  * a plugin receives the exact documented contract and its return value is
+    passed straight through;
+  * misconfiguration fails LOUD rather than silently falling back to the CLI a
+    plugin deployment specifically cannot run.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from code_indexer.global_repos import llm_invoker_plugin
+from code_indexer.global_repos.llm_invoker_plugin import (
+    ENV_VAR,
+    LlmInvokerPluginError,
+    get_llm_invoker,
+)
+from code_indexer.global_repos.repo_analyzer import invoke_claude_cli
+
+
+@pytest.fixture(autouse=True)
+def _clear_plugin_cache(monkeypatch):
+    """The resolved plugin is cached per process; isolate every test."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    llm_invoker_plugin.reset_cache()
+    yield
+    llm_invoker_plugin.reset_cache()
+
+
+# --------------------------------------------------------------------------
+# A test plugin, addressable by "module:callable" (this module is importable).
+# --------------------------------------------------------------------------
+
+calls: list = []
+
+
+def recording_invoker(repo_path, prompt, shell_timeout_seconds, outer_timeout_seconds):
+    calls.append((repo_path, prompt, shell_timeout_seconds, outer_timeout_seconds))
+    return True, "output from the plugin"
+
+
+def failing_invoker(repo_path, prompt, shell_timeout_seconds, outer_timeout_seconds):
+    return False, "backend refused the job"
+
+
+not_callable = "I am a string, not a callable"
+
+
+_THIS = "tests.unit.global_repos.test_llm_invoker_plugin"
+
+
+class TestNoPluginIsTheDefault:
+    def test_resolves_to_none_when_nothing_configured(self):
+        assert get_llm_invoker() is None
+
+    def test_invoke_claude_cli_still_spawns_the_subprocess(self):
+        """The default path must be untouched: no plugin -> CLI as before."""
+        with patch(
+            "code_indexer.global_repos.repo_analyzer.subprocess.Popen"
+        ) as mock_popen:
+            proc = mock_popen.return_value
+            proc.communicate.return_value = ("cli output", "")
+            proc.returncode = 0
+
+            ok, out = invoke_claude_cli("/repo", "analyze", 10, 20)
+
+        assert mock_popen.called, "the Claude CLI subprocess must still be spawned"
+        assert ok is True
+        assert "cli output" in out
+
+
+class TestPluginSelectedByEnvVar:
+    def test_plugin_replaces_the_subprocess_entirely(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, f"{_THIS}:recording_invoker")
+        calls.clear()
+
+        with patch(
+            "code_indexer.global_repos.repo_analyzer.subprocess.Popen"
+        ) as mock_popen:
+            ok, out = invoke_claude_cli("/repo", "analyze this", 10, 20)
+
+        assert (ok, out) == (True, "output from the plugin")
+        assert (
+            not mock_popen.called
+        ), "no subprocess may be spawned when a plugin is set"
+
+    def test_plugin_receives_the_documented_contract(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, f"{_THIS}:recording_invoker")
+        calls.clear()
+
+        invoke_claude_cli("/srv/repo", "the prompt", 300, 360)
+
+        assert calls == [("/srv/repo", "the prompt", 300, 360)]
+
+    def test_plugin_failure_is_passed_through_not_swallowed(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, f"{_THIS}:failing_invoker")
+
+        ok, out = invoke_claude_cli("/repo", "analyze", 10, 20)
+
+        assert ok is False
+        assert out == "backend refused the job"
+
+    def test_the_claude_mcp_self_registration_is_skipped(self, monkeypatch):
+        """MCP self-registration shells out to `claude mcp` -- exactly what a
+        plugin deployment does not have. It must not run."""
+        monkeypatch.setenv(ENV_VAR, f"{_THIS}:recording_invoker")
+
+        with patch(
+            "code_indexer.server.services.mcp_self_registration_service."
+            "MCPSelfRegistrationService.get_instance"
+        ) as mock_get:
+            invoke_claude_cli("/repo", "analyze", 10, 20)
+
+        assert not mock_get.called
+
+    def test_argument_validation_still_applies_to_plugins(self, monkeypatch):
+        """A plugin gets the same guarantees the CLI does."""
+        monkeypatch.setenv(ENV_VAR, f"{_THIS}:recording_invoker")
+
+        with pytest.raises(ValueError):
+            invoke_claude_cli("", "analyze", 10, 20)
+        with pytest.raises(ValueError):
+            invoke_claude_cli("/repo", "analyze", 20, 10)  # outer <= shell
+
+
+class TestPluginSelectedByEntryPoint:
+    def test_entry_point_plugin_is_used(self, monkeypatch):
+        class _EP:
+            name = "orchestrator"
+
+            def load(self):
+                return recording_invoker
+
+        monkeypatch.setattr(
+            llm_invoker_plugin, "entry_points", lambda group=None: [_EP()]
+        )
+        calls.clear()
+
+        assert get_llm_invoker() is recording_invoker
+
+    def test_no_entry_points_means_no_plugin(self, monkeypatch):
+        monkeypatch.setattr(llm_invoker_plugin, "entry_points", lambda group=None: [])
+        assert get_llm_invoker() is None
+
+    def test_env_var_wins_over_entry_point(self, monkeypatch):
+        class _EP:
+            name = "entrypoint-one"
+
+            def load(self):
+                return failing_invoker
+
+        monkeypatch.setattr(
+            llm_invoker_plugin, "entry_points", lambda group=None: [_EP()]
+        )
+        monkeypatch.setenv(ENV_VAR, f"{_THIS}:recording_invoker")
+
+        assert get_llm_invoker() is recording_invoker
+
+
+class TestMisconfigurationFailsLoud:
+    """A deployment that asked for a plugin must NOT silently get the CLI --
+    that is the exact behaviour it was configured to avoid."""
+
+    def test_unknown_module(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "no_such_module_xyz:invoke")
+        with pytest.raises(LlmInvokerPluginError, match="cannot import module"):
+            get_llm_invoker()
+
+    def test_missing_attribute(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, f"{_THIS}:does_not_exist")
+        with pytest.raises(LlmInvokerPluginError, match="has no attribute"):
+            get_llm_invoker()
+
+    def test_not_callable(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, f"{_THIS}:not_callable")
+        with pytest.raises(LlmInvokerPluginError, match="not callable"):
+            get_llm_invoker()
+
+    def test_malformed_spec(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "module.without.colon")
+        with pytest.raises(LlmInvokerPluginError, match="package.module:callable"):
+            get_llm_invoker()
+
+    def test_entry_point_that_fails_to_load(self, monkeypatch):
+        class _EP:
+            name = "broken"
+
+            def load(self):
+                raise ImportError("boom")
+
+        monkeypatch.setattr(
+            llm_invoker_plugin, "entry_points", lambda group=None: [_EP()]
+        )
+        with pytest.raises(LlmInvokerPluginError, match="failed to load"):
+            get_llm_invoker()


### PR DESCRIPTION
## Problem

Repo analysis — and the golden-repo registration lifecycle built on it — runs its prompt by shelling out to the `claude` CLI. That requires the CLI, and an API key, inside whatever image runs the server.

Some deployments cannot put it there. Ours runs cidx as a multi-pod service on EKS, where LLM execution is required to stay inside a separate sandboxed agent runner rather than in the server image. Today there is no seam: without `claude` on PATH, **every** registration lifecycle job dies with `exit 127` (we see it on every golden repo we add), and the only options are to bake the CLI into the image or patch the server.

## Fix

Add a plugin seam at the existing shared wrapper. `invoke_claude_cli()` already has exactly the right contract for it:

```python
(repo_path, prompt, shell_timeout_seconds, outer_timeout_seconds) -> (ok: bool, output: str)
```

A plugin is any callable with that signature, selected in order:

1. `CIDX_LLM_INVOKER="package.module:callable"`
2. an entry point in the `code_indexer.llm_invoker` group
3. nothing — the built-in Claude CLI subprocess, **exactly as before**

The default path is untouched, and a test pins that (no plugin → the same subprocess still spawns).

Because the contract is synchronous and may block for the duration of the timeouts — the caller already blocks on a subprocess — a plugin that submits the prompt to an external runner and polls for the result drops into the existing threading model with no changes.

## Two decisions worth arguing about

**Where the check sits.** After argument validation (so a plugin gets the same guarantees the CLI does) but *before* MCP self-registration — which itself shells out to `claude mcp`, i.e. precisely what a plugin deployment does not have. A plugin therefore replaces the CLI dependency *completely*, not partially. There's a test for that specifically.

**Misconfiguration fails loud.** A bad `CIDX_LLM_INVOKER` raises `LlmInvokerPluginError` rather than falling back to the CLI. A silent fallback would hand a deployment the exact behaviour it configured a plugin to avoid, and it would only find out from a stack trace inside a background job.

## Scope

This covers the repo-analysis / lifecycle path — the one that actually fails without the CLI. `dependency_map_analyzer` and `self_monitoring.scanner` each still spawn their own subprocess; routing those through this seam is a larger change and is deliberately **not** attempted here.

## Tests

15 new tests (default unchanged; env-var and entry-point selection; contract pass-through; failure pass-through; `claude mcp` registration skipped; validation still applies; every misconfiguration mode fails loud).

`tests/unit/global_repos/`: **1633 passed**. ruff, black, mypy clean.