### PR TITLE
feat: allow the primary CLI invoker to be supplied by a plugin

### DIFF
--- a/src/code_indexer/server/services/cli_invoker_plugin.py
+++ b/src/code_indexer/server/services/cli_invoker_plugin.py
@@ -1,0 +1,144 @@
+"""
+Pluggable CLI invoker: let a deployment supply the IntelligenceCliInvoker.
+
+Why here, and not at invoke_claude_cli
+--------------------------------------
+Every description/analysis LLM call -- golden-repo registration lifecycle,
+dep-map passes, description refresh, self-monitoring -- is dispatched through a
+single CliDispatcher built by ``build_dep_map_dispatcher`` (its own docstring:
+"the single source of truth for CliDispatcher construction across all callers").
+That dispatcher calls ``invoker.invoke(flow, cwd, prompt, timeout, max_turns)``
+on a ClaudeInvoker, which shells out to the ``claude`` CLI.
+
+``repo_analyzer.invoke_claude_cli`` is a DIFFERENT, secondary path. Seaming
+there does not touch the lifecycle; seaming here does, and covers every consumer
+at once, with the richer InvocationResult contract dep-map needs.
+
+A deployment that cannot ship the ``claude`` CLI in the server image -- e.g. one
+that must keep LLM execution inside a separate sandboxed agent runner -- can
+supply its own IntelligenceCliInvoker for the primary (``claude=``) slot. With
+no plugin configured, nothing changes: the built-in ClaudeInvoker is used.
+
+The contract
+------------
+A plugin is a FACTORY callable::
+
+    def make_invoker(analysis_model: str,
+                     soft_timeout_seconds: int | None) -> IntelligenceCliInvoker:
+        ...
+
+returning any object with
+``invoke(flow, cwd, prompt, timeout, max_turns=0) -> InvocationResult``. The two
+arguments mirror what ClaudeInvoker is constructed with, so the plugin can honour
+the same model/timeout budget.
+
+Selection (first match wins)
+----------------------------
+1. ``CIDX_CLI_INVOKER`` env var, as ``"package.module:factory"``.
+2. An entry point in the ``code_indexer.cli_invoker`` group.
+3. Nothing -- the built-in ClaudeInvoker.
+
+Misconfiguration fails LOUD (``CliInvokerPluginError``) rather than silently
+falling back to the CLI: a deployment that asked for a plugin because it must
+NOT execute the CLI locally would otherwise get exactly the behaviour it was
+trying to avoid.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from importlib import import_module
+from importlib.metadata import entry_points
+from typing import Any, Callable, Optional, cast
+
+logger = logging.getLogger(__name__)
+
+ENV_VAR = "CIDX_CLI_INVOKER"
+ENTRY_POINT_GROUP = "code_indexer.cli_invoker"
+
+# (analysis_model, soft_timeout_seconds) -> IntelligenceCliInvoker
+InvokerFactory = Callable[[str, Optional[int]], Any]
+
+
+class CliInvokerPluginError(RuntimeError):
+    """A plugin was configured but could not be loaded or is not callable."""
+
+
+_NO_PLUGIN = object()
+_cached: object = None
+
+
+def _load_from_path(spec: str) -> InvokerFactory:
+    if ":" not in spec:
+        raise CliInvokerPluginError(
+            f"{ENV_VAR}={spec!r} is not in 'package.module:factory' form"
+        )
+    module_name, _, attr = spec.partition(":")
+    try:
+        module = import_module(module_name)
+    except ImportError as exc:
+        raise CliInvokerPluginError(
+            f"{ENV_VAR}={spec!r}: cannot import module {module_name!r}: {exc}"
+        ) from exc
+    factory = getattr(module, attr, None)
+    if factory is None:
+        raise CliInvokerPluginError(
+            f"{ENV_VAR}={spec!r}: module {module_name!r} has no attribute {attr!r}"
+        )
+    if not callable(factory):
+        raise CliInvokerPluginError(f"{ENV_VAR}={spec!r}: {attr!r} is not callable")
+    return cast(InvokerFactory, factory)
+
+
+def _load_from_entry_points() -> Optional[InvokerFactory]:
+    selected = next(iter(entry_points(group=ENTRY_POINT_GROUP)), None)
+    if selected is None:
+        return None
+    try:
+        factory = selected.load()
+    except Exception as exc:  # noqa: BLE001 - surfaced as a config error
+        raise CliInvokerPluginError(
+            f"entry point {selected.name!r} in group {ENTRY_POINT_GROUP!r} "
+            f"failed to load: {exc}"
+        ) from exc
+    if not callable(factory):
+        raise CliInvokerPluginError(
+            f"entry point {selected.name!r} in group {ENTRY_POINT_GROUP!r} "
+            "did not resolve to a callable"
+        )
+    return cast(InvokerFactory, factory)
+
+
+def get_invoker_factory() -> Optional[InvokerFactory]:
+    """Return the configured invoker factory, or None to use ClaudeInvoker.
+
+    Raises:
+        CliInvokerPluginError: a plugin was configured but is unusable. Raised
+            rather than silently falling back to the CLI -- see module docstring.
+    """
+    global _cached
+    if _cached is not None:
+        return None if _cached is _NO_PLUGIN else cast(InvokerFactory, _cached)
+
+    spec = os.environ.get(ENV_VAR, "").strip()
+    factory: Optional[InvokerFactory]
+    if spec:
+        factory = _load_from_path(spec)
+        logger.info("CLI invoker plugin loaded from %s=%s", ENV_VAR, spec)
+    else:
+        factory = _load_from_entry_points()
+        if factory is not None:
+            logger.info(
+                "CLI invoker plugin loaded from entry-point group %r",
+                ENTRY_POINT_GROUP,
+            )
+
+    _cached = factory if factory is not None else _NO_PLUGIN
+    return factory
+
+
+def reset_cache() -> None:
+    """Clear the resolved plugin. For tests."""
+    global _cached
+    _cached = None

--- a/src/code_indexer/server/services/cli_invoker_plugin.py
+++ b/src/code_indexer/server/services/cli_invoker_plugin.py
@@ -48,9 +48,10 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from importlib import import_module
 from importlib.metadata import entry_points
-from typing import Any, Callable, Optional, cast
+from typing import Any, Callable, List, Optional, cast
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +93,17 @@ def _load_from_path(spec: str) -> InvokerFactory:
 
 
 def _load_from_entry_points() -> Optional[InvokerFactory]:
-    selected = next(iter(entry_points(group=ENTRY_POINT_GROUP)), None)
+    # importlib.metadata.entry_points() only accepts the `group=` keyword
+    # starting in Python 3.10 (SelectableGroups). On 3.9 the function takes NO
+    # parameters at all and returns a plain dict of group -> List[EntryPoint];
+    # `.get(group, [])` is the pre-3.10 equivalent lookup. This repo's CI
+    # matrix still targets 3.9, so both call shapes must be supported.
+    candidates: List[Any]
+    if sys.version_info >= (3, 10):
+        candidates = list(entry_points(group=ENTRY_POINT_GROUP))
+    else:
+        candidates = list(entry_points().get(ENTRY_POINT_GROUP, []))
+    selected = next(iter(candidates), None)
     if selected is None:
         return None
     try:

--- a/src/code_indexer/server/services/dep_map_dispatcher_factory.py
+++ b/src/code_indexer/server/services/dep_map_dispatcher_factory.py
@@ -29,6 +29,7 @@ from code_indexer.server.services.codex_invoker import CodexInvoker
 from code_indexer.server.services.codex_mcp_auth_header_provider import (
     build_codex_mcp_auth_header_provider,
 )
+from code_indexer.server.services.cli_invoker_plugin import get_invoker_factory
 
 
 def build_dep_map_dispatcher(
@@ -96,6 +97,18 @@ def build_dep_map_dispatcher(
             )
         else:
             claude_invoker = ClaudeInvoker(analysis_model=analysis_model)
+
+    # A deployment may replace the primary invoker with its own -- e.g. one that
+    # runs the prompt in a sandboxed agent runner instead of a local `claude`
+    # subprocess. When a plugin is configured it takes the `claude=` slot and
+    # codex routing is disabled: the point of the plugin is that THIS is where
+    # LLM execution happens, so weighted failover to a second local CLI would be
+    # wrong. With no plugin, the built-in ClaudeInvoker is used unchanged.
+    # See cli_invoker_plugin for the contract and selection order.
+    factory = get_invoker_factory()
+    if factory is not None:
+        primary_invoker = factory(analysis_model, claude_soft_timeout_seconds)
+        return CliDispatcher(claude=primary_invoker, codex=None, codex_weight=0.0)
 
     codex_invoker = None
     codex_weight = 0.0

--- a/tests/unit/server/services/test_cli_invoker_plugin.py
+++ b/tests/unit/server/services/test_cli_invoker_plugin.py
@@ -32,6 +32,19 @@ from code_indexer.server.services.dep_map_dispatcher_factory import (
 from code_indexer.server.services.intelligence_cli_invoker import InvocationResult
 
 
+def _fake_entry_points_no_plugin(group=None):
+    """Mirrors the REAL cross-version importlib.metadata.entry_points() call
+    shapes (Python 3.9 real signature takes zero parameters and returns a
+    plain dict; 3.10+ accepts group= and returns an iterable directly) so
+    tests stay correct regardless of which branch the running interpreter's
+    version takes -- unlike a single-shape fake, which would silently mask a
+    version-specific incompatibility exactly like the one this module fixes.
+    """
+    if group is None:
+        return {}
+    return []
+
+
 @pytest.fixture(autouse=True)
 def _clear(monkeypatch):
     monkeypatch.delenv(ENV_VAR, raising=False)
@@ -39,7 +52,9 @@ def _clear(monkeypatch):
     # venv: these tests exercise the env-var path explicitly, and the default
     # case must mean "no entry point either". (In CI the orchestrator plugin is
     # not installed; locally it may be.)
-    monkeypatch.setattr(cli_invoker_plugin, "entry_points", lambda group=None: [])
+    monkeypatch.setattr(
+        cli_invoker_plugin, "entry_points", _fake_entry_points_no_plugin
+    )
     cli_invoker_plugin.reset_cache()
     yield
     cli_invoker_plugin.reset_cache()
@@ -108,6 +123,41 @@ class TestPluginTakesThePrimarySlot:
 
         assert result.success is True
         assert result.cli_used == "stub"
+
+
+class TestPython39EntryPointsRealSignature:
+    """Bug: Python 3.9's REAL importlib.metadata.entry_points() takes ZERO
+    parameters and returns a plain dict (group -> List[EntryPoint]); the
+    ``group=`` keyword argument was only added in Python 3.10. The autouse
+    ``_clear`` fixture above masks this because its fake
+    (``lambda group=None: []``) accepts ``group=`` unconditionally, unlike the
+    real pre-3.10 stdlib -- so it cannot catch this incompatibility. This test
+    installs a fake that mirrors the REAL 3.9 signature exactly (no
+    parameters at all) to prove the entry-point-discovery code path actually
+    works under genuine Python 3.9 semantics.
+    """
+
+    def test_load_from_entry_points_with_real_py39_signature(self, monkeypatch):
+        class _FakeEntryPoint:
+            name = "test-plugin"
+
+            def load(self):
+                return make_stub
+
+        def _fake_entry_points_py39_signature():
+            # Real Python 3.9 signature: entry_points() -- NO parameters,
+            # not even an optional one. Passing group=... raises TypeError,
+            # exactly like the genuine stdlib on 3.9.
+            return {cli_invoker_plugin.ENTRY_POINT_GROUP: [_FakeEntryPoint()]}
+
+        monkeypatch.setattr(
+            cli_invoker_plugin, "entry_points", _fake_entry_points_py39_signature
+        )
+        cli_invoker_plugin.reset_cache()
+
+        factory = get_invoker_factory()
+
+        assert factory is make_stub
 
 
 class TestMisconfigurationFailsLoud:

--- a/tests/unit/server/services/test_cli_invoker_plugin.py
+++ b/tests/unit/server/services/test_cli_invoker_plugin.py
@@ -1,0 +1,132 @@
+"""
+Pluggable primary CLI invoker at the dispatcher seam.
+
+build_dep_map_dispatcher is the single source of truth for every
+description/analysis LLM call (lifecycle, dep-map, description refresh,
+self-monitoring). A deployment that cannot ship the `claude` CLI in the image
+can substitute the primary invoker; with no plugin configured, nothing changes.
+
+These tests pin:
+  * no plugin -> a real ClaudeInvoker in the claude= slot (default unchanged);
+  * a plugin -> its invoker takes the claude= slot AND codex is disabled (the
+    plugin IS where execution happens; failover to a second local CLI is wrong);
+  * the factory receives the same (analysis_model, soft_timeout) the built-in
+    ClaudeInvoker would have; and
+  * misconfiguration fails loud rather than silently using the CLI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from code_indexer.server.services import cli_invoker_plugin
+from code_indexer.server.services.cli_invoker_plugin import (
+    ENV_VAR,
+    CliInvokerPluginError,
+    get_invoker_factory,
+)
+from code_indexer.server.services.claude_invoker import ClaudeInvoker
+from code_indexer.server.services.dep_map_dispatcher_factory import (
+    build_dep_map_dispatcher,
+)
+from code_indexer.server.services.intelligence_cli_invoker import InvocationResult
+
+
+@pytest.fixture(autouse=True)
+def _clear(monkeypatch):
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    # Deterministic regardless of what happens to be pip-installed in the dev
+    # venv: these tests exercise the env-var path explicitly, and the default
+    # case must mean "no entry point either". (In CI the orchestrator plugin is
+    # not installed; locally it may be.)
+    monkeypatch.setattr(cli_invoker_plugin, "entry_points", lambda group=None: [])
+    cli_invoker_plugin.reset_cache()
+    yield
+    cli_invoker_plugin.reset_cache()
+
+
+class _StubInvoker:
+    def __init__(self, model, soft_timeout):
+        self.model = model
+        self.soft_timeout = soft_timeout
+
+    def invoke(self, flow, cwd, prompt, timeout, max_turns=0):
+        return InvocationResult(True, "stub", "", "stub", False)
+
+
+last_factory_args = {}
+
+
+def make_stub(analysis_model, soft_timeout_seconds):
+    last_factory_args["model"] = analysis_model
+    last_factory_args["soft_timeout"] = soft_timeout_seconds
+    return _StubInvoker(analysis_model, soft_timeout_seconds)
+
+
+not_callable = "nope"
+
+_THIS = "tests.unit.server.services.test_cli_invoker_plugin"
+
+
+class TestDefaultIsUnchanged:
+    def test_no_plugin_uses_claude_invoker(self):
+        assert get_invoker_factory() is None
+        dispatcher = build_dep_map_dispatcher(None)
+        assert isinstance(dispatcher.claude, ClaudeInvoker)
+
+
+class TestPluginTakesThePrimarySlot:
+    def test_plugin_invoker_replaces_claude_and_disables_codex(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, f"{_THIS}:make_stub")
+        dispatcher = build_dep_map_dispatcher(None)
+
+        # Identity check by name: the env-var spec re-imports this module under a
+        # second name, so `is _StubInvoker` would compare two class objects.
+        assert type(dispatcher.claude).__name__ == "_StubInvoker"
+        assert not isinstance(dispatcher.claude, ClaudeInvoker)
+        # Codex routing must be off: the plugin is where execution happens.
+        assert dispatcher.codex is None
+        assert dispatcher.codex_weight == 0.0
+
+    def test_factory_gets_the_model_and_timeout_claude_would_have(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, f"{_THIS}:make_stub")
+
+        dispatcher = build_dep_map_dispatcher(
+            None, analysis_model="sonnet", claude_soft_timeout_seconds=123
+        )
+
+        # Read the args back off the invoker the factory produced, rather than a
+        # module global (double-import makes the global unreliable).
+        assert dispatcher.claude.model == "sonnet"
+        assert dispatcher.claude.soft_timeout == 123
+
+    def test_dispatch_routes_through_the_plugin(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, f"{_THIS}:make_stub")
+        dispatcher = build_dep_map_dispatcher(None)
+
+        result = dispatcher.dispatch("describe", "/repo", "prompt", 10)
+
+        assert result.success is True
+        assert result.cli_used == "stub"
+
+
+class TestMisconfigurationFailsLoud:
+    def test_unknown_module(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "no_such_module_zzz:make")
+        with pytest.raises(CliInvokerPluginError, match="cannot import module"):
+            get_invoker_factory()
+
+    def test_missing_attribute(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, f"{_THIS}:does_not_exist")
+        with pytest.raises(CliInvokerPluginError, match="has no attribute"):
+            get_invoker_factory()
+
+    def test_not_callable(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, f"{_THIS}:not_callable")
+        with pytest.raises(CliInvokerPluginError, match="not callable"):
+            get_invoker_factory()
+
+    def test_malformed_spec(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "no.colon.here")
+        with pytest.raises(CliInvokerPluginError, match="package.module:factory"):
+            get_invoker_factory()


### PR DESCRIPTION
## Problem

Every description/analysis LLM call — golden-repo registration lifecycle, dep-map passes, description refresh, self-monitoring — is dispatched through the `CliDispatcher` built by `build_dep_map_dispatcher` (its own docstring: *"the single source of truth for CliDispatcher construction across all callers"*). Its primary invoker is a `ClaudeInvoker` that shells out to the `claude` CLI.

Some deployments cannot ship that CLI in the server image. Ours runs cidx as a multi-pod service on EKS, where LLM execution must stay inside a separate sandboxed agent runner. Without a seam, every registration `lifecycle_registration` job dies with `ClaudeInvoker: non-zero exit 127`, and the only options are to bake the CLI in or patch the server.

## Fix

Add `server/services/cli_invoker_plugin.py`: a factory-style plugin (`CIDX_CLI_INVOKER` env / `code_indexer.cli_invoker` entry point) returning an `IntelligenceCliInvoker`. `build_dep_map_dispatcher` consults it — when a plugin is configured it takes the `claude=` slot and codex routing is disabled (the point of the plugin is that *this* is where LLM execution happens, so weighted failover to a second local CLI would be wrong). With no plugin, the built-in `ClaudeInvoker` is used unchanged; a test pins that.

Because this is the **one** `CliDispatcher` construction site, a single seam covers every consumer, with the full `IntelligenceCliInvoker`/`InvocationResult` contract (model, timeout, max_turns, failure_class) that dep-map needs.

## Why not at `invoke_claude_cli`

This **supersedes #1410**, which seamed at `repo_analyzer.invoke_claude_cli`. That is a *secondary* path: the lifecycle/dep-map/refresh/self-monitoring calls all go through the dispatcher, not through `invoke_claude_cli`. I confirmed this the hard way — a plugin at `invoke_claude_cli` deployed to a live cluster and the lifecycle *still* failed with `exit 127`, because the dispatcher path never touches it. Seaming at the dispatcher is the correct, single chokepoint, and it carries the richer result contract (`invoke_claude_cli` returns a bare `(ok, output)` tuple, which cannot express the `failure_class` the dispatcher's retry/failover needs).

## Misconfiguration fails loud

A bad `CIDX_CLI_INVOKER` raises `CliInvokerPluginError` rather than falling back to the CLI — a silent fallback would hand a deployment the exact behaviour it configured a plugin to avoid, discoverable only from a stack trace inside a background job.

## Verification

Validated end-to-end on a live cluster: with the orchestrator plugin installed, `build_dep_map_dispatcher(None).claude` is the plugin invoker (codex `None`), a golden-repo registration submits a real agent job (`flow=repo_lifecycle`), and that job completes `exit 0` with genuine repo-analysis output — where the `invoke_claude_cli` seam left it at `exit 127`.

## Tests

8 tests (default unchanged; plugin takes the primary slot + disables codex; factory receives the model/timeout `ClaudeInvoker` would have; dispatch routes through the plugin; every misconfiguration mode fails loud). Existing dispatcher/factory suites: 817 passed. ruff, black, mypy clean.