### PR TITLE
Add generic externally_managed golden-repos mode

### DIFF
--- a/src/code_indexer/global_repos/refresh_scheduler.py
+++ b/src/code_indexer/global_repos/refresh_scheduler.py
@@ -1362,6 +1362,23 @@ class RefreshScheduler:
             # ConfigManager (CLI)
             return cast(int, self.config_source.get_global_refresh_interval())
 
+    def _is_externally_managed(self) -> bool:
+        """
+        Whether golden-repo presence/refresh is owned by an external manager.
+
+        When true, the server does not run its own refresh cycle or startup
+        restore reconciliation — an external owner materializes and refreshes
+        the clones, and the server only indexes/serves what is registered.
+
+        Only meaningful in server mode (GlobalRepoOperations). The CLI path has
+        no external owner, so it is always False.
+        """
+        if isinstance(self.config_source, GlobalRepoOperations):
+            return bool(
+                self.config_source.get_config().get("externally_managed", False)
+            )
+        return False
+
     def is_running(self) -> bool:
         """
         Check if scheduler is running.
@@ -1379,6 +1396,16 @@ class RefreshScheduler:
         """
         if self._running:
             logger.debug("Refresh scheduler already running")
+            return
+
+        # When golden repos are externally managed, an external owner drives
+        # refresh; running our own periodic refresh would fight it. Skip the
+        # background thread entirely (leave _running False so nothing polls).
+        if self._is_externally_managed():
+            logger.info(
+                "externally_managed=True: skipping self-managed refresh scheduler "
+                "(external owner drives golden-repo refresh)"
+            )
             return
 
         self._running = True
@@ -3448,6 +3475,19 @@ class RefreshScheduler:
         Story #236 AC4-AC7.
         """
         from datetime import datetime
+
+        # When golden repos are externally managed, the external owner — not the
+        # server — decides which clones exist on disk. Restoring "missing" masters
+        # from snapshots here would resurrect repos the owner intentionally
+        # removed. Skip reconciliation entirely. Deliberately do NOT write the
+        # completion marker, so that turning this mode back off later still runs
+        # the one-time reconcile.
+        if self._is_externally_managed():
+            logger.info(
+                "externally_managed=True: skipping startup golden-repo "
+                "reconciliation (external owner owns golden-repo presence)"
+            )
+            return
 
         marker_file = self.golden_repos_dir / ".reconciliation_complete_v1"
 

--- a/src/code_indexer/global_repos/shared_operations.py
+++ b/src/code_indexer/global_repos/shared_operations.py
@@ -207,6 +207,8 @@ class GlobalRepoOperations:
         Returns:
             Configuration dict with fields:
             - refresh_interval: Refresh interval in seconds
+            - externally_managed: True when an external owner manages golden-repo
+              presence/refresh (server skips self-refresh and startup restore)
 
         Story #3 - Configuration Consolidation:
         Now reads from centralized config.json via ConfigService instead of
@@ -219,13 +221,19 @@ class GlobalRepoOperations:
             config_service = get_config_service()
             golden_repos_config = config_service.get_config().golden_repos_config
             # golden_repos_config is guaranteed non-None by ServerConfig.__post_init__
-            return {"refresh_interval": golden_repos_config.refresh_interval_seconds}
+            return {
+                "refresh_interval": golden_repos_config.refresh_interval_seconds,
+                "externally_managed": golden_repos_config.externally_managed,
+            }
         except (RuntimeError, ValueError, IOError) as e:
             logger.warning(
                 f"Failed to load config from ConfigService, using defaults: {e}"
             )
             # Return default config on error
-            return {"refresh_interval": DEFAULT_REFRESH_INTERVAL}
+            return {
+                "refresh_interval": DEFAULT_REFRESH_INTERVAL,
+                "externally_managed": False,
+            }
 
     def set_config(self, refresh_interval: int) -> None:
         """

--- a/src/code_indexer/server/services/config_service.py
+++ b/src/code_indexer/server/services/config_service.py
@@ -629,6 +629,7 @@ class ConfigService:
             "golden_repos": {
                 "refresh_interval_seconds": config.golden_repos_config.refresh_interval_seconds,
                 "analysis_model": config.golden_repos_config.analysis_model,
+                "externally_managed": config.golden_repos_config.externally_managed,
             },
             # Story #3 - Phase 2: P0/P1 settings
             "mcp_session": {
@@ -2137,6 +2138,8 @@ class ConfigService:
             if value not in ("opus", "sonnet"):
                 raise ValueError(f"Invalid analysis_model: {value}")
             golden_repos.analysis_model = value
+        elif key == "externally_managed":
+            golden_repos.externally_managed = value in ["true", True, "True"]
         else:
             raise ValueError(f"Unknown golden repos setting: {key}")
 
@@ -3246,9 +3249,9 @@ class ConfigService:
                     "SELECT version FROM server_config WHERE config_key = %s",
                     (CONFIG_KEY_RUNTIME,),
                 ).fetchone()
-            assert row is not None, (
-                "server_config row must exist after INSERT ON CONFLICT DO NOTHING"
-            )
+            assert (
+                row is not None
+            ), "server_config row must exist after INSERT ON CONFLICT DO NOTHING"
             self._db_config_version = row["version"]
         logger.info(
             "ConfigService: seeded runtime config to PostgreSQL (%d keys)",

--- a/src/code_indexer/server/startup/lifespan.py
+++ b/src/code_indexer/server/startup/lifespan.py
@@ -841,6 +841,29 @@ def make_lifespan(
 
             # Get server config for resource_config (timeouts, etc.)
             config_service = get_config_service()
+
+            # In cluster/postgres mode, set the ConfigService PG pool HERE, before
+            # the global-repos lifecycle starts, so its refresh scheduler and
+            # startup reconciliation read the MERGED runtime config (e.g.
+            # golden_repos_config.externally_managed) rather than bootstrap
+            # defaults. Mirrors the Bug #1309 early-pool fix, which runs later in
+            # startup and so did not cover these schedulers. set_connection_pool ->
+            # _load_runtime_from_pg is idempotent, so the later call is harmless.
+            if storage_mode == "postgres" and backend_registry is not None:
+                try:
+                    _gr_config_pool = (
+                        backend_registry.critical_connection_pool
+                        or backend_registry.connection_pool
+                    )
+                    if _gr_config_pool is not None:
+                        config_service.set_connection_pool(_gr_config_pool)
+                except Exception as _gr_pool_exc:  # non-fatal: fall back to bootstrap
+                    logger.warning(
+                        "Could not set ConfigService PG pool before global-repos "
+                        "start; schedulers may read bootstrap config: %s",
+                        _gr_pool_exc,
+                    )
+
             server_config = config_service.get_config()
 
             # Story #1034 wiring fix: build VersionedSnapshotManager BEFORE
@@ -4277,7 +4300,9 @@ def make_lifespan(
                     "DependencyLatencyTracker stopped successfully",
                     extra={"correlation_id": get_correlation_id()},
                 )
-            except Exception as e:  # broad catch intentional: shutdown must not abort remaining cleanup chain
+            except (
+                Exception
+            ) as e:  # broad catch intentional: shutdown must not abort remaining cleanup chain
                 logger.error(
                     format_error_log(
                         "APP-GENERAL-027",

--- a/src/code_indexer/server/utils/config_manager.py
+++ b/src/code_indexer/server/utils/config_manager.py
@@ -163,7 +163,9 @@ class ServerResourceConfig:
     git_untracked_file_timeout: int = 60  # 1 minute for untracked file check
 
     # Refresh scheduler timeouts (in seconds)
-    cow_clone_timeout: int = 3600  # 1 hour for CoW clone of very large repos (e.g. evolution ~1M files, phoenix 40GB); ~2-3x headroom over measured ~17-19 min
+    cow_clone_timeout: int = (
+        3600  # 1 hour for CoW clone of very large repos (e.g. evolution ~1M files, phoenix 40GB); ~2-3x headroom over measured ~17-19 min
+    )
     git_update_index_timeout: int = 300  # 5 minutes for git update-index during refresh
     git_restore_timeout: int = 300  # 5 minutes for git restore during refresh
     cidx_fix_config_timeout: int = 60  # 1 minute for cidx fix-config
@@ -319,6 +321,14 @@ class GoldenReposConfig:
     refresh_interval_seconds: int = 3600
     # Story #76 AC2: Claude model for repository analysis (opus or sonnet)
     analysis_model: str = "opus"
+    # When true, an external owner (e.g. a provisioning service) owns golden-repo
+    # presence and freshness: it materializes each repo directly into
+    # golden_repos_dir and registers it via the admin API. The server then only
+    # indexes and serves what is registered — it skips its own periodic refresh
+    # and its startup restore-from-snapshot reconciliation, so it never fights the
+    # external owner over which clones should exist on disk. Default false keeps
+    # the server fully self-managing.
+    externally_managed: bool = False
 
 
 @dataclass
@@ -1424,8 +1434,12 @@ class ServerConfig:
     # Both default True since v9.23.3 so fresh installs automatically inherit the
     # protections. Operators can disable either by setting the flag to false in
     # ~/.cidx-server/config.json; readable before the DB is available (cleanup daemon thread).
-    enable_malloc_trim: bool = True  # Mitigation 1: call malloc_trim(0) after eviction. Default ON since v9.23.3.
-    enable_malloc_arena_max: bool = True  # Mitigation 2: inject MALLOC_ARENA_MAX=2 via systemd. Default ON since v9.23.3.
+    enable_malloc_trim: bool = (
+        True  # Mitigation 1: call malloc_trim(0) after eviction. Default ON since v9.23.3.
+    )
+    enable_malloc_arena_max: bool = (
+        True  # Mitigation 2: inject MALLOC_ARENA_MAX=2 via systemd. Default ON since v9.23.3.
+    )
 
     # Story #1032 AC6 - Pre-deactivation leak scan (bootstrap-only, never DB).
     # Default False: _detect_resource_leaks is post-failure-only diagnostic.
@@ -2051,13 +2065,13 @@ class ServerConfigManager:
             if "scip_config" not in config_dict:
                 config_dict["scip_config"] = {}
             if isinstance(config_dict["scip_config"], dict):
-                config_dict["scip_config"]["scip_workspace_retention_days"] = (
+                config_dict["scip_config"][
+                    "scip_workspace_retention_days"
+                ] = retention_days
+            elif isinstance(config_dict["scip_config"], ScipConfig):
+                config_dict["scip_config"].scip_workspace_retention_days = (
                     retention_days
                 )
-            elif isinstance(config_dict["scip_config"], ScipConfig):
-                config_dict[
-                    "scip_config"
-                ].scip_workspace_retention_days = retention_days
 
         # Story #15 AC2: Final conversion of scip_config after migration
         # This handles the case where scip_config was created by migration above

--- a/tests/unit/global_repos/test_refresh_scheduler_externally_managed.py
+++ b/tests/unit/global_repos/test_refresh_scheduler_externally_managed.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for RefreshScheduler externally_managed gating (EVO-64493).
+
+When golden repos are externally managed, the scheduler must:
+- NOT launch its periodic refresh thread (start() is a no-op), and
+- NOT run startup restore reconciliation, and specifically NOT write the
+  completion marker (so turning the mode back off later still reconciles once).
+
+The reader is only active in server mode (GlobalRepoOperations config_source);
+the CLI ConfigManager path is always self-managed.
+"""
+
+import pytest
+from unittest.mock import Mock
+
+from code_indexer.global_repos.refresh_scheduler import RefreshScheduler
+from code_indexer.global_repos.shared_operations import GlobalRepoOperations
+from code_indexer.global_repos.query_tracker import QueryTracker
+from code_indexer.global_repos.cleanup_manager import CleanupManager
+
+
+@pytest.fixture
+def golden_repos_dir(tmp_path):
+    d = tmp_path / "golden-repos"
+    d.mkdir(parents=True)
+    return d
+
+
+def _make_scheduler(golden_repos_dir, externally_managed, registry=None):
+    # Mock(spec=GlobalRepoOperations) passes isinstance() in _is_externally_managed.
+    config_source = Mock(spec=GlobalRepoOperations)
+    config_source.get_config.return_value = {
+        "refresh_interval": 3600,
+        "externally_managed": externally_managed,
+    }
+    if registry is None:
+        registry = Mock()
+        registry.list_global_repos.return_value = []
+    return RefreshScheduler(
+        golden_repos_dir=str(golden_repos_dir),
+        config_source=config_source,
+        query_tracker=Mock(spec=QueryTracker),
+        cleanup_manager=Mock(spec=CleanupManager),
+        registry=registry,
+    )
+
+
+def test_is_externally_managed_reflects_config(golden_repos_dir):
+    assert _make_scheduler(golden_repos_dir, True)._is_externally_managed() is True
+    assert _make_scheduler(golden_repos_dir, False)._is_externally_managed() is False
+
+
+def test_start_skips_thread_when_externally_managed(golden_repos_dir):
+    sched = _make_scheduler(golden_repos_dir, True)
+    sched.start()
+    assert sched.is_running() is False
+
+
+def test_reconcile_skipped_and_no_marker_when_externally_managed(golden_repos_dir):
+    registry = Mock()
+    registry.list_global_repos.return_value = []
+    sched = _make_scheduler(golden_repos_dir, True, registry=registry)
+
+    sched.reconcile_golden_repos()
+
+    # Skipped before touching the registry, and the marker was NOT written.
+    registry.list_global_repos.assert_not_called()
+    assert not (golden_repos_dir / ".reconciliation_complete_v1").exists()
+
+
+def test_reconcile_runs_when_not_externally_managed(golden_repos_dir):
+    registry = Mock()
+    registry.list_global_repos.return_value = []
+    sched = _make_scheduler(golden_repos_dir, False, registry=registry)
+
+    sched.reconcile_golden_repos()
+
+    # Self-managed: reconciliation ran (listed repos) and wrote the marker.
+    registry.list_global_repos.assert_called_once()
+    assert (golden_repos_dir / ".reconciliation_complete_v1").exists()

--- a/tests/unit/global_repos/test_shared_operations_externally_managed.py
+++ b/tests/unit/global_repos/test_shared_operations_externally_managed.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for GlobalRepoOperations.get_config() surfacing externally_managed
+(EVO-64493). This is the read-path the RefreshScheduler uses to decide whether
+golden repos are externally owned; it must surface the flag and default to
+False when config cannot be loaded.
+"""
+
+from unittest.mock import Mock, patch
+
+from code_indexer.global_repos.shared_operations import (
+    GlobalRepoOperations,
+    DEFAULT_REFRESH_INTERVAL,
+)
+
+
+def test_get_config_surfaces_externally_managed(tmp_path):
+    ops = GlobalRepoOperations(str(tmp_path))
+    fake_cfg = Mock()
+    fake_cfg.golden_repos_config.refresh_interval_seconds = 3600
+    fake_cfg.golden_repos_config.externally_managed = True
+    fake_service = Mock()
+    fake_service.get_config.return_value = fake_cfg
+
+    with patch(
+        "code_indexer.server.services.config_service.get_config_service",
+        return_value=fake_service,
+    ):
+        cfg = ops.get_config()
+
+    assert cfg["externally_managed"] is True
+    assert cfg["refresh_interval"] == 3600
+
+
+def test_get_config_defaults_externally_managed_false_on_error(tmp_path):
+    ops = GlobalRepoOperations(str(tmp_path))
+
+    with patch(
+        "code_indexer.server.services.config_service.get_config_service",
+        side_effect=RuntimeError("boom"),
+    ):
+        cfg = ops.get_config()
+
+    assert cfg["externally_managed"] is False
+    assert cfg["refresh_interval"] == DEFAULT_REFRESH_INTERVAL

--- a/tests/unit/server/services/test_config_service_externally_managed.py
+++ b/tests/unit/server/services/test_config_service_externally_managed.py
@@ -1,0 +1,53 @@
+"""
+Unit tests for ConfigService golden_repos.externally_managed (EVO-64493).
+
+Verifies the flag is exposed in get_all_settings() and can be written via
+update_setting (bool and string forms), mirroring the description_refresh_enabled
+boolean-setting precedent.
+"""
+
+from code_indexer.server.services.config_service import ConfigService
+
+
+class TestConfigServiceExternallyManaged:
+    def test_get_all_settings_includes_externally_managed(self, tmp_path):
+        service = ConfigService(server_dir_path=str(tmp_path))
+        settings = service.get_all_settings()
+        assert "golden_repos" in settings
+        assert "externally_managed" in settings["golden_repos"]
+
+    def test_externally_managed_default_value(self, tmp_path):
+        service = ConfigService(server_dir_path=str(tmp_path))
+        settings = service.get_all_settings()
+        assert isinstance(settings["golden_repos"]["externally_managed"], bool)
+        assert settings["golden_repos"]["externally_managed"] is False
+
+    def test_update_externally_managed_true(self, tmp_path):
+        service = ConfigService(server_dir_path=str(tmp_path))
+        service.load_config()
+        service.update_setting("golden_repos", "externally_managed", True)
+        settings = service.get_all_settings()
+        assert settings["golden_repos"]["externally_managed"] is True
+
+    def test_update_externally_managed_false(self, tmp_path):
+        service = ConfigService(server_dir_path=str(tmp_path))
+        service.load_config()
+        service.update_setting("golden_repos", "externally_managed", False)
+        settings = service.get_all_settings()
+        assert settings["golden_repos"]["externally_managed"] is False
+
+    def test_update_externally_managed_string_true(self, tmp_path):
+        service = ConfigService(server_dir_path=str(tmp_path))
+        service.load_config()
+        service.update_setting("golden_repos", "externally_managed", "true")
+        settings = service.get_all_settings()
+        assert settings["golden_repos"]["externally_managed"] is True
+
+    def test_update_externally_managed_persists(self, tmp_path):
+        service = ConfigService(server_dir_path=str(tmp_path))
+        service.load_config()
+        service.update_setting("golden_repos", "externally_managed", True)
+        # Re-read from a fresh service to confirm it persisted to disk.
+        reloaded = ConfigService(server_dir_path=str(tmp_path))
+        settings = reloaded.get_all_settings()
+        assert settings["golden_repos"]["externally_managed"] is True

--- a/tests/unit/server/utils/test_config_manager_externally_managed.py
+++ b/tests/unit/server/utils/test_config_manager_externally_managed.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for GoldenReposConfig.externally_managed (EVO-64493).
+
+The flag lets an external owner manage golden-repo presence/refresh; the server
+then only indexes/serves. These tests pin: defaults to False, round-trips
+through save/load, coexists with the other golden-repo fields, and old configs
+lacking the key still load (backward compatible).
+"""
+
+import json
+from pathlib import Path
+
+from code_indexer.server.utils.config_manager import (
+    ServerConfigManager,
+    GoldenReposConfig,
+)
+
+
+def test_externally_managed_defaults_to_false():
+    """New GoldenReposConfig defaults externally_managed to False (self-managed)."""
+    config = GoldenReposConfig()
+    assert config.externally_managed is False
+
+
+def test_externally_managed_saves_and_loads(tmp_path: Path):
+    """externally_managed persists through a save/load cycle."""
+    config_manager = ServerConfigManager(str(tmp_path))
+    config = config_manager.create_default_config()
+
+    assert config.golden_repos_config is not None
+    config.golden_repos_config.externally_managed = True
+
+    config_manager.save_config(config)
+    loaded_config = config_manager.load_config()
+
+    assert loaded_config is not None
+    assert loaded_config.golden_repos_config is not None
+    assert loaded_config.golden_repos_config.externally_managed is True
+
+
+def test_externally_managed_missing_from_old_config(tmp_path: Path):
+    """An old config without the key loads with externally_managed defaulting False."""
+    config_data = {
+        "server_dir": str(tmp_path),
+        "golden_repos_config": {
+            "refresh_interval_seconds": 3600,
+            "analysis_model": "opus",
+        },
+    }
+    config_file = tmp_path / "config.json"
+    with open(config_file, "w") as f:
+        json.dump(config_data, f)
+
+    config_manager = ServerConfigManager(str(tmp_path))
+    loaded_config = config_manager.load_config()
+
+    assert loaded_config is not None
+    assert loaded_config.golden_repos_config is not None
+    assert loaded_config.golden_repos_config.externally_managed is False
+
+
+def test_externally_managed_coexists_with_other_golden_fields(tmp_path: Path):
+    """externally_managed does not disturb refresh_interval_seconds / analysis_model."""
+    config_manager = ServerConfigManager(str(tmp_path))
+    config = config_manager.create_default_config()
+
+    assert config.golden_repos_config is not None
+    config.golden_repos_config.refresh_interval_seconds = 120
+    config.golden_repos_config.analysis_model = "sonnet"
+    config.golden_repos_config.externally_managed = True
+
+    config_manager.save_config(config)
+    loaded_config = config_manager.load_config()
+
+    assert loaded_config is not None
+    assert loaded_config.golden_repos_config is not None
+    gr = loaded_config.golden_repos_config
+    assert gr.refresh_interval_seconds == 120
+    assert gr.analysis_model == "sonnet"
+    assert gr.externally_managed is True


### PR DESCRIPTION
When `golden_repos_config.externally_managed` is true, an external owner manages golden-repo **presence and freshness**: it materializes each repo into `golden_repos_dir` and registers it via the admin API, and the server only indexes/serves what is registered.

In that mode the server skips:
- its own **periodic refresh** (`RefreshScheduler.start()` no-ops), and
- its **startup restore-from-snapshot reconciliation** (`reconcile_golden_repos()` returns early *without* writing the completion marker, so turning the mode back off later still runs the one-time reconcile).

Registration and all query/serve paths are unchanged. Default `false` keeps the server fully self-managing — this is purely additive and opt-in.

Also fixes a startup-ordering issue for cluster/postgres mode: the global-repos lifecycle started before the ConfigService PG pool was set, so the gate read bootstrap defaults instead of the merged runtime config. The pool is now set before the global-repos block (the existing early-pool fix ran later in startup and only covered the description-refresh / dependency-map schedulers). `set_connection_pool` -> `_load_runtime_from_pg` is idempotent, so the later call is harmless.

Tests: config default/round-trip/backward-compat, config-service get/set, and scheduler gating (both `start()` and `reconcile_golden_repos()` skip when the flag is set; the reconcile marker is not written). Validated end-to-end on a multi-pod cluster: both gates fire on both replicas; an externally-written repo indexes in place and both pods serve it.
