### PR TITLE
feat(cluster): memory-aware admission + pod-pull work-stealing for heavy index jobs

### DIFF
--- a/docs/architecture-invariants.md
+++ b/docs/architecture-invariants.md
@@ -593,6 +593,20 @@ Deepest reference: `docs/server-memory-invariants.md`.
 
 ---
 
+### Pod-Pull Work-Stealing + Memory-Aware Admission (PR #1424)
+
+In cluster mode (`storage_mode=postgres`) the memory-heavy index ops in `POD_PULL_OPS` (`background_jobs.py`: `add_golden_repo`, `provider_index_add`, `provider_temporal_index_rebuild`, `sync_repository`, `change_branch`) are left PENDING in the shared `background_jobs` queue with their reconstruction params in the row's `metadata` JSONB, and are claimed and executed by an always-on per-pod `IndexJobClaimLoop` via the memory-gated `DistributedJobClaimer`. Key invariants:
+
+- **Shared claimer memory gate also throttles the leader's refresh claims (intended)**: `lifespan.py` builds ONE `DistributedJobClaimer` (with the cgroup-aware memory gate) and shares it between the leader-only `DistributedJobWorkerService` and the per-pod `IndexJobClaimLoop`. The gate is checked at the top of `claim_next_job` BEFORE any op-type filter, so under sustained memory pressure the leader also declines `refresh_golden_repo` claims, not just pod-pull ops. This is deliberate (refresh is memory-heavy too) -- a pressured pod leaves refresh rows PENDING for a pod with headroom rather than risking an OOM.
+- **Disjoint claim sets**: the leader claims with `exclude_types=POD_PULL_OPS`; the loop claims with `job_types=POD_PULL_OPS`. Complementary filters + `FOR UPDATE SKIP LOCKED` guarantee exactly one executor per row.
+- **Work-stolen progress is DB-backed (H2)**: the executing pod is NOT the submitting pod, so the in-process progress_callback closure is gone. `IndexJobClaimLoop` injects a per-job callback that routes to `DistributedJobClaimer.update_progress` (ownership-scoped `UPDATE background_jobs SET progress/current_phase/phase_detail ...`), so the originating node's dashboard -- which polls that row -- shows real incremental progress. For `sync_repository` the client webhook (`options.progress_webhook`, carried in metadata) is rebuilt on the executing node via the shared `build_sync_progress_webhook_callback` (`app_helpers.py`) and fanned out alongside the DB callback. Progress writes are best-effort (a failed tick never fails the work).
+- **Retry-safe add_golden_repo (H1)**: pod-pull makes these ops cross-node reclaim-eligible (dead-node reclaim resets a dead node's `running` row to `pending`). `execute_add_golden_repo_work` calls `_remove_orphan_clone_for_retry` before cloning: a hard-crash partial clone (dir present, NO committed `golden_repos` row, not in-place) is removed so the retry does not wedge forever on "destination path already exists". Guarded to never delete in-place-registration content or a committed registration.
+- **No stale node-local job state (Cluster-Aware State)**: `submit_job` does NOT retain the in-memory `self.jobs[job_id]` entry for a pod-pull job (it is `pop`ped in the pod-pull early-return). The job runs on whichever node claims it and its truth lives in the shared `background_jobs` row; because `get_job_status` and `get_jobs_for_display` both PREFER the in-memory copy over the DB row, keeping a node-local PENDING entry would make a poll landing on the submitting node report stale PENDING forever. Dropping it makes both read paths fall through to the shared DB row on every node. Cancellation stays correct via `cancel_job`'s no-in-memory cross-node DB-cancellation branch.
+- **Dispatch coverage guard (M3)**: `validate_dispatch_covers(_index_dispatch, POD_PULL_OPS)` runs at startup and raises if the dispatch executors do not EXACTLY cover `POD_PULL_OPS`, so a future half-wired op fails loudly instead of being claimed with no executor.
+- **Admission gate fail-open**: the local-pool admission gate (`_admission_blocked`) and the claimer memory gate both fail OPEN (allow the job) when no `MemoryGovernor` exists, the gate is disabled, or the governor raises -- degrading to pre-PR behavior rather than wedging the queue.
+
+---
+
 ## Global Repo Alias Fallback
 
 ### Global Repo Alias Fallback (Story #1039)

--- a/src/code_indexer/server/app_helpers.py
+++ b/src/code_indexer/server/app_helpers.py
@@ -15,6 +15,7 @@ app.py sets it via set_server_start_time() during create_app().
 import json
 import logging
 import psutil
+import requests
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, cast
@@ -349,6 +350,55 @@ def _find_activated_repository(
             return cast(Optional[str], repo["user_alias"])
 
     return None
+
+
+# Sync progress webhook POST timeout (seconds). Kept short so a slow/unreachable
+# client webhook never stalls the sync; preserves the original inline value.
+WEBHOOK_POST_TIMEOUT_SECONDS = 5
+
+
+def build_sync_progress_webhook_callback(
+    webhook_url: Optional[str],
+    repo_id: str,
+    username: str,
+) -> Optional[Callable[[int], None]]:
+    """Build a best-effort sync-progress webhook callback, or None.
+
+    Single source of the sync webhook-POST logic (PR #1424 H2). Used by BOTH the
+    local sync path (inline_repos) and the executing node's pod-pull dispatch
+    (lifespan), so a work-stolen sync -- which runs on the CLAIMING node, not the
+    submitting one -- can rebuild and push the client-supplied webhook (carried
+    in job metadata ``options.progress_webhook``) from that node.
+
+    Returns None when no URL is provided. Otherwise returns
+    ``callback(progress: int)`` that POSTs a small JSON payload and NEVER raises
+    (a webhook failure must not interrupt the sync).
+    """
+    if not webhook_url:
+        return None
+
+    def webhook_callback(progress: int) -> None:
+        try:
+            payload = {
+                "repository_id": repo_id,
+                "progress": progress,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "username": username,
+            }
+            response = requests.post(
+                webhook_url,
+                json=payload,
+                timeout=WEBHOOK_POST_TIMEOUT_SECONDS,
+                headers={"Content-Type": "application/json"},
+            )
+            if not response.ok:
+                logging.warning(
+                    f"Webhook {webhook_url} returned {response.status_code}"
+                )
+        except Exception as e:  # noqa: BLE001 — webhook is best-effort
+            logging.warning(f"Failed to send webhook to {webhook_url}: {str(e)}")
+
+    return webhook_callback
 
 
 def _execute_repository_sync(

--- a/src/code_indexer/server/mcp/handlers/repos.py
+++ b/src/code_indexer/server/mcp/handlers/repos.py
@@ -318,6 +318,9 @@ def sync_repository(params: Dict[str, Any], user: User) -> Dict[str, Any]:
             func=sync_job_wrapper,
             submitter_username=user.username,
             repo_alias=repo_id,
+            # Pod-pull: reconstruction params for
+            # _execute_repository_sync on whichever pod claims the row.
+            metadata={"repo_id": repo_id, "username": user.username, "options": {}},
         )
         return _mcp_response(
             {
@@ -2396,6 +2399,12 @@ def bulk_add_provider_index(params: Dict[str, Any], user: User) -> Dict[str, Any
                 repo_path=repo_path,
                 provider_name=provider_name,
                 clear=False,
+                # Pod-pull: reconstruction params for _provider_index_job.
+                metadata={
+                    "repo_path": repo_path,
+                    "provider_name": provider_name,
+                    "clear": False,
+                },
             )
             job_ids.append({"alias": alias, "job_id": job_id})
 

--- a/src/code_indexer/server/repositories/background_jobs.py
+++ b/src/code_indexer/server/repositories/background_jobs.py
@@ -142,6 +142,38 @@ PROGRESS_DEBOUNCE_INTERVAL: float = 0.5
 # The dashboard and API consumers use at most 50 rows per page in practice.
 MAX_PAGE_SIZE: int = 50
 
+# Memory-aware admission: operation types whose execution loads large structures into
+# RAM (HNSW graph build + FTS index + Voyage embedding batches). These are the
+# ops the memory-aware admission gate throttles under pod memory pressure.
+# Cheap/quick ops (status, cancel, xray reads, dependency-map queries) are never
+# gated so they stay responsive even while indexing is backpressured.
+_MEMORY_HEAVY_OPS: frozenset = frozenset(
+    {
+        "add_golden_repo",
+        "provider_index_add",
+        "provider_temporal_index_rebuild",
+        "sync_repository",
+        "change_branch",
+    }
+)
+
+# Pod-pull work-stealing: operation types that, in cluster mode,
+# are left PENDING in the shared Postgres queue for any pod with memory headroom
+# to claim and execute — instead of being pinned to the submitting pod's local
+# worker pool. Same set as the memory-heavy ops: these are exactly the
+# expensive index builds worth distributing. Each must (a) have its submit call
+# pass reconstruction params via `metadata=` and (b) be dispatchable by the
+# IndexJobClaimLoop, or it simply keeps the legacy local-pool path.
+# Public (imported by distributed_job_worker + index_job_claim_loop + lifespan)
+# so the ops set has a single source of truth across the cluster job plumbing.
+POD_PULL_OPS: frozenset = _MEMORY_HEAVY_OPS
+
+# Memory-aware admission: min seconds between "deferring under memory pressure" INFO
+# logs per manager, so a sustained RED spell (a heavy job deferred every
+# backoff interval by every worker) can't storm the log while still leaving a
+# clear, periodic breadcrumb that the gate is actively throttling.
+_ADMISSION_DEFER_LOG_INTERVAL_SECONDS: float = 10.0
+
 
 class BackgroundJobManager:
     """
@@ -162,6 +194,7 @@ class BackgroundJobManager:
         data_retention_config: Optional["DataRetentionConfig"] = None,
         storage_backend: Optional[Any] = None,
         node_id: Optional[str] = None,
+        cluster_mode: bool = False,
     ):
         """Initialize enhanced background job manager.
 
@@ -246,6 +279,15 @@ class BackgroundJobManager:
         # Bug #1063 Part 3: Bounded worker pool shutdown signal.
         self._pool_shutdown = threading.Event()
 
+        # Memory-aware admission: last time a memory-pressure deferral was logged
+        # (monotonic seconds); rate-limits the deferral breadcrumb.
+        self._last_admission_defer_log: float = 0.0
+
+        # Pod-pull: when True (cluster/postgres mode), _POD_PULL_OPS
+        # are left PENDING in PG for cross-pod claiming instead of dispatched to
+        # this pod's local pool. False = legacy single-pod behavior (solo/CLI).
+        self._cluster_mode: bool = cluster_mode
+
         # Bug #1153: Cancel-handler registry keyed by operation_type.
         # Handlers are callables that signal cooperative cancellation to the
         # service owning the running job (e.g. DependencyMapService._cancel_event).
@@ -311,6 +353,17 @@ class BackgroundJobManager:
                 queue_ref.task_done()
                 break
             job_id, func, args, kwargs = item
+            # Memory-aware admission: under memory pressure, re-queue a heavy
+            # index job onto THIS lane's queue (it stays PENDING) and back off
+            # rather than running it and risking an OOM. Jobs wait, never OOM.
+            if self._admission_blocked(job_id):
+                self._log_admission_deferred(job_id)
+                queue_ref.put(item)
+                queue_ref.task_done()
+                self._pool_shutdown.wait(
+                    self._background_jobs_config.job_admission_backoff_seconds
+                )
+                continue
             try:
                 self._execute_job(job_id, func, args, kwargs)
             except Exception:
@@ -321,6 +374,66 @@ class BackgroundJobManager:
                 )
             finally:
                 queue_ref.task_done()
+
+    def _admission_blocked(self, job_id: str) -> bool:
+        """should this heavy job be deferred under memory pressure?
+
+        Returns True only when ALL of: the gate is enabled, the job's op type is
+        memory-heavy, a MemoryGovernor singleton exists, and the governor denies
+        admission at the configured cgroup watermark. Fail-open on everything
+        else (gate disabled, cheap op, no governor in CLI/solo mode) so the only
+        behavior change is throttling heavy indexing when the pod is pressured.
+        """
+        cfg = self._background_jobs_config
+        if not cfg.job_admission_memory_gate_enabled:
+            return False
+        job = self.jobs.get(job_id)
+        op_type = job.operation_type if job is not None else ""
+        if op_type not in _MEMORY_HEAVY_OPS:
+            return False
+        from code_indexer.server.services.memory_governor import get_memory_governor
+
+        governor = get_memory_governor()
+        if governor is None:
+            return False
+        return not governor.admission_allowed(cfg.job_admission_memory_max_used_pct)
+
+    def _log_admission_deferred(self, job_id: str) -> None:
+        """rate-limited breadcrumb when a heavy job is deferred.
+
+        Makes the throttle observable (throttled vs. stuck) without storming the
+        log: at most one line per _ADMISSION_DEFER_LOG_INTERVAL_SECONDS per
+        manager, tagged with the governor band and last-sampled cgroup used%.
+        """
+        now = time.monotonic()
+        if now - self._last_admission_defer_log < _ADMISSION_DEFER_LOG_INTERVAL_SECONDS:
+            return
+        self._last_admission_defer_log = now
+        # Best-effort: a breadcrumb must never crash the worker loop.
+        try:
+            job = self.jobs.get(job_id)
+            op_type = job.operation_type if job is not None else ""
+            from code_indexer.server.services.memory_governor import (
+                get_memory_governor,
+            )
+
+            governor = get_memory_governor()
+            band_obj = getattr(governor, "band", None)
+            band = getattr(band_obj, "value", "no-governor")
+            used_pct = getattr(governor, "last_used_pct", -1.0)
+            logging.info(
+                "memory-pressure: deferring memory-heavy job %s (op=%s) under memory pressure "
+                "(band=%s used_pct=%.1f); re-queued PENDING, backing off %.1fs",
+                job_id,
+                op_type,
+                band,
+                used_pct,
+                self._background_jobs_config.job_admission_backoff_seconds,
+            )
+        except Exception:  # noqa: BLE001 — logging must never break admission
+            logging.debug(
+                "memory-pressure: deferral-log failed (ignored)", exc_info=True
+            )
 
     @property
     def max_concurrent_jobs(self) -> int:
@@ -454,6 +567,7 @@ class BackgroundJobManager:
         actor_username: Optional[str] = None,  # AC12: who triggered the job
         lane: str = "ordinary",  # Story #1400 CRITICAL 1: dedicated worker pool
         snapshot_ctx: Optional[Dict[str, Any]] = None,  # Story #1400: job metadata only
+        metadata: Optional[Dict[str, Any]] = None,  # pod-pull reconstruction params
         **kwargs,
     ) -> str:
         """
@@ -475,6 +589,11 @@ class BackgroundJobManager:
             snapshot_ctx: Opaque job-registration metadata for the temporal
                 foreground/handoff layer. Stored on the job, NEVER passed to
                 `func`.
+            metadata: Reconstruction params persisted to the
+                background_jobs row (JSONB) so a pod-pull index op can be
+                executed on any pod that claims it. Required for a
+                ``_POD_PULL_OPS`` op to be work-stolen in cluster mode; without
+                it the op falls back to this pod's local worker pool.
             **kwargs: Function keyword arguments
 
         Returns:
@@ -564,6 +683,7 @@ class BackgroundJobManager:
                     operation_type=operation_type,
                     username=submitter_username,
                     repo_alias=repo_alias,
+                    metadata=metadata,
                     is_admin=is_admin,
                     actor_username=resolved_actor,
                 )
@@ -617,10 +737,33 @@ class BackgroundJobManager:
                         exc_info=True,
                     )
 
-        # Bug #1063 Part 3 / Story #1400 CRITICAL 1: Enqueue the job for its
-        # dedicated bounded worker pool. Workers pull from the LANE-SPECIFIC
-        # queue and call _execute_job() -- ordinary and temporal jobs are
-        # routed to entirely separate queues, never a shared one.
+        # Pod-pull work-stealing: in cluster mode a memory-heavy index op has
+        # already been registered PENDING / executing_node NULL in the shared
+        # queue above, so it is immediately claimable by ANY node with memory
+        # headroom. Do NOT dispatch it to THIS node's in-memory pool (which would
+        # pin it here) -- leave it for the memory-gated IndexJobClaimLoop running
+        # on every node. Guarded on metadata being present so a not-yet-migrated
+        # caller (no reconstruction params) safely falls back to the local pool
+        # instead of stranding an unexecutable row.
+        if (
+            self._cluster_mode
+            and operation_type in POD_PULL_OPS
+            and repo_alias
+            and metadata is not None
+            and self._job_tracker is not None
+        ):
+            logging.info(
+                "Background job %s (%s) left PENDING for pod-pull work-stealing "
+                "(not dispatched to local pool)",
+                job_id,
+                operation_type,
+            )
+            return job_id
+
+        # Story #1400 CRITICAL 1: Enqueue the job for its dedicated bounded
+        # worker pool. Workers pull from the LANE-SPECIFIC queue and call
+        # _execute_job() -- ordinary and temporal jobs are routed to entirely
+        # separate queues, never a shared one.
         target_queue = (
             self._temporal_pending_job_queue
             if lane == "temporal"
@@ -1411,9 +1554,9 @@ class BackgroundJobManager:
                             # Bug #679: COMPLETED_PARTIAL is a completion variant — notify tracker
                             self._job_tracker.complete_job(
                                 job_id,
-                                result=job.result
-                                if isinstance(job.result, dict)
-                                else None,
+                                result=(
+                                    job.result if isinstance(job.result, dict) else None
+                                ),
                             )
                         elif job.status == JobStatus.FAILED:
                             error_msg = (

--- a/src/code_indexer/server/repositories/background_jobs.py
+++ b/src/code_indexer/server/repositories/background_jobs.py
@@ -396,7 +396,17 @@ class BackgroundJobManager:
         governor = get_memory_governor()
         if governor is None:
             return False
-        return not governor.admission_allowed(cfg.job_admission_memory_max_used_pct)
+        try:
+            return not governor.admission_allowed(cfg.job_admission_memory_max_used_pct)
+        except Exception:  # noqa: BLE001 — L1: a governor error must never kill
+            # the pool-worker thread. Fail-open (do not block) so the only effect
+            # of a broken governor is that admission throttling is skipped, never
+            # a stalled lane.
+            logging.debug(
+                "memory-pressure: admission check raised; failing open (ignored)",
+                exc_info=True,
+            )
+            return False
 
     def _log_admission_deferred(self, job_id: str) -> None:
         """rate-limited breadcrumb when a heavy job is deferred.
@@ -752,9 +762,24 @@ class BackgroundJobManager:
             and metadata is not None
             and self._job_tracker is not None
         ):
+            # Cluster-Aware State (ABSOLUTE RULE): this job executes on WHICHEVER
+            # node claims it, and its real progress/status live in the shared
+            # background_jobs row (written cross-node by the claimer's
+            # update_progress/complete_job/fail_job). Do NOT retain a node-local
+            # in-memory PENDING entry -- get_job_status and get_jobs_for_display
+            # both PREFER self.jobs over the DB row, so keeping it would make a
+            # poll that lands on THIS (submitting) node report stale PENDING
+            # forever while another node runs the job. Dropping it makes both
+            # read paths fall through to the authoritative shared DB row
+            # regardless of which node the poll hits. (Cancellation stays
+            # correct: cancel_job's no-in-memory branch already routes to the
+            # cross-node DB-cancellation path.)
+            with self._lock:
+                self.jobs.pop(job_id, None)
             logging.info(
                 "Background job %s (%s) left PENDING for pod-pull work-stealing "
-                "(not dispatched to local pool)",
+                "(not dispatched to local pool; in-memory entry dropped so "
+                "status reads defer to the shared DB row)",
                 job_id,
                 operation_type,
             )

--- a/src/code_indexer/server/repositories/golden_repo_manager.py
+++ b/src/code_indexer/server/repositories/golden_repo_manager.py
@@ -21,7 +21,7 @@ import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional, Any, TYPE_CHECKING, cast
+from typing import Callable, Dict, List, Optional, Any, TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from code_indexer.server.models.golden_repo_branch_models import (
@@ -480,6 +480,59 @@ class GoldenRepoManager:
                     f"Invalid or inaccessible git repository: {repo_url}"
                 )
 
+        # Pod-pull: the real clone+index+register+activate work now
+        # lives in execute_add_golden_repo_work() so any pod's IndexJobClaimLoop
+        # can run it from the job row's metadata. This thin wrapper preserves the
+        # exact solo/local-pool path.
+        def background_worker(progress_callback=None) -> Dict[str, Any]:
+            return self.execute_add_golden_repo_work(
+                repo_url=repo_url,
+                alias=alias,
+                default_branch=default_branch,
+                enable_temporal=enable_temporal,
+                temporal_options=temporal_options,
+                submitter_username=submitter_username,
+                progress_callback=progress_callback,
+            )
+
+        # Submit to BackgroundJobManager. Pod-pull: pass reconstruction params
+        # as metadata so in cluster mode the row is left PENDING and claimable +
+        # runnable on any pod (pod-pull); solo mode runs background_worker locally.
+        job_id = self.background_job_manager.submit_job(
+            operation_type="add_golden_repo",
+            func=background_worker,
+            submitter_username=submitter_username,
+            is_admin=True,
+            repo_alias=alias,  # AC5: Fix unknown repo bug
+            metadata={
+                "repo_url": repo_url,
+                "alias": alias,
+                "default_branch": default_branch,
+                "enable_temporal": enable_temporal,
+                "temporal_options": temporal_options,
+                "submitter_username": submitter_username,
+            },
+        )
+        return cast(str, job_id)
+
+    def execute_add_golden_repo_work(
+        self,
+        *,
+        repo_url: str,
+        alias: str,
+        default_branch: Optional[str] = None,
+        enable_temporal: bool = False,
+        temporal_options: Optional[Dict] = None,
+        submitter_username: str = "admin",
+        progress_callback: Optional[Callable[..., Any]] = None,
+    ) -> Dict[str, Any]:
+        """reusable clone + index + register + global-activate body for
+        add_golden_repo, extracted verbatim from the former background_worker
+        closure so a pod-pull IndexJobClaimLoop can execute it on any pod from the
+        job row's metadata. Retry-safe: a partial clone is cleaned up on failure
+        and a duplicate alias is rejected up front by the caller.
+        """
+
         def _cleanup_failed_clone(clone_path: Optional[str]) -> None:
             """Remove a partially-cloned directory so retries don't fail with
             'destination path already exists' (Bug #1218 orphan-clone cleanup).
@@ -512,7 +565,7 @@ class GoldenRepoManager:
 
         # Create wrapper for background execution that accepts progress_callback
         # so BackgroundJobManager can inject it (Story #482 PATH A).
-        def background_worker(progress_callback=None) -> Dict[str, Any]:
+        def _run() -> Dict[str, Any]:
             """Execute add operation in background thread."""
             nonlocal default_branch
             # Bug #1218: track clone_path so we can clean it up on failure.
@@ -742,15 +795,7 @@ class GoldenRepoManager:
                 _cleanup_failed_clone(_clone_path_for_cleanup)
                 raise
 
-        # Submit to BackgroundJobManager
-        job_id = self.background_job_manager.submit_job(
-            operation_type="add_golden_repo",
-            func=background_worker,
-            submitter_username=submitter_username,
-            is_admin=True,
-            repo_alias=alias,  # AC5: Fix unknown repo bug
-        )
-        return cast(str, job_id)
+        return _run()
 
     def _register_lifecycle_after_registration(
         self, alias: str, submitter_username: str
@@ -3315,6 +3360,9 @@ class GoldenRepoManager:
             submitter_username=submitter_username,
             is_admin=True,
             repo_alias=alias,
+            # Pod-pull: the executor is the bound change_branch method
+            # reconstructed from these params on whichever pod claims the row.
+            metadata={"alias": alias, "target_branch": target_branch},
         )
         return {"success": True, "job_id": job_id}
 

--- a/src/code_indexer/server/repositories/golden_repo_manager.py
+++ b/src/code_indexer/server/repositories/golden_repo_manager.py
@@ -573,6 +573,17 @@ class GoldenRepoManager:
             # retries with "destination path already exists".
             _clone_path_for_cleanup: Optional[str] = None
             try:
+                # Pod-pull retry safety (PR #1424 H1): a dead-node reclaim can
+                # re-execute this body after a hard crash (SIGKILL) that left a
+                # PARTIAL clone dir at golden_repos_dir/{alias} with no committed
+                # golden_repos row (the except-path cleanup below never ran). If
+                # we cloned now, _clone_repository would raise "destination path
+                # already exists" BEFORE _clone_path_for_cleanup is assigned, so
+                # nothing would ever be cleaned and every retry -- and every
+                # future manual re-add of this alias -- would fail forever.
+                # Remove such an orphan up front (guards inside the helper never
+                # touch in-place content or a committed registration).
+                self._remove_orphan_clone_for_retry(repo_url, alias)
                 # Clone repository
                 clone_path = self._clone_repository(repo_url, alias, default_branch)
                 # EVO-64228 (review MAJOR): in index-in-place mode clone_path IS
@@ -796,6 +807,43 @@ class GoldenRepoManager:
                 raise
 
         return _run()
+
+    def _remove_orphan_clone_for_retry(self, repo_url: str, alias: str) -> bool:
+        """Remove an ORPHAN partial-clone dir so an add_golden_repo retry can
+        proceed (PR #1424 H1).
+
+        Pod-pull work-stealing made add_golden_repo cross-node reclaim-eligible.
+        A hard crash (SIGKILL) mid-clone leaves a partial clone at
+        golden_repos_dir/{alias} with NO committed golden_repos row (the
+        except-path _cleanup_failed_clone never ran). Without removing it, the
+        next clone raises "destination path already exists" and every retry --
+        plus every future manual re-add of this alias -- fails forever.
+
+        Removes the directory ONLY when ALL hold, so it can never destroy live
+        or caller-owned content:
+          - the clone dir actually exists, AND
+          - it is NOT an in-place registration (EVO-64228: the content is the
+            caller's, not cidx's, to delete), AND
+          - there is NO committed golden_repos row for the alias (a row means a
+            near-complete registration, not an orphan).
+
+        Returns True iff an orphan clone was removed.
+        """
+        clone_path = os.path.join(self.golden_repos_dir, alias)
+        if not os.path.exists(clone_path):
+            return False
+        if self._is_in_place_registration(repo_url, clone_path):
+            return False
+        if self.get_golden_repo(alias) is not None:
+            return False
+        logging.warning(
+            "add_golden_repo retry: removing orphan clone for '%s' at %s "
+            "(no committed registry row) so the clone can proceed",
+            alias,
+            clone_path,
+        )
+        shutil.rmtree(clone_path, ignore_errors=True)
+        return True
 
     def _register_lifecycle_after_registration(
         self, alias: str, submitter_username: str

--- a/src/code_indexer/server/routers/inline_admin_ops.py
+++ b/src/code_indexer/server/routers/inline_admin_ops.py
@@ -465,6 +465,12 @@ def register_admin_ops_routes(
                     repo_path=repo_path,
                     provider_name=request.providers[0],
                     clear=False,
+                    # Pod-pull: reconstruction params for _provider_index_job.
+                    metadata={
+                        "repo_path": repo_path,
+                        "provider_name": request.providers[0],
+                        "clear": False,
+                    },
                 )
                 job_ids.append(provider_job_id)
 
@@ -521,6 +527,14 @@ def register_admin_ops_routes(
                     provider_name=request.providers[0],
                     clear=False,
                     temporal_options=_temporal_opts,
+                    # Pod-pull: reconstruction params for
+                    # _provider_temporal_index_job (temporal_options → **kwargs).
+                    metadata={
+                        "repo_path": repo_path,
+                        "provider_name": request.providers[0],
+                        "clear": False,
+                        "temporal_options": _temporal_opts,
+                    },
                 )
                 job_ids.append(provider_job_id)
 
@@ -632,7 +646,9 @@ def register_admin_ops_routes(
             from code_indexer.server.services.config_service import get_config_service
 
             _config_service = get_config_service()
-            max_age_hours = _config_service.get_config().data_retention_config.background_jobs_retention_hours
+            max_age_hours = (
+                _config_service.get_config().data_retention_config.background_jobs_retention_hours
+            )
         if max_age_hours < 1:
             max_age_hours = 1
         if max_age_hours > 8760:  # 1 year

--- a/src/code_indexer/server/routers/inline_admin_ops.py
+++ b/src/code_indexer/server/routers/inline_admin_ops.py
@@ -646,9 +646,7 @@ def register_admin_ops_routes(
             from code_indexer.server.services.config_service import get_config_service
 
             _config_service = get_config_service()
-            max_age_hours = (
-                _config_service.get_config().data_retention_config.background_jobs_retention_hours
-            )
+            max_age_hours = _config_service.get_config().data_retention_config.background_jobs_retention_hours
         if max_age_hours < 1:
             max_age_hours = 1
         if max_age_hours > 8760:  # 1 year

--- a/src/code_indexer/server/routers/inline_repos.py
+++ b/src/code_indexer/server/routers/inline_repos.py
@@ -939,6 +939,15 @@ def register_repo_routes(
                 sync_job_wrapper,
                 submitter_username=current_user.username,
                 repo_alias=cleaned_repo_id,  # AC5: Fix unknown repo bug
+                # Pod-pull: reconstruction params for
+                # _execute_repository_sync. options carries the (optional)
+                # progress_webhook; a work-stolen sync completes without pushing
+                # incremental webhook progress (progress_callback rebuilt as None).
+                metadata={
+                    "repo_id": cleaned_repo_id,
+                    "username": current_user.username,
+                    "options": sync_options,
+                },
             )
 
             # Return job details

--- a/src/code_indexer/server/routers/inline_repos.py
+++ b/src/code_indexer/server/routers/inline_repos.py
@@ -23,10 +23,9 @@ Large method sizes are pre-existing in the source inline_routes.py (3221 lines).
 
 import logging
 import os
-import requests
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Dict, Any, Optional
+from typing import Dict, Any, Optional
 
 from ..repositories.activated_repo_manager import (  # noqa: E402
     ActivatedRepoError,
@@ -82,6 +81,7 @@ from ..auth import dependencies
 from ..auth.user_manager import UserRole
 from ..app_helpers import (
     _execute_repository_sync,
+    build_sync_progress_webhook_callback,
 )
 
 # Module-level logger
@@ -887,44 +887,14 @@ def register_repo_routes(
                 "progress_webhook": sync_request.progress_webhook,
             }
 
-            def create_webhook_callback(
-                webhook_url: Optional[str],
-            ) -> Optional[Callable[[int], None]]:
-                """Create a webhook callback function if webhook URL is provided."""
-                if not webhook_url:
-                    return None
-
-                def webhook_callback(progress: int) -> None:
-                    """Send progress updates to webhook URL."""
-                    try:
-                        payload = {
-                            "repository_id": cleaned_repo_id,
-                            "progress": progress,
-                            "timestamp": datetime.now(timezone.utc).isoformat(),
-                            "username": current_user.username,
-                        }
-                        response = requests.post(
-                            webhook_url,
-                            json=payload,
-                            timeout=5,  # Don't wait too long for webhook responses
-                            headers={"Content-Type": "application/json"},
-                        )
-                        # Log webhook failures but don't interrupt sync
-                        if not response.ok:
-                            logging.warning(
-                                f"Webhook {webhook_url} returned {response.status_code}"
-                            )
-                    except Exception as e:
-                        logging.warning(
-                            f"Failed to send webhook to {webhook_url}: {str(e)}"
-                        )
-
-                return webhook_callback
-
             def sync_job_wrapper():
-                # Create webhook callback if webhook URL provided
+                # Build the client webhook callback (if a URL was provided) via
+                # the shared helper -- the SAME builder the pod-pull executing
+                # node uses, so the webhook-POST logic lives in one place.
                 webhook_url: Optional[str] = sync_options.get("progress_webhook")  # type: ignore[assignment]
-                webhook_callback = create_webhook_callback(webhook_url)
+                webhook_callback = build_sync_progress_webhook_callback(
+                    webhook_url, cleaned_repo_id, current_user.username
+                )
 
                 return _execute_repository_sync(
                     repo_id=cleaned_repo_id,

--- a/src/code_indexer/server/routers/inline_repos_v2.py
+++ b/src/code_indexer/server/routers/inline_repos_v2.py
@@ -687,6 +687,13 @@ def register_repos_v2_routes(
                 sync_job_wrapper,
                 submitter_username=current_user.username,
                 repo_alias=cleaned_repo_id,  # AC5: Fix unknown repo bug
+                # Pod-pull: reconstruction params for
+                # _execute_repository_sync (see inline_repos.py for the webhook note).
+                metadata={
+                    "repo_id": cleaned_repo_id,
+                    "username": current_user.username,
+                    "options": sync_options,
+                },
             )
 
             # Create response with job details

--- a/src/code_indexer/server/routers/provider_indexes.py
+++ b/src/code_indexer/server/routers/provider_indexes.py
@@ -225,6 +225,12 @@ async def bulk_add(
             repo_path=repo_path,
             provider_name=body.provider,
             clear=False,
+            # Pod-pull: reconstruction params for _provider_index_job.
+            metadata={
+                "repo_path": repo_path,
+                "provider_name": body.provider,
+                "clear": False,
+            },
         )
         job_ids.append({"alias": alias, "job_id": str(job_id)})
 

--- a/src/code_indexer/server/services/distributed_job_claimer.py
+++ b/src/code_indexer/server/services/distributed_job_claimer.py
@@ -377,6 +377,63 @@ class DistributedJobClaimer:
             )
         return failed
 
+    def update_progress(
+        self,
+        job_id: str,
+        progress: int,
+        phase: Optional[str] = None,
+        detail: Optional[str] = None,
+    ) -> bool:
+        """Write incremental progress for a claimed (work-stolen) job.
+
+        PR #1424 H2: a pod-pull index op runs on whichever node claimed it, not
+        the submitting node, so its in-process progress_callback closure is gone.
+        This writes progress back to the SHARED background_jobs row -- the same
+        row the originating node's dashboard polls -- so a work-stolen job shows
+        real incremental progress instead of a 0 -> 100 jump.
+
+        Ownership-scoped (``executing_node = self._node_id``) like complete/fail,
+        and phase/detail are COALESCE-updated so omitting them preserves the
+        existing values rather than nulling them.
+
+        Args:
+            job_id: The job to update (must be owned by this node).
+            progress: Percent complete (0-100).
+            phase: Optional coarse phase label (e.g. "index", "cow").
+            detail: Optional human-readable phase detail.
+
+        Returns:
+            True if the row was updated, False if not found or not owned by this
+            node (e.g. reclaimed by reconciliation while executing).
+        """
+        with self._pool.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE background_jobs
+                    SET progress      = %s,
+                        current_phase = COALESCE(%s, current_phase),
+                        phase_detail  = COALESCE(%s, phase_detail)
+                    WHERE job_id = %s
+                      AND executing_node = %s
+                    """,
+                    (progress, phase, detail, job_id, self._node_id),
+                )
+                updated: bool = cur.rowcount > 0
+            conn.commit()
+
+        if not updated:
+            # Not fatal: a lost progress tick just means the dashboard misses one
+            # update. Log at DEBUG (fail_job/complete_job already WARN on the
+            # terminal-transition version of this reclaim race).
+            logger.debug(
+                "Node %s progress update for job %s no-op (rowcount=0; "
+                "likely reclaimed)",
+                self._node_id,
+                job_id,
+            )
+        return updated
+
     def get_node_jobs(self) -> List[Dict[str, Any]]:
         """
         Return all jobs currently claimed (running) by this node.

--- a/src/code_indexer/server/services/distributed_job_claimer.py
+++ b/src/code_indexer/server/services/distributed_job_claimer.py
@@ -27,8 +27,19 @@ _SELECT_COLS = """
     job_id, operation_type, status, created_at, started_at, completed_at,
     result, error, progress, username, is_admin, cancelled, repo_alias,
     resolution_attempts, claude_actions, failure_reason, extended_error,
-    language_resolution_status, executing_node, claimed_at
+    language_resolution_status, executing_node, claimed_at, metadata
 """
+
+
+def _json_col(val: Any) -> Any:
+    """Decode a JSONB column psycopg may hand back already-parsed or as text."""
+    if val is None:
+        return None
+    if isinstance(val, (dict, list)):
+        return val
+    if isinstance(val, str):
+        return json.loads(val)
+    return val
 
 
 def _row_to_dict(row: Any) -> Dict[str, Any]:
@@ -54,6 +65,8 @@ def _row_to_dict(row: Any) -> Dict[str, Any]:
         "language_resolution_status": json.loads(row[17]) if row[17] else None,
         "executing_node": row[18],
         "claimed_at": row[19],
+        # Pod-pull: reconstruction params for pod-pull work-stealing.
+        "metadata": _json_col(row[20]),
     }
 
 
@@ -79,7 +92,14 @@ class DistributedJobClaimer:
                 └─ release_job()  ──>  pending (executing_node = NULL)
     """
 
-    def __init__(self, pool: Any, node_id: str, max_concurrent_jobs: int = 0) -> None:
+    def __init__(
+        self,
+        pool: Any,
+        node_id: str,
+        max_concurrent_jobs: int = 0,
+        memory_gate_enabled: bool = True,
+        memory_max_used_pct: float = 80.0,
+    ) -> None:
         """
         Initialise the claimer.
 
@@ -89,17 +109,30 @@ class DistributedJobClaimer:
             max_concurrent_jobs: Cluster-wide max running jobs (Bug #541).
                 When > 0, claim_next_job() checks the total running count
                 across ALL nodes before claiming. 0 = no limit.
+            memory_gate_enabled: When True, a pod under memory
+                pressure declines to claim so the row stays ``pending`` for a
+                pod with headroom (or for later) instead of being run and
+                risking an OOMKill. Fail-open when no MemoryGovernor exists.
+            memory_max_used_pct: cgroup used% watermark for the memory gate;
+                below it (and not RED) a claim is allowed. Self-tunes to the
+                pod's own memory.max.
         """
         self._pool = pool
         self._node_id = node_id
         self._max_concurrent_jobs = max_concurrent_jobs
+        self._memory_gate_enabled = memory_gate_enabled
+        self._memory_max_used_pct = memory_max_used_pct
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
     def claim_next_job(
-        self, job_type: Optional[str] = None
+        self,
+        job_type: Optional[str] = None,
+        *,
+        job_types: Optional[List[str]] = None,
+        exclude_types: Optional[List[str]] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Atomically claim the next pending job for this node.
@@ -110,13 +143,42 @@ class DistributedJobClaimer:
         the same row.
 
         Args:
-            job_type: If provided, only claim jobs of this operation_type.
+            job_type: If provided, only claim jobs of this operation_type
+                (single-type shorthand, kept for backward compatibility).
+            job_types: If provided, only claim jobs whose
+                operation_type is in this list (``= ANY``). Used by the
+                per-pod IndexJobClaimLoop to claim only pod-pull index ops.
+            exclude_types: If provided, never claim jobs of these
+                operation_types (``<> ALL``). Used by the leader-only
+                DistributedJobWorkerService so it leaves pod-pull rows for the
+                index loop and the two claimers target disjoint row sets.
 
         Returns:
             A job dictionary (same schema as BackgroundJobsPostgresBackend
-            rows plus ``executing_node`` and ``claimed_at``) if a job was
-            claimed, or None if no pending jobs are available.
+            rows plus ``executing_node``, ``claimed_at`` and ``metadata``) if a
+            job was claimed, or None if no pending jobs are available.
         """
+        # Memory-aware admission: memory-aware admission. A pod under memory pressure
+        # declines the claim so the row stays 'pending' — another pod with
+        # headroom (or this pod once it recovers) picks it up, instead of
+        # running it now and risking an OOMKill. Fail-open when no governor
+        # exists (CLI/solo) or the gate is disabled.
+        if self._memory_gate_enabled:
+            from code_indexer.server.services.memory_governor import (
+                get_memory_governor,
+            )
+
+            governor = get_memory_governor()
+            if governor is not None and not governor.admission_allowed(
+                self._memory_max_used_pct
+            ):
+                logger.debug(
+                    "Node %s under memory pressure — skipping claim, "
+                    "leaving job pending",
+                    self._node_id,
+                )
+                return None
+
         # Bug #541: Cluster-wide concurrency check. Count running jobs across
         # ALL nodes before claiming. If at or above limit, skip claim.
         if self._max_concurrent_jobs > 0:
@@ -135,12 +197,21 @@ class DistributedJobClaimer:
                 )
                 return None
 
-        type_filter = "AND operation_type = %s" if job_type else ""
-        # One positional param for SET executing_node = %s,
-        # plus one optional param for the job_type filter.
+        # Build the operation_type filter. The first positional param is always
+        # SET executing_node = %s; the sub-SELECT filter params follow in the
+        # exact textual order they appear in the WHERE clause.
+        filters: List[str] = []
         params: List[Any] = [self._node_id]
         if job_type:
+            filters.append("AND operation_type = %s")
             params.append(job_type)
+        if job_types:
+            filters.append("AND operation_type = ANY(%s)")
+            params.append(list(job_types))
+        if exclude_types:
+            filters.append("AND operation_type <> ALL(%s)")
+            params.append(list(exclude_types))
+        type_filter = "\n                  ".join(filters)
 
         sql = f"""
             UPDATE background_jobs

--- a/src/code_indexer/server/services/distributed_job_worker.py
+++ b/src/code_indexer/server/services/distributed_job_worker.py
@@ -68,7 +68,13 @@ class DistributedJobWorkerService:
 
     def _process_one_job(self) -> None:
         """Attempt to claim and execute one pending job."""
-        job = self._claimer.claim_next_job()
+        # Pod-pull: never claim pod-pull index ops — those are owned by the
+        # per-pod IndexJobClaimLoop. Without this exclusion the leader worker
+        # (which fails any non-retryable type it claims) would fail the PENDING
+        # add_golden_repo/sync/etc. rows before a pod could work-steal them.
+        from code_indexer.server.repositories.background_jobs import POD_PULL_OPS
+
+        job = self._claimer.claim_next_job(exclude_types=sorted(POD_PULL_OPS))
         if job is None:
             return
 

--- a/src/code_indexer/server/services/index_job_claim_loop.py
+++ b/src/code_indexer/server/services/index_job_claim_loop.py
@@ -1,0 +1,161 @@
+"""
+Per-pod index-job claim loop (Pod-pull: pod-pull work-stealing).
+
+In cluster mode, memory-heavy index ops (POD_PULL_OPS: add_golden_repo,
+provider_index_add, provider_temporal_index_rebuild, sync_repository,
+change_branch) are registered PENDING in the shared Postgres background_jobs
+queue by submit_job and are NOT dispatched to the submitting pod's in-memory
+pool. This loop — started on EVERY postgres pod, not just the leader — claims
+those rows via the memory-gated DistributedJobClaimer and executes them by
+reconstructing the work from the row's ``metadata``.
+
+Because the claimer's claim is memory-gated , a node under
+memory pressure returns None and leaves the row PENDING for a pod with
+headroom. FOR UPDATE SKIP LOCKED guarantees exactly one pod runs each row.
+
+Contrast DistributedJobWorkerService: that runs on the LEADER only, re-executes
+reclaimed refresh jobs, and fails non-retryable types. It now claims with
+``exclude_types=POD_PULL_OPS`` so the two loops target disjoint row sets.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# op_type -> callable(metadata_dict) -> optional result dict.
+DispatchTable = Dict[str, Callable[[Dict[str, Any]], Optional[Dict[str, Any]]]]
+
+
+class IndexJobClaimLoop:
+    """Claims and executes pod-pull index jobs on this pod when it has headroom."""
+
+    def __init__(
+        self,
+        claimer: Any,
+        dispatch: DispatchTable,
+        node_id: str,
+        poll_interval: float = 5.0,
+    ) -> None:
+        """
+        Args:
+            claimer: DistributedJobClaimer for atomic, memory-gated claiming.
+            dispatch: op_type -> executor(metadata) -> result. The claim is
+                restricted to ``dispatch.keys()`` so only executable ops are
+                pulled.
+            node_id: this pod's node id (logging only; claimer owns ownership).
+            poll_interval: seconds between claim attempts when idle.
+        """
+        self._claimer = claimer
+        self._dispatch = dict(dispatch)
+        self._node_id = node_id
+        self._poll_interval = poll_interval
+        self._job_types = sorted(self._dispatch.keys())
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        # job_id currently executing on this pod (for release on shutdown).
+        self._in_flight: Optional[str] = None
+        self._in_flight_lock = threading.Lock()
+
+    def start(self) -> None:
+        """Start the claim loop thread (idempotent)."""
+        if not self._dispatch:
+            logger.info("IndexJobClaimLoop: no dispatchable ops — not starting")
+            return
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._poll_loop, daemon=True, name="index-job-claim-loop"
+        )
+        self._thread.start()
+        logger.info(
+            "IndexJobClaimLoop: started (node=%s, ops=%s, interval=%.1fs)",
+            self._node_id,
+            ",".join(self._job_types),
+            self._poll_interval,
+        )
+
+    def stop(self) -> None:
+        """Signal stop, release any in-flight claim back to PENDING, and join."""
+        self._stop_event.set()
+        # Return an in-flight claim to the pool so another pod can pick it up
+        # rather than waiting for dead-node reconciliation.
+        with self._in_flight_lock:
+            job_id = self._in_flight
+        if job_id is not None:
+            try:
+                self._claimer.release_job(job_id)
+            except Exception:  # noqa: BLE001 — best-effort on shutdown
+                logger.warning(
+                    "IndexJobClaimLoop: failed to release in-flight job %s",
+                    job_id,
+                    exc_info=True,
+                )
+        if self._thread is not None:
+            self._thread.join(timeout=10)
+        logger.info("IndexJobClaimLoop: stopped")
+
+    def _poll_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                claimed = self._process_one_job()
+            except Exception:  # noqa: BLE001 — loop must never die
+                logger.exception("IndexJobClaimLoop: error in poll loop")
+                claimed = False
+            # If we just ran a job, immediately try for the next one (drain
+            # fast); only sleep when the queue/headroom yielded nothing.
+            if not claimed:
+                self._stop_event.wait(timeout=self._poll_interval)
+
+    def _process_one_job(self) -> bool:
+        """Claim and execute at most one job. Returns True if one was executed."""
+        job = self._claimer.claim_next_job(job_types=self._job_types)
+        if job is None:
+            # No pending pod-pull job, or this pod is memory-pressured (the
+            # claimer's memory gate returned None) — leave rows for a pod w/ headroom.
+            return False
+
+        job_id = job["job_id"]
+        op_type = job.get("operation_type", "")
+        metadata = job.get("metadata") or {}
+        executor = self._dispatch.get(op_type)
+
+        if executor is None:
+            # Should not happen (claim filtered to dispatch keys), but never
+            # strand a claimed row: fail it so reconciliation doesn't loop.
+            logger.error(
+                "IndexJobClaimLoop: no executor for claimed op '%s' (job %s)",
+                op_type,
+                job_id,
+            )
+            self._claimer.fail_job(job_id, f"No pod-pull executor for {op_type}")
+            return True
+
+        with self._in_flight_lock:
+            self._in_flight = job_id
+        try:
+            logger.info(
+                "IndexJobClaimLoop: node %s executing %s (op=%s)",
+                self._node_id,
+                job_id,
+                op_type,
+            )
+            result = executor(metadata)
+            self._claimer.complete_job(job_id, result)
+            logger.info("IndexJobClaimLoop: completed %s", job_id)
+        except Exception as exc:  # noqa: BLE001 — surface as job failure
+            logger.error(
+                "IndexJobClaimLoop: job %s (op=%s) failed: %s",
+                job_id,
+                op_type,
+                exc,
+            )
+            self._claimer.fail_job(job_id, str(exc))
+        finally:
+            with self._in_flight_lock:
+                self._in_flight = None
+        return True

--- a/src/code_indexer/server/services/index_job_claim_loop.py
+++ b/src/code_indexer/server/services/index_job_claim_loop.py
@@ -26,8 +26,41 @@ from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
-# op_type -> callable(metadata_dict) -> optional result dict.
-DispatchTable = Dict[str, Callable[[Dict[str, Any]], Optional[Dict[str, Any]]]]
+# op_type -> callable(metadata_dict, progress_callback) -> optional result dict.
+# progress_callback(progress: int, phase: Optional[str], detail: Optional[str])
+# routes to the shared background_jobs row so a work-stolen job (PR #1424 H2)
+# reports incremental progress cross-node instead of a 0 -> 100 jump.
+DispatchTable = Dict[
+    str, Callable[[Dict[str, Any], Callable[..., Any]], Optional[Dict[str, Any]]]
+]
+
+
+def validate_dispatch_covers(
+    dispatch: DispatchTable, required_ops: "frozenset[str]"
+) -> None:
+    """Fail loudly at startup if the pod-pull dispatch drifts from the op set.
+
+    PR #1424 M3: the IndexJobClaimLoop claims rows whose operation_type is in
+    ``required_ops`` (POD_PULL_OPS) and executes them via ``dispatch``. If an op
+    is added to one but not the other, a claimed row could have no executor (or
+    a heavy op would never be work-stolen). This turns that silent drift into a
+    RuntimeError at wiring time.
+
+    Raises:
+        RuntimeError: if the dispatch keys are not EXACTLY ``required_ops``.
+    """
+    dispatch_ops = set(dispatch)
+    required = set(required_ops)
+    if dispatch_ops == required:
+        return
+    missing = required - dispatch_ops
+    extra = dispatch_ops - required
+    raise RuntimeError(
+        "pod-pull index dispatch does not match POD_PULL_OPS "
+        f"(missing executors for {sorted(missing)}; "
+        f"unexpected executors {sorted(extra)}). Every pod-pull op MUST have "
+        "exactly one dispatch executor and vice versa."
+    )
 
 
 class IndexJobClaimLoop:
@@ -144,7 +177,7 @@ class IndexJobClaimLoop:
                 job_id,
                 op_type,
             )
-            result = executor(metadata)
+            result = executor(metadata, self._make_progress_callback(job_id))
             self._claimer.complete_job(job_id, result)
             logger.info("IndexJobClaimLoop: completed %s", job_id)
         except Exception as exc:  # noqa: BLE001 — surface as job failure
@@ -159,3 +192,37 @@ class IndexJobClaimLoop:
             with self._in_flight_lock:
                 self._in_flight = None
         return True
+
+    def _make_progress_callback(self, job_id: str) -> Callable[..., None]:
+        """Build a per-job progress callback for a work-stolen op (PR #1424 H2).
+
+        The executor runs on THIS (claiming) node, not the submitting one, so the
+        in-process progress_callback closure the local pool would have injected is
+        gone. This callback writes progress back to the SHARED background_jobs row
+        via the claimer, so the originating node's dashboard (which polls that
+        row) shows real incremental progress. Best-effort: a progress-write hiccup
+        must never fail the actual work, so errors are swallowed at DEBUG.
+
+        Accepts the same shape the worker functions call
+        (``progress_callback(progress)`` positionally, or with ``phase``/
+        ``detail`` keywords); extra kwargs are ignored defensively.
+        """
+
+        def progress_callback(
+            progress: int,
+            phase: Optional[str] = None,
+            detail: Optional[str] = None,
+            **_ignored: Any,
+        ) -> None:
+            try:
+                self._claimer.update_progress(
+                    job_id, progress, phase=phase, detail=detail
+                )
+            except Exception:  # noqa: BLE001 — progress is best-effort
+                logger.debug(
+                    "IndexJobClaimLoop: progress update failed for %s (ignored)",
+                    job_id,
+                    exc_info=True,
+                )
+
+        return progress_callback

--- a/src/code_indexer/server/services/memory_governor.py
+++ b/src/code_indexer/server/services/memory_governor.py
@@ -331,6 +331,28 @@ class MemoryGovernor:
             return True
         return self.band == MemoryBand.RED
 
+    def admission_allowed(self, max_used_pct: float) -> bool:
+        """True iff a new memory-heavy job may be admitted for execution.
+
+        Reactive, cgroup-aware admission gate that reuses the sampler's signal
+        (never reads /sys/fs/cgroup or psutil directly here). Fail-safe: returns
+        False until the first successful sample (band starts RED) and whenever
+        the band is RED (used_pct >= red_pct OR swap-in death-spiral), so a
+        pressured — or not-yet-observed — pod never starts another heavy index
+        job. Otherwise admits only while the last sampled cgroup used% is below
+        ``max_used_pct``, an admission watermark set below the RED/eviction line
+        to leave headroom for the admitted job's own HNSW/FTS/embedding growth.
+
+        Expressed purely as a percentage of the pod's own cgroup limit, so it
+        self-tunes to whatever memory.max the container has (4Gi, 8Gi, …) with
+        no per-deployment job-count tuning.
+        """
+        if self._first_tick:
+            return False
+        if self.band == MemoryBand.RED:
+            return False
+        return self.last_used_pct < max_used_pct
+
     def get_snapshot(self) -> dict:
         """Return the full §3.5 snapshot dict for the admin endpoint (Story 4).
 

--- a/src/code_indexer/server/startup/lifespan.py
+++ b/src/code_indexer/server/startup/lifespan.py
@@ -3116,38 +3116,72 @@ def make_lifespan(
                     # stopped by the _cluster_services shutdown loop.
                     from code_indexer.server.services.index_job_claim_loop import (
                         IndexJobClaimLoop,
+                        validate_dispatch_covers,
+                    )
+                    from code_indexer.server.repositories.background_jobs import (
+                        POD_PULL_OPS,
                     )
                     from code_indexer.server.app_helpers import (
                         _execute_repository_sync,
+                        build_sync_progress_webhook_callback,
                     )
                     from code_indexer.server.mcp.handlers.repos import (
                         _provider_index_job,
                         _provider_temporal_index_job,
                     )
 
-                    def _pp_add_golden_repo(md):
-                        return golden_repo_manager.execute_add_golden_repo_work(**md)
-
-                    def _pp_change_branch(md):
-                        return golden_repo_manager.change_branch(
-                            md["alias"], md["target_branch"]
+                    # Pod-pull dispatch executors (PR #1424 H2): each takes the
+                    # row's metadata AND a per-job progress_callback that the
+                    # IndexJobClaimLoop routes to the shared background_jobs row,
+                    # so a work-stolen op reports incremental progress to the
+                    # originating node's dashboard instead of a 0 -> 100 jump.
+                    def _pp_add_golden_repo(md, progress_callback):
+                        return golden_repo_manager.execute_add_golden_repo_work(
+                            **md, progress_callback=progress_callback
                         )
 
-                    def _pp_sync_repository(md):
+                    def _pp_change_branch(md, progress_callback):
+                        return golden_repo_manager.change_branch(
+                            md["alias"],
+                            md["target_branch"],
+                            progress_callback=progress_callback,
+                        )
+
+                    def _pp_sync_repository(md, progress_callback):
+                        # Rebuild the client webhook on THIS (executing) node from
+                        # the metadata options, then fan progress out to BOTH the
+                        # DB-backed dashboard callback and the webhook.
+                        options = md.get("options") or {}
+                        webhook_cb = build_sync_progress_webhook_callback(
+                            options.get("progress_webhook"),
+                            md["repo_id"],
+                            md["username"],
+                        )
+
+                        def _combined(progress: int) -> None:
+                            progress_callback(progress)
+                            if webhook_cb is not None:
+                                webhook_cb(progress)
+
                         return _execute_repository_sync(
                             repo_id=md["repo_id"],
                             username=md["username"],
-                            options=md.get("options") or {},
+                            options=options,
                             activated_repo_manager=getattr(
                                 golden_repo_manager, "activated_repo_manager", None
                             ),
+                            progress_callback=_combined,
                         )
 
-                    def _pp_provider_index(md):
-                        return _provider_index_job(**md)
+                    def _pp_provider_index(md, progress_callback):
+                        return _provider_index_job(
+                            **md, progress_callback=progress_callback
+                        )
 
-                    def _pp_provider_temporal(md):
-                        return _provider_temporal_index_job(**md)
+                    def _pp_provider_temporal(md, progress_callback):
+                        return _provider_temporal_index_job(
+                            **md, progress_callback=progress_callback
+                        )
 
                     _index_dispatch = {
                         "add_golden_repo": _pp_add_golden_repo,
@@ -3156,6 +3190,9 @@ def make_lifespan(
                         "provider_index_add": _pp_provider_index,
                         "provider_temporal_index_rebuild": _pp_provider_temporal,
                     }
+                    # M3: fail loudly if a pod-pull op ever lacks an executor (or
+                    # vice versa) instead of silently claiming an unrunnable row.
+                    validate_dispatch_covers(_index_dispatch, POD_PULL_OPS)
                     _index_claim_loop = IndexJobClaimLoop(
                         claimer=_job_claimer,
                         dispatch=_index_dispatch,
@@ -4372,9 +4409,7 @@ def make_lifespan(
                     "DependencyLatencyTracker stopped successfully",
                     extra={"correlation_id": get_correlation_id()},
                 )
-            except (
-                Exception
-            ) as e:  # broad catch intentional: shutdown must not abort remaining cleanup chain
+            except Exception as e:  # broad catch intentional: shutdown must not abort remaining cleanup chain
                 logger.error(
                     format_error_log(
                         "APP-GENERAL-027",

--- a/src/code_indexer/server/startup/lifespan.py
+++ b/src/code_indexer/server/startup/lifespan.py
@@ -3078,8 +3078,23 @@ def make_lifespan(
                         DistributedJobWorkerService,
                     )
 
+                    # Memory-aware admission: give the claimer the same cgroup-aware
+                    # memory watermark the per-pod pool uses, so a pressured pod
+                    # declines cross-pod refresh claims and leaves them pending.
+                    from code_indexer.server.utils.config_manager import (
+                        BackgroundJobsConfig as _BgJobsConfig,
+                    )
+
+                    _bg_jobs_config = _BgJobsConfig()
                     _job_claimer = DistributedJobClaimer(
-                        pool=_cluster_pool, node_id=_node_id
+                        pool=_cluster_pool,
+                        node_id=_node_id,
+                        memory_gate_enabled=(
+                            _bg_jobs_config.job_admission_memory_gate_enabled
+                        ),
+                        memory_max_used_pct=(
+                            _bg_jobs_config.job_admission_memory_max_used_pct
+                        ),
                     )
                     _refresh_sched = (
                         global_lifecycle_manager.refresh_scheduler
@@ -3091,6 +3106,63 @@ def make_lifespan(
                         refresh_scheduler=_refresh_sched,
                     )
                     _cluster_services.append(("dist_job_worker", _dist_worker))
+
+                    # Pod-pull work-stealing: an always-on (NOT
+                    # leader-gated) per-pod loop that claims the memory-heavy
+                    # index ops left PENDING in the shared queue and runs them by
+                    # reconstructing from the row's metadata. The claim is
+                    # memory-gated, so a pressured pod leaves rows for a pod
+                    # with headroom. Started immediately on every postgres pod;
+                    # stopped by the _cluster_services shutdown loop.
+                    from code_indexer.server.services.index_job_claim_loop import (
+                        IndexJobClaimLoop,
+                    )
+                    from code_indexer.server.app_helpers import (
+                        _execute_repository_sync,
+                    )
+                    from code_indexer.server.mcp.handlers.repos import (
+                        _provider_index_job,
+                        _provider_temporal_index_job,
+                    )
+
+                    def _pp_add_golden_repo(md):
+                        return golden_repo_manager.execute_add_golden_repo_work(**md)
+
+                    def _pp_change_branch(md):
+                        return golden_repo_manager.change_branch(
+                            md["alias"], md["target_branch"]
+                        )
+
+                    def _pp_sync_repository(md):
+                        return _execute_repository_sync(
+                            repo_id=md["repo_id"],
+                            username=md["username"],
+                            options=md.get("options") or {},
+                            activated_repo_manager=getattr(
+                                golden_repo_manager, "activated_repo_manager", None
+                            ),
+                        )
+
+                    def _pp_provider_index(md):
+                        return _provider_index_job(**md)
+
+                    def _pp_provider_temporal(md):
+                        return _provider_temporal_index_job(**md)
+
+                    _index_dispatch = {
+                        "add_golden_repo": _pp_add_golden_repo,
+                        "change_branch": _pp_change_branch,
+                        "sync_repository": _pp_sync_repository,
+                        "provider_index_add": _pp_provider_index,
+                        "provider_temporal_index_rebuild": _pp_provider_temporal,
+                    }
+                    _index_claim_loop = IndexJobClaimLoop(
+                        claimer=_job_claimer,
+                        dispatch=_index_dispatch,
+                        node_id=_node_id,
+                    )
+                    _index_claim_loop.start()
+                    _cluster_services.append(("index_claim_loop", _index_claim_loop))
 
                     # Story #538: Enable PG advisory locks for password changes
                     from code_indexer.server.auth.concurrency_protection import (
@@ -4300,7 +4372,9 @@ def make_lifespan(
                     "DependencyLatencyTracker stopped successfully",
                     extra={"correlation_id": get_correlation_id()},
                 )
-            except Exception as e:  # broad catch intentional: shutdown must not abort remaining cleanup chain
+            except (
+                Exception
+            ) as e:  # broad catch intentional: shutdown must not abort remaining cleanup chain
                 logger.error(
                     format_error_log(
                         "APP-GENERAL-027",

--- a/src/code_indexer/server/startup/service_init.py
+++ b/src/code_indexer/server/startup/service_init.py
@@ -516,6 +516,9 @@ def initialize_services() -> Dict[str, Any]:
         # fail_orphaned_jobs() can detect a PostgreSQL backend and skip its
         # unscoped sweep, avoiding cross-node false failures.
         node_id=_node_id,
+        # Pod-pull: in postgres/cluster mode, leave _POD_PULL_OPS PENDING in the
+        # shared queue for cross-pod work-stealing instead of the local pool.
+        cluster_mode=(_storage_mode == "postgres"),
     )
     # Inject BackgroundJobManager into GoldenRepoManager for async operations
     golden_repo_manager.background_job_manager = background_job_manager

--- a/src/code_indexer/server/utils/config_manager.py
+++ b/src/code_indexer/server/utils/config_manager.py
@@ -163,9 +163,7 @@ class ServerResourceConfig:
     git_untracked_file_timeout: int = 60  # 1 minute for untracked file check
 
     # Refresh scheduler timeouts (in seconds)
-    cow_clone_timeout: int = (
-        3600  # 1 hour for CoW clone of very large repos (e.g. evolution ~1M files, phoenix 40GB); ~2-3x headroom over measured ~17-19 min
-    )
+    cow_clone_timeout: int = 3600  # 1 hour for CoW clone of very large repos (e.g. evolution ~1M files, phoenix 40GB); ~2-3x headroom over measured ~17-19 min
     git_update_index_timeout: int = 300  # 5 minutes for git update-index during refresh
     git_restore_timeout: int = 300  # 5 minutes for git restore during refresh
     cidx_fix_config_timeout: int = 60  # 1 minute for cidx fix-config
@@ -1481,12 +1479,8 @@ class ServerConfig:
     # Both default True since v9.23.3 so fresh installs automatically inherit the
     # protections. Operators can disable either by setting the flag to false in
     # ~/.cidx-server/config.json; readable before the DB is available (cleanup daemon thread).
-    enable_malloc_trim: bool = (
-        True  # Mitigation 1: call malloc_trim(0) after eviction. Default ON since v9.23.3.
-    )
-    enable_malloc_arena_max: bool = (
-        True  # Mitigation 2: inject MALLOC_ARENA_MAX=2 via systemd. Default ON since v9.23.3.
-    )
+    enable_malloc_trim: bool = True  # Mitigation 1: call malloc_trim(0) after eviction. Default ON since v9.23.3.
+    enable_malloc_arena_max: bool = True  # Mitigation 2: inject MALLOC_ARENA_MAX=2 via systemd. Default ON since v9.23.3.
 
     # Story #1032 AC6 - Pre-deactivation leak scan (bootstrap-only, never DB).
     # Default False: _detect_resource_leaks is post-failure-only diagnostic.
@@ -2112,13 +2106,13 @@ class ServerConfigManager:
             if "scip_config" not in config_dict:
                 config_dict["scip_config"] = {}
             if isinstance(config_dict["scip_config"], dict):
-                config_dict["scip_config"][
-                    "scip_workspace_retention_days"
-                ] = retention_days
-            elif isinstance(config_dict["scip_config"], ScipConfig):
-                config_dict["scip_config"].scip_workspace_retention_days = (
+                config_dict["scip_config"]["scip_workspace_retention_days"] = (
                     retention_days
                 )
+            elif isinstance(config_dict["scip_config"], ScipConfig):
+                config_dict[
+                    "scip_config"
+                ].scip_workspace_retention_days = retention_days
 
         # Story #15 AC2: Final conversion of scip_config after migration
         # This handles the case where scip_config was created by migration above

--- a/src/code_indexer/server/utils/config_manager.py
+++ b/src/code_indexer/server/utils/config_manager.py
@@ -163,7 +163,9 @@ class ServerResourceConfig:
     git_untracked_file_timeout: int = 60  # 1 minute for untracked file check
 
     # Refresh scheduler timeouts (in seconds)
-    cow_clone_timeout: int = 3600  # 1 hour for CoW clone of very large repos (e.g. evolution ~1M files, phoenix 40GB); ~2-3x headroom over measured ~17-19 min
+    cow_clone_timeout: int = (
+        3600  # 1 hour for CoW clone of very large repos (e.g. evolution ~1M files, phoenix 40GB); ~2-3x headroom over measured ~17-19 min
+    )
     git_update_index_timeout: int = 300  # 5 minutes for git update-index during refresh
     git_restore_timeout: int = 300  # 5 minutes for git restore during refresh
     cidx_fix_config_timeout: int = 60  # 1 minute for cidx fix-config
@@ -854,6 +856,22 @@ class BackgroundJobsConfig:
     # RESTART_REQUIRED_FIELDS in web/routes.py), not live-reloaded.
     temporal_lane_concurrency: int = 2
 
+    # Memory-aware admission for heavy index jobs.
+    # A fixed pool size (above) is memory-blind: under bulk golden-repo indexing
+    # the combined HNSW + FTS + embedding footprint of pool_size concurrent jobs
+    # can exceed the process/cgroup memory limit and OOM the server. When the
+    # gate is enabled, a worker consults the cgroup-aware MemoryGovernor before
+    # starting a memory-heavy op and, if under pressure, re-queues the job (it
+    # stays PENDING) and backs off — jobs wait instead of OOMing. The watermark
+    # is a percentage of the process's OWN cgroup limit, so it self-tunes to any
+    # memory.max without per-deployment tuning.
+    job_admission_memory_gate_enabled: bool = True
+    # Admit a heavy job only while cgroup used% is below this (below the
+    # governor's 85% RED/eviction line, leaving headroom for the job's growth).
+    job_admission_memory_max_used_pct: float = 80.0
+    # Seconds a worker waits after declining to admit before re-checking.
+    job_admission_backoff_seconds: float = 2.0
+
     def __post_init__(self) -> None:
         if self.max_concurrent_refresh_jobs < 0:
             self.max_concurrent_refresh_jobs = max(
@@ -1463,8 +1481,12 @@ class ServerConfig:
     # Both default True since v9.23.3 so fresh installs automatically inherit the
     # protections. Operators can disable either by setting the flag to false in
     # ~/.cidx-server/config.json; readable before the DB is available (cleanup daemon thread).
-    enable_malloc_trim: bool = True  # Mitigation 1: call malloc_trim(0) after eviction. Default ON since v9.23.3.
-    enable_malloc_arena_max: bool = True  # Mitigation 2: inject MALLOC_ARENA_MAX=2 via systemd. Default ON since v9.23.3.
+    enable_malloc_trim: bool = (
+        True  # Mitigation 1: call malloc_trim(0) after eviction. Default ON since v9.23.3.
+    )
+    enable_malloc_arena_max: bool = (
+        True  # Mitigation 2: inject MALLOC_ARENA_MAX=2 via systemd. Default ON since v9.23.3.
+    )
 
     # Story #1032 AC6 - Pre-deactivation leak scan (bootstrap-only, never DB).
     # Default False: _detect_resource_leaks is post-failure-only diagnostic.
@@ -2090,13 +2112,13 @@ class ServerConfigManager:
             if "scip_config" not in config_dict:
                 config_dict["scip_config"] = {}
             if isinstance(config_dict["scip_config"], dict):
-                config_dict["scip_config"]["scip_workspace_retention_days"] = (
+                config_dict["scip_config"][
+                    "scip_workspace_retention_days"
+                ] = retention_days
+            elif isinstance(config_dict["scip_config"], ScipConfig):
+                config_dict["scip_config"].scip_workspace_retention_days = (
                     retention_days
                 )
-            elif isinstance(config_dict["scip_config"], ScipConfig):
-                config_dict[
-                    "scip_config"
-                ].scip_workspace_retention_days = retention_days
 
         # Story #15 AC2: Final conversion of scip_config after migration
         # This handles the case where scip_config was created by migration above

--- a/tests/unit/server/repositories/test_background_job_manager_tracker.py
+++ b/tests/unit/server/repositories/test_background_job_manager_tracker.py
@@ -194,6 +194,9 @@ class TestBGMSubmitJobTrackerRegistration:
                     operation_type="test_operation",
                     username="testuser",
                     repo_alias="my-repo",
+                    # Pod-pull (PR #1424): submit_job threads metadata (None here,
+                    # no reconstruction params) into the atomic INSERT.
+                    metadata=None,
                     is_admin=False,
                     actor_username="testuser",
                 )

--- a/tests/unit/server/repositories/test_background_jobs_admission_gate.py
+++ b/tests/unit/server/repositories/test_background_jobs_admission_gate.py
@@ -12,6 +12,7 @@ import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, List
 
 import pytest
 
@@ -33,7 +34,13 @@ class _StubGovernor:
 
     def __init__(self, allowed: bool):
         self.allowed = allowed
-        self.calls = []
+        self.calls: List[float] = []
+        # Optional governor-reporting attributes, mirroring the real
+        # MemoryGovernor's `band`/`last_used_pct` properties. Left unset
+        # (None / 0.0) by default; some tests assign real values to exercise
+        # _log_admission_deferred's breadcrumb formatting.
+        self.band: Any = None
+        self.last_used_pct: float = 0.0
 
     def admission_allowed(self, max_used_pct: float) -> bool:
         self.calls.append(max_used_pct)
@@ -106,6 +113,20 @@ class TestAdmissionBlockedHelper:
         m = self._manager(job_admission_memory_gate_enabled=False)
         m.jobs["j1"] = _job("j1", "add_golden_repo")
         mg.set_memory_governor(_StubGovernor(allowed=False))
+        assert m._admission_blocked("j1") is False
+
+    def test_governor_exception_fails_open(self):
+        # L1: a governor that raises must not propagate out of the admission
+        # check -- otherwise the exception would kill the pool-worker thread and
+        # silently stop the lane. Fail-open (do not block).
+        m = self._manager()
+        m.jobs["j1"] = _job("j1", "add_golden_repo")
+
+        class _BoomGovernor:
+            def admission_allowed(self, max_used_pct):
+                raise RuntimeError("governor boom")
+
+        mg.set_memory_governor(_BoomGovernor())
         assert m._admission_blocked("j1") is False
 
     def test_uses_configured_watermark(self):

--- a/tests/unit/server/repositories/test_background_jobs_admission_gate.py
+++ b/tests/unit/server/repositories/test_background_jobs_admission_gate.py
@@ -1,0 +1,189 @@
+"""memory-aware admission gate in BackgroundJobManager.
+
+Covers the pure decision helper (_admission_blocked) and the pool-worker
+behavior (a blocked heavy job is re-queued and NOT executed until the governor
+allows). Uses a stub governor installed via set_memory_governor so no real
+cgroup/psutil I/O is involved.
+"""
+
+import os
+import shutil
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+# Import via the `code_indexer` package name (NOT `src.code_indexer`): the module
+# under test reads the MemoryGovernor singleton through `code_indexer...`, so the
+# test must install the stub on that same module object. Mixing the two import
+# prefixes would create two module identities with two separate singletons.
+from code_indexer.server.repositories.background_jobs import (
+    BackgroundJob,
+    BackgroundJobManager,
+    JobStatus,
+)
+from code_indexer.server.services import memory_governor as mg
+from code_indexer.server.utils.config_manager import BackgroundJobsConfig
+
+
+class _StubGovernor:
+    """Minimal governor stand-in: admission_allowed returns a settable flag."""
+
+    def __init__(self, allowed: bool):
+        self.allowed = allowed
+        self.calls = []
+
+    def admission_allowed(self, max_used_pct: float) -> bool:
+        self.calls.append(max_used_pct)
+        return self.allowed
+
+
+def _job(job_id: str, op_type: str) -> BackgroundJob:
+    return BackgroundJob(
+        job_id=job_id,
+        operation_type=op_type,
+        status=JobStatus.PENDING,
+        created_at=datetime.now(timezone.utc),
+        started_at=None,
+        completed_at=None,
+        result=None,
+        error=None,
+        progress=0,
+        username="admin",
+        is_admin=True,
+    )
+
+
+class TestAdmissionBlockedHelper:
+    """_admission_blocked() decision matrix — no threads."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage = Path(self.temp_dir) / "jobs.json"
+        self.manager = None
+
+    def teardown_method(self):
+        if self.manager is not None:
+            self.manager.shutdown()
+        mg.clear_memory_governor()
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def _manager(self, **cfg_kwargs):
+        config = BackgroundJobsConfig(max_concurrent_background_jobs=1, **cfg_kwargs)
+        self.manager = BackgroundJobManager(
+            storage_path=str(self.storage), background_jobs_config=config
+        )
+        return self.manager
+
+    def test_heavy_op_blocked_when_governor_denies(self):
+        m = self._manager()
+        m.jobs["j1"] = _job("j1", "add_golden_repo")
+        mg.set_memory_governor(_StubGovernor(allowed=False))
+        assert m._admission_blocked("j1") is True
+
+    def test_heavy_op_allowed_when_governor_permits(self):
+        m = self._manager()
+        m.jobs["j1"] = _job("j1", "add_golden_repo")
+        mg.set_memory_governor(_StubGovernor(allowed=True))
+        assert m._admission_blocked("j1") is False
+
+    def test_cheap_op_never_blocked(self):
+        m = self._manager()
+        m.jobs["j1"] = _job("j1", "xray_search")
+        mg.set_memory_governor(_StubGovernor(allowed=False))
+        assert m._admission_blocked("j1") is False
+
+    def test_no_governor_fails_open(self):
+        m = self._manager()
+        m.jobs["j1"] = _job("j1", "add_golden_repo")
+        mg.clear_memory_governor()
+        assert m._admission_blocked("j1") is False
+
+    def test_gate_disabled_fails_open(self):
+        m = self._manager(job_admission_memory_gate_enabled=False)
+        m.jobs["j1"] = _job("j1", "add_golden_repo")
+        mg.set_memory_governor(_StubGovernor(allowed=False))
+        assert m._admission_blocked("j1") is False
+
+    def test_uses_configured_watermark(self):
+        m = self._manager(job_admission_memory_max_used_pct=73.5)
+        m.jobs["j1"] = _job("j1", "add_golden_repo")
+        stub = _StubGovernor(allowed=True)
+        mg.set_memory_governor(stub)
+        m._admission_blocked("j1")
+        assert stub.calls == [73.5]
+
+    def test_deferral_log_rate_limited(self, caplog):
+        import logging as _logging
+
+        m = self._manager()
+        m.jobs["j1"] = _job("j1", "add_golden_repo")
+        gov = _StubGovernor(allowed=False)
+        gov.band = type("B", (), {"value": "RED"})()
+        gov.last_used_pct = 92.0
+        mg.set_memory_governor(gov)
+
+        with caplog.at_level(_logging.INFO):
+            m._log_admission_deferred("j1")  # first: logs
+            m._log_admission_deferred("j1")  # immediately after: suppressed
+
+        defer_lines = [
+            r for r in caplog.records if "memory-pressure: deferring" in r.getMessage()
+        ]
+        assert len(defer_lines) == 1
+        assert "band=RED" in defer_lines[0].getMessage()
+        assert "op=add_golden_repo" in defer_lines[0].getMessage()
+
+
+@pytest.mark.slow
+class TestPoolWorkerRequeue:
+    """The pool worker re-queues a blocked heavy job and runs it once unblocked."""
+
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage = Path(self.temp_dir) / "jobs.json"
+        self.manager = None
+
+    def teardown_method(self):
+        if self.manager is not None:
+            self.manager.shutdown()
+        mg.clear_memory_governor()
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def test_blocked_job_deferred_then_executed_on_recovery(self):
+        config = BackgroundJobsConfig(
+            max_concurrent_background_jobs=1,
+            job_admission_backoff_seconds=0.05,
+        )
+        self.manager = BackgroundJobManager(
+            storage_path=str(self.storage), background_jobs_config=config
+        )
+        m = self.manager
+
+        executed = []
+        m._execute_job = lambda job_id, func, args, kwargs: executed.append(job_id)
+
+        m.jobs["j1"] = _job("j1", "add_golden_repo")
+        stub = _StubGovernor(allowed=False)
+        stub.band = type("B", (), {"value": "RED"})()
+        stub.last_used_pct = 92.0
+        mg.set_memory_governor(stub)
+
+        # Enqueue the heavy job directly onto the pool queue.
+        m._pending_job_queue.put(("j1", lambda: None, (), {}))
+
+        # While the governor denies, the worker keeps re-queuing — no execution.
+        time.sleep(0.3)
+        assert executed == []
+        assert len(stub.calls) > 0  # the gate was consulted at least once
+
+        # Pod recovers: governor now admits → worker executes exactly once.
+        stub.allowed = True
+        deadline = time.time() + 2.0
+        while not executed and time.time() < deadline:
+            time.sleep(0.05)
+        assert executed == ["j1"]

--- a/tests/unit/server/repositories/test_background_jobs_pod_pull_status_readthrough_bug1424.py
+++ b/tests/unit/server/repositories/test_background_jobs_pod_pull_status_readthrough_bug1424.py
@@ -1,0 +1,136 @@
+"""Cluster-aware read-through for pod-pull jobs (PR #1424 follow-up).
+
+A pod-pull job is left PENDING in the shared background_jobs queue and executed
+on WHICHEVER node claims it -- its real progress/status live in the shared DB
+row (written cross-node by the claimer's update_progress/complete_job/fail_job).
+
+Bug: submit_job added a node-local in-memory PENDING entry (self.jobs[job_id])
+for the pod-pull job and never removed it. Both read paths PREFER the in-memory
+copy over the shared DB row (get_job_status returns it first; get_jobs_for_display
+adds it to seen_ids and excludes the DB row), so a poll landing on the SUBMITTING
+node would show stale PENDING forever -- exactly the cluster-aware-state class of
+bug CLAUDE.md prohibits.
+
+Fix: do NOT retain the in-memory entry for a pod-pull job, so both read paths
+fall through to the authoritative shared DB row regardless of which node the poll
+hits. These tests use a REAL BackgroundJobsSqliteBackend as the shared store and
+simulate a different node's writes by updating that shared row directly.
+"""
+
+import os
+import shutil
+import tempfile
+from datetime import datetime, timezone
+
+import pytest
+from unittest.mock import MagicMock
+
+from code_indexer.server.repositories.background_jobs import BackgroundJobManager
+from code_indexer.server.storage.sqlite_backends import BackgroundJobsSqliteBackend
+from code_indexer.server.utils.config_manager import BackgroundJobsConfig
+
+
+@pytest.mark.slow
+class TestPodPullStatusReadThrough:
+    def setup_method(self):
+        from code_indexer.server.storage.database_manager import DatabaseSchema
+
+        self.temp_dir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.temp_dir, "shared_jobs.db")
+        self.storage = os.path.join(self.temp_dir, "jobs.json")
+        # Create the real shared background_jobs schema, then a backend over it.
+        DatabaseSchema(self.db_path).initialize_database()
+        self.shared = BackgroundJobsSqliteBackend(self.db_path)
+        self.manager = None
+
+    def teardown_method(self):
+        if self.manager is not None:
+            self.manager.shutdown()
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def _bgm(self):
+        tracker = MagicMock()
+        tracker.register_job_if_no_conflict.return_value = MagicMock()
+        self.manager = BackgroundJobManager(
+            storage_path=self.storage,
+            background_jobs_config=BackgroundJobsConfig(
+                max_concurrent_background_jobs=1
+            ),
+            storage_backend=self.shared,
+            job_tracker=tracker,
+            cluster_mode=True,
+        )
+        # Never actually run a job on the local pool in this test.
+        self.manager._execute_job = lambda *a, **k: None
+        return self.manager
+
+    def _submit_pod_pull(self, m, metadata):
+        return m.submit_job(
+            operation_type="add_golden_repo",
+            func=lambda progress_callback=None: {"ok": True},
+            submitter_username="admin",
+            is_admin=True,
+            repo_alias="repoA",
+            metadata=metadata,
+        )
+
+    def _register_shared_row(self, job_id):
+        """Represent the PENDING row the JobTracker registered in the shared DB."""
+        self.shared.save_job(
+            job_id=job_id,
+            operation_type="add_golden_repo",
+            status="pending",
+            created_at=datetime.now(timezone.utc).isoformat(),
+            username="admin",
+            progress=0,
+            repo_alias="repoA",
+            is_admin=True,
+        )
+
+    def test_get_job_status_reflects_remote_progress_and_completion(self):
+        m = self._bgm()
+        job_id = self._submit_pod_pull(m, metadata={"alias": "repoA"})
+        self._register_shared_row(job_id)
+
+        # A DIFFERENT node claims and reports progress into the shared row.
+        self.shared.update_job(
+            job_id,
+            status="running",
+            progress=40,
+            current_phase="index",
+        )
+        status = m.get_job_status(job_id, username="admin", is_admin=True)
+        assert status is not None
+        assert status["status"] == "running"
+        assert status["progress"] == 40
+
+        # ...then completes it in the shared row.
+        self.shared.update_job(
+            job_id,
+            status="completed",
+            progress=100,
+            result={"success": True},
+        )
+        status = m.get_job_status(job_id, username="admin", is_admin=True)
+        assert status["status"] == "completed"
+        assert status["progress"] == 100
+
+    def test_get_jobs_for_display_reflects_shared_db_state(self):
+        m = self._bgm()
+        job_id = self._submit_pod_pull(m, metadata={"alias": "repoA"})
+        self._register_shared_row(job_id)
+        self.shared.update_job(job_id, status="running", progress=55)
+
+        jobs, _total, _pages = m.get_jobs_for_display(is_admin=True)
+        entry = next((j for j in jobs if j["job_id"] == job_id), None)
+        assert entry is not None, "pod-pull job must still be listed (from the DB)"
+        assert entry["status"] == "running"
+        assert entry["progress"] == 55
+
+    def test_metadata_less_fallback_job_retains_local_entry(self):
+        # Scoping guard: without metadata the op falls back to the local pool
+        # (not work-stolen), so its in-memory entry MUST be retained.
+        m = self._bgm()
+        job_id = self._submit_pod_pull(m, metadata=None)
+        assert job_id in m.jobs

--- a/tests/unit/server/repositories/test_background_jobs_pod_pull_submit.py
+++ b/tests/unit/server/repositories/test_background_jobs_pod_pull_submit.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
+from typing import Any, List
 from unittest.mock import MagicMock
 
 import pytest
@@ -41,7 +42,7 @@ class TestPodPullSubmit:
         )
         # Neutralize actual execution and spy on local-pool enqueues.
         self.manager._execute_job = lambda *a, **k: None
-        self.enqueued = []
+        self.enqueued: List[Any] = []
         orig = self.manager._pending_job_queue.put
 
         def spy(item, *a, **k):

--- a/tests/unit/server/repositories/test_background_jobs_pod_pull_submit.py
+++ b/tests/unit/server/repositories/test_background_jobs_pod_pull_submit.py
@@ -1,0 +1,99 @@
+"""cluster-mode submit leaves pod-pull ops PENDING (not enqueued locally)."""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from code_indexer.server.repositories.background_jobs import (
+    BackgroundJobManager,
+    POD_PULL_OPS,
+)
+from code_indexer.server.utils.config_manager import BackgroundJobsConfig
+
+
+@pytest.mark.slow
+class TestPodPullSubmit:
+    def setup_method(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.storage = Path(self.temp_dir) / "jobs.json"
+        self.manager = None
+
+    def teardown_method(self):
+        if self.manager is not None:
+            self.manager.shutdown()
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def _manager(self, cluster_mode: bool):
+        tracker = MagicMock()
+        tracker.register_job_if_no_conflict.return_value = MagicMock()
+        self.manager = BackgroundJobManager(
+            storage_path=str(self.storage),
+            background_jobs_config=BackgroundJobsConfig(
+                max_concurrent_background_jobs=1
+            ),
+            job_tracker=tracker,
+            cluster_mode=cluster_mode,
+        )
+        # Neutralize actual execution and spy on local-pool enqueues.
+        self.manager._execute_job = lambda *a, **k: None
+        self.enqueued = []
+        orig = self.manager._pending_job_queue.put
+
+        def spy(item, *a, **k):
+            if item is not None:
+                self.enqueued.append(item)
+            return orig(item, *a, **k)
+
+        self.manager._pending_job_queue.put = spy
+        return self.manager, tracker
+
+    def _submit(self, m, op, *, metadata=None):
+        return m.submit_job(
+            operation_type=op,
+            func=lambda progress_callback=None: {"ok": True},
+            submitter_username="admin",
+            is_admin=True,
+            repo_alias="repoA",
+            metadata=metadata,
+        )
+
+    def test_cluster_pod_pull_op_with_metadata_not_enqueued(self):
+        m, tracker = self._manager(cluster_mode=True)
+        job_id = self._submit(m, "add_golden_repo", metadata={"alias": "repoA"})
+        assert job_id  # returns id
+        tracker.register_job_if_no_conflict.assert_called_once()
+        # Left PENDING for pod-pull — NOT put on the local pool.
+        assert all(item[0] != job_id for item in self.enqueued)
+        assert self.enqueued == []
+
+    def test_cluster_pod_pull_without_metadata_falls_back_to_local(self):
+        m, _ = self._manager(cluster_mode=True)
+        job_id = self._submit(m, "add_golden_repo", metadata=None)
+        assert any(item[0] == job_id for item in self.enqueued)
+
+    def test_cluster_cheap_op_still_enqueued(self):
+        m, _ = self._manager(cluster_mode=True)
+        # xray_search is not a pod-pull op.
+        job_id = self._submit(m, "xray_search", metadata={"x": 1})
+        assert any(item[0] == job_id for item in self.enqueued)
+
+    def test_non_cluster_pod_pull_op_still_enqueued(self):
+        m, _ = self._manager(cluster_mode=False)
+        job_id = self._submit(m, "add_golden_repo", metadata={"alias": "repoA"})
+        assert any(item[0] == job_id for item in self.enqueued)
+
+    def test_all_five_heavy_ops_are_pod_pull(self):
+        assert POD_PULL_OPS == frozenset(
+            {
+                "add_golden_repo",
+                "provider_index_add",
+                "provider_temporal_index_rebuild",
+                "sync_repository",
+                "change_branch",
+            }
+        )

--- a/tests/unit/server/repositories/test_golden_repo_add_retry_orphan_clone_bug1424.py
+++ b/tests/unit/server/repositories/test_golden_repo_add_retry_orphan_clone_bug1424.py
@@ -1,0 +1,127 @@
+"""Regression: add_golden_repo retry must clean an orphan partial clone (H1).
+
+Pod-pull work-stealing (PR #1424) made add_golden_repo cross-node
+reclaim-eligible. A hard crash (SIGKILL) mid-clone leaves a partial clone dir
+at golden_repos_dir/{alias} with NO committed golden_repos row -- the
+except-path _cleanup_failed_clone never ran. On dead-node reclaim + retry,
+_clone_repository raises "destination path already exists" BEFORE
+_clone_path_for_cleanup is assigned, so nothing is ever cleaned and every retry
+AND every future manual re-add of that alias fails forever.
+
+Fix: execute_add_golden_repo_work proactively removes such an ORPHAN clone via
+_remove_orphan_clone_for_retry(repo_url, alias) before cloning. Guards:
+  - never touch in-place-registration content (EVO-64228)
+  - never remove a clone whose golden_repos row IS committed (near-complete
+    registration, not an orphan)
+"""
+
+import os
+import shutil
+import tempfile
+from datetime import datetime, timezone
+
+import pytest
+
+from code_indexer.server.repositories.golden_repo_manager import (
+    GoldenRepoManager,
+)
+
+
+@pytest.fixture()
+def manager():
+    tmp = tempfile.mkdtemp()
+    try:
+        mgr = GoldenRepoManager(data_dir=tmp)
+        os.makedirs(mgr.golden_repos_dir, exist_ok=True)
+        yield mgr
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _make_orphan_clone(manager: GoldenRepoManager, alias: str) -> str:
+    """Create a non-empty partial-clone dir at golden_repos_dir/{alias}."""
+    clone_path = os.path.join(manager.golden_repos_dir, alias)
+    os.makedirs(clone_path, exist_ok=True)
+    with open(os.path.join(clone_path, "partial.txt"), "w") as fh:
+        fh.write("partial clone leftover")
+    return clone_path
+
+
+class TestRemoveOrphanCloneForRetry:
+    def test_removes_orphan_clone_when_no_committed_row(self, manager):
+        clone_path = _make_orphan_clone(manager, "repoA")
+        assert os.path.exists(clone_path)
+
+        removed = manager._remove_orphan_clone_for_retry(
+            "https://github.com/org/repoA.git", "repoA"
+        )
+
+        assert removed is True
+        assert not os.path.exists(clone_path)
+
+    def test_keeps_clone_when_committed_row_exists(self, manager):
+        clone_path = _make_orphan_clone(manager, "repoB")
+        # A committed golden_repos row => NOT an orphan (near-complete register).
+        manager._sqlite_backend.add_repo(
+            alias="repoB",
+            repo_url="https://github.com/org/repoB.git",
+            default_branch="main",
+            clone_path=clone_path,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            enable_temporal=False,
+            temporal_options=None,
+        )
+
+        removed = manager._remove_orphan_clone_for_retry(
+            "https://github.com/org/repoB.git", "repoB"
+        )
+
+        assert removed is False
+        assert os.path.exists(clone_path)
+
+    def test_skips_in_place_registration(self, manager):
+        # repo_url == clone_path => in-place; content is not cidx's to remove.
+        clone_path = _make_orphan_clone(manager, "repoC")
+        removed = manager._remove_orphan_clone_for_retry(clone_path, "repoC")
+
+        assert removed is False
+        assert os.path.exists(clone_path)
+
+    def test_noop_when_no_clone_dir(self, manager):
+        clone_path = os.path.join(manager.golden_repos_dir, "repoD")
+        assert not os.path.exists(clone_path)
+
+        removed = manager._remove_orphan_clone_for_retry(
+            "https://github.com/org/repoD.git", "repoD"
+        )
+
+        assert removed is False
+
+
+class TestExecuteAddRetryDoesNotWedgeOnOrphanClone:
+    """The real execute_add_golden_repo_work retry path (no mocking of the
+    manager's own methods): a pre-existing orphan clone is removed before the
+    real clone runs, so the retry fails for the REAL underlying reason (bogus
+    source) rather than wedging forever on "destination path already exists"."""
+
+    def test_orphan_marker_removed_before_real_clone(self, manager):
+        clone_path = _make_orphan_clone(manager, "repoE")
+        marker = os.path.join(clone_path, "partial.txt")
+        assert os.path.exists(marker)
+
+        # A local (not in-place) source that does not exist: _clone_repository
+        # runs for real and fails fast with no network. The point is that the
+        # orphan is cleaned BEFORE that clone attempt.
+        bogus_source = os.path.join(manager.data_dir, "nonexistent-source-repoE")
+        assert not os.path.exists(bogus_source)
+
+        with pytest.raises(Exception):
+            manager.execute_add_golden_repo_work(
+                repo_url=bogus_source,
+                alias="repoE",
+            )
+
+        # The orphan leftover MUST be gone -- proving cleanup ran before clone.
+        # (Before the fix, clone raises "destination path already exists" and
+        # the marker survives.)
+        assert not os.path.exists(marker)

--- a/tests/unit/server/services/test_distributed_job_claimer.py
+++ b/tests/unit/server/services/test_distributed_job_claimer.py
@@ -19,7 +19,6 @@ from unittest.mock import MagicMock
 
 from code_indexer.server.services.distributed_job_claimer import DistributedJobClaimer
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -64,6 +63,7 @@ def _make_job_row(
     language_resolution_status=None,
     executing_node="node-1",
     claimed_at="2026-01-01T00:01:00+00:00",
+    metadata=None,
 ):
     """Build a tuple matching the _SELECT_COLS column order."""
     return (
@@ -87,6 +87,8 @@ def _make_job_row(
         json.dumps(language_resolution_status) if language_resolution_status else None,
         executing_node,
         claimed_at,
+        # Pod-pull: metadata JSONB column (pod-pull reconstruction params).
+        json.dumps(metadata) if metadata else None,
     )
 
 

--- a/tests/unit/server/services/test_distributed_job_claimer_memory_gate.py
+++ b/tests/unit/server/services/test_distributed_job_claimer_memory_gate.py
@@ -1,0 +1,79 @@
+"""memory-aware admission gate in DistributedJobClaimer.
+
+A pod under memory pressure must decline to claim so the row stays 'pending'
+for a pod with headroom (or for later). Uses a stub governor installed via
+set_memory_governor — no real cgroup/psutil I/O.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from code_indexer.server.services import memory_governor as mg
+from code_indexer.server.services.distributed_job_claimer import DistributedJobClaimer
+
+
+class _StubGovernor:
+    def __init__(self, allowed: bool):
+        self.allowed = allowed
+
+    def admission_allowed(self, max_used_pct: float) -> bool:
+        return self.allowed
+
+
+def _claimer(**kwargs):
+    pool = MagicMock()
+    claimer = DistributedJobClaimer(pool=pool, node_id="node-1", **kwargs)
+    return claimer, pool
+
+
+def _wire_empty_claim(pool):
+    """Make pool.connection() yield a cursor whose claim SELECT finds nothing."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = None
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+    pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+
+
+class TestClaimerMemoryGate:
+    def teardown_method(self):
+        mg.clear_memory_governor()
+
+    def test_declines_claim_under_pressure(self):
+        """Governor denies → return None and never touch the DB (row stays pending)."""
+        claimer, pool = _claimer()
+        mg.set_memory_governor(_StubGovernor(allowed=False))
+        assert claimer.claim_next_job() is None
+        assert pool.connection.call_count == 0
+
+    def test_proceeds_when_governor_admits(self):
+        """Governor admits → reach the claim SQL (no pending → None, but DB touched)."""
+        claimer, pool = _claimer()
+        _wire_empty_claim(pool)
+        mg.set_memory_governor(_StubGovernor(allowed=True))
+        assert claimer.claim_next_job() is None
+        assert pool.connection.call_count == 1
+
+    def test_no_governor_fails_open(self):
+        """No governor singleton (CLI/solo) → proceed to claim."""
+        claimer, pool = _claimer()
+        _wire_empty_claim(pool)
+        mg.clear_memory_governor()
+        assert claimer.claim_next_job() is None
+        assert pool.connection.call_count == 1
+
+    def test_gate_disabled_skips_governor(self):
+        """memory_gate_enabled=False → ignore governor entirely."""
+        claimer, pool = _claimer(memory_gate_enabled=False)
+        _wire_empty_claim(pool)
+        mg.set_memory_governor(_StubGovernor(allowed=False))
+        assert claimer.claim_next_job() is None
+        assert pool.connection.call_count == 1
+
+    def test_gate_defaults(self):
+        claimer, _ = _claimer()
+        assert claimer._memory_gate_enabled is True
+        assert claimer._memory_max_used_pct == pytest.approx(80.0)

--- a/tests/unit/server/services/test_distributed_job_claimer_metadata.py
+++ b/tests/unit/server/services/test_distributed_job_claimer_metadata.py
@@ -1,5 +1,6 @@
 """DistributedJobClaimer metadata column + job_types/exclude_types filters."""
 
+from typing import Any, List
 from unittest.mock import MagicMock
 
 from code_indexer.server.services import memory_governor as mg
@@ -21,14 +22,14 @@ class TestMetadataColumn:
         assert _json_col('{"a": 1}') == {"a": 1}
 
     def test_row_to_dict_includes_metadata_parsed(self):
-        row = [None] * 21
+        row: List[Any] = [None] * 21
         row[0] = "j1"
         row[20] = {"repo_url": "u", "alias": "a"}
         d = _row_to_dict(row)
         assert d["metadata"] == {"repo_url": "u", "alias": "a"}
 
     def test_row_to_dict_metadata_from_json_string(self):
-        row = [None] * 21
+        row: List[Any] = [None] * 21
         row[20] = '{"clear": false}'
         assert _row_to_dict(row)["metadata"] == {"clear": False}
 

--- a/tests/unit/server/services/test_distributed_job_claimer_metadata.py
+++ b/tests/unit/server/services/test_distributed_job_claimer_metadata.py
@@ -1,0 +1,90 @@
+"""DistributedJobClaimer metadata column + job_types/exclude_types filters."""
+
+from unittest.mock import MagicMock
+
+from code_indexer.server.services import memory_governor as mg
+from code_indexer.server.services.distributed_job_claimer import (
+    DistributedJobClaimer,
+    _SELECT_COLS,
+    _json_col,
+    _row_to_dict,
+)
+
+
+class TestMetadataColumn:
+    def test_select_cols_includes_metadata(self):
+        assert "metadata" in _SELECT_COLS
+
+    def test_json_col_handles_none_dict_str(self):
+        assert _json_col(None) is None
+        assert _json_col({"a": 1}) == {"a": 1}
+        assert _json_col('{"a": 1}') == {"a": 1}
+
+    def test_row_to_dict_includes_metadata_parsed(self):
+        row = [None] * 21
+        row[0] = "j1"
+        row[20] = {"repo_url": "u", "alias": "a"}
+        d = _row_to_dict(row)
+        assert d["metadata"] == {"repo_url": "u", "alias": "a"}
+
+    def test_row_to_dict_metadata_from_json_string(self):
+        row = [None] * 21
+        row[20] = '{"clear": false}'
+        assert _row_to_dict(row)["metadata"] == {"clear": False}
+
+
+def _claimer():
+    pool = MagicMock()
+    return DistributedJobClaimer(pool=pool, node_id="n1"), pool
+
+
+def _capture_execute(pool):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.fetchone.return_value = None
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+    pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+    return cur
+
+
+class TestClaimFilters:
+    def teardown_method(self):
+        mg.clear_memory_governor()
+
+    def test_job_types_builds_any_filter(self):
+        c, pool = _claimer()
+        cur = _capture_execute(pool)
+        c.claim_next_job(job_types=["add_golden_repo", "sync_repository"])
+        sql, params = cur.execute.call_args[0]
+        assert "operation_type = ANY(%s)" in sql
+        assert params == ["n1", ["add_golden_repo", "sync_repository"]]
+
+    def test_exclude_types_builds_all_filter(self):
+        c, pool = _claimer()
+        cur = _capture_execute(pool)
+        c.claim_next_job(exclude_types=["add_golden_repo"])
+        sql, params = cur.execute.call_args[0]
+        assert "operation_type <> ALL(%s)" in sql
+        assert params == ["n1", ["add_golden_repo"]]
+
+    def test_no_filter_has_no_type_clause(self):
+        c, pool = _claimer()
+        cur = _capture_execute(pool)
+        c.claim_next_job()
+        sql, params = cur.execute.call_args[0]
+        # No type filter in the WHERE clause (operation_type still appears in the
+        # RETURNING column list, so assert on the filter predicates specifically).
+        assert "operation_type = %s" not in sql
+        assert "ANY(%s)" not in sql
+        assert "ALL(%s)" not in sql
+        assert params == ["n1"]
+
+    def test_single_job_type_backward_compat(self):
+        c, pool = _claimer()
+        cur = _capture_execute(pool)
+        c.claim_next_job(job_type="refresh_golden_repo")
+        sql, params = cur.execute.call_args[0]
+        assert "operation_type = %s" in sql
+        assert params == ["n1", "refresh_golden_repo"]

--- a/tests/unit/server/services/test_distributed_job_claimer_progress.py
+++ b/tests/unit/server/services/test_distributed_job_claimer_progress.py
@@ -1,0 +1,66 @@
+"""DistributedJobClaimer.update_progress: DB-backed progress for work-stolen jobs.
+
+PR #1424 H2: a pod-pull index op executes on whichever node claims it, NOT the
+submitting node. Its progress must be written back to the shared background_jobs
+row (ownership-scoped) so the originating node's dashboard -- which polls that
+row -- surfaces incremental progress (progress + current_phase + phase_detail)
+instead of a 0 -> 100 jump.
+"""
+
+from unittest.mock import MagicMock
+
+from code_indexer.server.services.distributed_job_claimer import DistributedJobClaimer
+
+
+def _claimer():
+    pool = MagicMock()
+    return DistributedJobClaimer(pool=pool, node_id="node-1"), pool
+
+
+def _wire_cursor(pool, rowcount=1):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.rowcount = rowcount
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+    pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+    return cur
+
+
+class TestUpdateProgress:
+    def test_writes_progress_phase_and_detail_scoped_to_executing_node(self):
+        c, pool = _claimer()
+        cur = _wire_cursor(pool, rowcount=1)
+
+        ok = c.update_progress("j1", 50, phase="index", detail="building")
+
+        assert ok is True
+        sql, params = cur.execute.call_args[0]
+        # All three progress columns are updated.
+        assert "progress" in sql
+        assert "current_phase" in sql
+        assert "phase_detail" in sql
+        # Ownership-scoped by executing_node.
+        assert "executing_node = %s" in sql
+        assert params[-1] == "node-1"
+        # Values pass through.
+        assert "j1" in params
+        assert 50 in params
+        assert "index" in params
+        assert "building" in params
+
+    def test_returns_false_when_not_owned(self):
+        c, pool = _claimer()
+        _wire_cursor(pool, rowcount=0)
+        assert c.update_progress("j1", 10) is False
+
+    def test_phase_and_detail_default_to_none(self):
+        c, pool = _claimer()
+        cur = _wire_cursor(pool, rowcount=1)
+        # Omitting phase/detail must still write progress, passing None through
+        # for the phase/detail params (COALESCE preserves the existing values).
+        assert c.update_progress("j1", 25) is True
+        sql, params = cur.execute.call_args[0]
+        assert 25 in params
+        assert None in params

--- a/tests/unit/server/services/test_distributed_job_worker.py
+++ b/tests/unit/server/services/test_distributed_job_worker.py
@@ -16,8 +16,12 @@ class FakeClaimer:
         self.jobs_to_return = []
         self.completed_jobs = []
         self.failed_jobs = []
+        self.last_exclude_types = None
 
-    def claim_next_job(self):
+    def claim_next_job(self, job_type=None, *, job_types=None, exclude_types=None):
+        # Mirror the real DistributedJobClaimer signature: the leader worker
+        # excludes POD_PULL_OPS so it leaves those rows for the IndexJobClaimLoop.
+        self.last_exclude_types = exclude_types
         if self.jobs_to_return:
             return self.jobs_to_return.pop(0)
         return None

--- a/tests/unit/server/services/test_index_dispatch_coverage_bug1424.py
+++ b/tests/unit/server/services/test_index_dispatch_coverage_bug1424.py
@@ -1,0 +1,43 @@
+"""M3: pod-pull dispatch must exactly cover POD_PULL_OPS.
+
+A future op added to POD_PULL_OPS without a matching IndexJobClaimLoop dispatch
+executor (or vice versa) would let a row be claimed with no executor (or a
+never-work-stolen op). validate_dispatch_covers turns that silent drift into a
+loud startup failure.
+"""
+
+import pytest
+
+from code_indexer.server.services.index_job_claim_loop import validate_dispatch_covers
+
+
+def _noop(md, pc):
+    return None
+
+
+class TestValidateDispatchCovers:
+    def test_exact_match_ok(self):
+        required = frozenset({"a", "b"})
+        dispatch = {"a": _noop, "b": _noop}
+        # Must not raise.
+        validate_dispatch_covers(dispatch, required)
+
+    def test_missing_executor_raises(self):
+        required = frozenset({"a", "b", "c"})
+        dispatch = {"a": _noop, "b": _noop}
+        with pytest.raises(RuntimeError):
+            validate_dispatch_covers(dispatch, required)
+
+    def test_extra_executor_raises(self):
+        required = frozenset({"a"})
+        dispatch = {"a": _noop, "b": _noop}
+        with pytest.raises(RuntimeError):
+            validate_dispatch_covers(dispatch, required)
+
+    def test_matches_real_pod_pull_ops(self):
+        # Guards the actual production wiring: the concrete dispatch built in
+        # lifespan must match POD_PULL_OPS.
+        from code_indexer.server.repositories.background_jobs import POD_PULL_OPS
+
+        dispatch = {op: _noop for op in POD_PULL_OPS}
+        validate_dispatch_covers(dispatch, POD_PULL_OPS)

--- a/tests/unit/server/services/test_index_job_claim_loop.py
+++ b/tests/unit/server/services/test_index_job_claim_loop.py
@@ -1,4 +1,9 @@
-"""IndexJobClaimLoop claim -> dispatch -> complete/fail behavior."""
+"""IndexJobClaimLoop claim -> dispatch -> complete/fail behavior.
+
+Dispatch executors take (metadata, progress_callback): PR #1424 H2 gives a
+work-stolen job a real DB-backed progress path via a per-job progress_callback
+that routes to DistributedJobClaimer.update_progress.
+"""
 
 from unittest.mock import MagicMock
 
@@ -17,11 +22,11 @@ def _job(op="add_golden_repo", metadata=None):
     }
 
 
-class TestProcessOneJob:
+class TestClaimAndDispatch:
     def test_none_claim_is_noop(self):
         claimer = MagicMock()
         claimer.claim_next_job.return_value = None
-        loop = _loop(claimer, {"add_golden_repo": lambda md: {"ok": True}})
+        loop = _loop(claimer, {"add_golden_repo": lambda md, pc: {"ok": True}})
         assert loop._process_one_job() is False
         claimer.complete_job.assert_not_called()
         claimer.fail_job.assert_not_called()
@@ -31,7 +36,7 @@ class TestProcessOneJob:
         claimer.claim_next_job.return_value = _job(metadata={"alias": "a"})
         seen = {}
 
-        def executor(md):
+        def executor(md, progress_callback):
             seen.update(md)
             return {"success": True}
 
@@ -41,11 +46,60 @@ class TestProcessOneJob:
         claimer.complete_job.assert_called_once_with("j1", {"success": True})
         claimer.fail_job.assert_not_called()
 
+    def test_claim_restricted_to_dispatch_keys(self):
+        claimer = MagicMock()
+        claimer.claim_next_job.return_value = None
+        loop = _loop(
+            claimer,
+            {
+                "add_golden_repo": lambda md, pc: None,
+                "sync_repository": lambda md, pc: None,
+            },
+        )
+        loop._process_one_job()
+        kwargs = claimer.claim_next_job.call_args.kwargs
+        assert kwargs["job_types"] == ["add_golden_repo", "sync_repository"]
+
+
+class TestProgressCallback:
+    def test_executor_receives_progress_callback_routing_to_claimer(self):
+        claimer = MagicMock()
+        claimer.claim_next_job.return_value = _job()
+
+        def executor(md, progress_callback):
+            # The executor drives progress; it must land on the shared row via
+            # the claimer, scoped to THIS job_id.
+            progress_callback(60, phase="index", detail="building")
+            return {"success": True}
+
+        loop = _loop(claimer, {"add_golden_repo": executor})
+        assert loop._process_one_job() is True
+        claimer.update_progress.assert_called_once_with(
+            "j1", 60, phase="index", detail="building"
+        )
+
+    def test_progress_callback_tolerates_positional_only(self):
+        claimer = MagicMock()
+        claimer.claim_next_job.return_value = _job()
+
+        def executor(md, progress_callback):
+            # _execute_repository_sync calls progress_callback(int) positionally.
+            progress_callback(25)
+            return {"success": True}
+
+        loop = _loop(claimer, {"add_golden_repo": executor})
+        assert loop._process_one_job() is True
+        claimer.update_progress.assert_called_once_with(
+            "j1", 25, phase=None, detail=None
+        )
+
+
+class TestFailurePaths:
     def test_executor_exception_fails_job(self):
         claimer = MagicMock()
         claimer.claim_next_job.return_value = _job()
 
-        def boom(md):
+        def boom(md, pc):
             raise RuntimeError("kaboom")
 
         loop = _loop(claimer, {"add_golden_repo": boom})
@@ -59,33 +113,22 @@ class TestProcessOneJob:
         # Claim filtered to dispatch keys, but defend anyway.
         claimer = MagicMock()
         claimer.claim_next_job.return_value = _job(op="mystery")
-        loop = _loop(claimer, {"add_golden_repo": lambda md: None})
+        loop = _loop(claimer, {"add_golden_repo": lambda md, pc: None})
         assert loop._process_one_job() is True
         claimer.fail_job.assert_called_once()
-
-    def test_claim_restricted_to_dispatch_keys(self):
-        claimer = MagicMock()
-        claimer.claim_next_job.return_value = None
-        loop = _loop(
-            claimer,
-            {"add_golden_repo": lambda md: None, "sync_repository": lambda md: None},
-        )
-        loop._process_one_job()
-        kwargs = claimer.claim_next_job.call_args.kwargs
-        assert kwargs["job_types"] == ["add_golden_repo", "sync_repository"]
 
 
 class TestStopReleasesInflight:
     def test_stop_releases_in_flight_claim(self):
         claimer = MagicMock()
-        loop = _loop(claimer, {"add_golden_repo": lambda md: None})
+        loop = _loop(claimer, {"add_golden_repo": lambda md, pc: None})
         loop._in_flight = "j-running"
         loop.stop()
         claimer.release_job.assert_called_once_with("j-running")
 
     def test_stop_no_inflight_no_release(self):
         claimer = MagicMock()
-        loop = _loop(claimer, {"add_golden_repo": lambda md: None})
+        loop = _loop(claimer, {"add_golden_repo": lambda md, pc: None})
         loop.stop()
         claimer.release_job.assert_not_called()
 

--- a/tests/unit/server/services/test_index_job_claim_loop.py
+++ b/tests/unit/server/services/test_index_job_claim_loop.py
@@ -1,0 +1,98 @@
+"""IndexJobClaimLoop claim -> dispatch -> complete/fail behavior."""
+
+from unittest.mock import MagicMock
+
+from code_indexer.server.services.index_job_claim_loop import IndexJobClaimLoop
+
+
+def _loop(claimer, dispatch):
+    return IndexJobClaimLoop(claimer=claimer, dispatch=dispatch, node_id="n1")
+
+
+def _job(op="add_golden_repo", metadata=None):
+    return {
+        "job_id": "j1",
+        "operation_type": op,
+        "metadata": metadata if metadata is not None else {"alias": "a"},
+    }
+
+
+class TestProcessOneJob:
+    def test_none_claim_is_noop(self):
+        claimer = MagicMock()
+        claimer.claim_next_job.return_value = None
+        loop = _loop(claimer, {"add_golden_repo": lambda md: {"ok": True}})
+        assert loop._process_one_job() is False
+        claimer.complete_job.assert_not_called()
+        claimer.fail_job.assert_not_called()
+
+    def test_claim_dispatch_complete(self):
+        claimer = MagicMock()
+        claimer.claim_next_job.return_value = _job(metadata={"alias": "a"})
+        seen = {}
+
+        def executor(md):
+            seen.update(md)
+            return {"success": True}
+
+        loop = _loop(claimer, {"add_golden_repo": executor})
+        assert loop._process_one_job() is True
+        assert seen == {"alias": "a"}
+        claimer.complete_job.assert_called_once_with("j1", {"success": True})
+        claimer.fail_job.assert_not_called()
+
+    def test_executor_exception_fails_job(self):
+        claimer = MagicMock()
+        claimer.claim_next_job.return_value = _job()
+
+        def boom(md):
+            raise RuntimeError("kaboom")
+
+        loop = _loop(claimer, {"add_golden_repo": boom})
+        assert loop._process_one_job() is True
+        claimer.complete_job.assert_not_called()
+        args = claimer.fail_job.call_args[0]
+        assert args[0] == "j1"
+        assert "kaboom" in args[1]
+
+    def test_unknown_op_is_failed_not_stranded(self):
+        # Claim filtered to dispatch keys, but defend anyway.
+        claimer = MagicMock()
+        claimer.claim_next_job.return_value = _job(op="mystery")
+        loop = _loop(claimer, {"add_golden_repo": lambda md: None})
+        assert loop._process_one_job() is True
+        claimer.fail_job.assert_called_once()
+
+    def test_claim_restricted_to_dispatch_keys(self):
+        claimer = MagicMock()
+        claimer.claim_next_job.return_value = None
+        loop = _loop(
+            claimer,
+            {"add_golden_repo": lambda md: None, "sync_repository": lambda md: None},
+        )
+        loop._process_one_job()
+        kwargs = claimer.claim_next_job.call_args.kwargs
+        assert kwargs["job_types"] == ["add_golden_repo", "sync_repository"]
+
+
+class TestStopReleasesInflight:
+    def test_stop_releases_in_flight_claim(self):
+        claimer = MagicMock()
+        loop = _loop(claimer, {"add_golden_repo": lambda md: None})
+        loop._in_flight = "j-running"
+        loop.stop()
+        claimer.release_job.assert_called_once_with("j-running")
+
+    def test_stop_no_inflight_no_release(self):
+        claimer = MagicMock()
+        loop = _loop(claimer, {"add_golden_repo": lambda md: None})
+        loop.stop()
+        claimer.release_job.assert_not_called()
+
+
+class TestStartGuards:
+    def test_empty_dispatch_does_not_start(self):
+        claimer = MagicMock()
+        loop = _loop(claimer, {})
+        loop.start()
+        assert loop._thread is None

--- a/tests/unit/server/services/test_memory_governor_admission.py
+++ b/tests/unit/server/services/test_memory_governor_admission.py
@@ -1,0 +1,84 @@
+"""MemoryGovernor.admission_allowed() gate tests.
+
+Drives the governor synchronously via _tick() (start_sampler=False) using the
+injectable FakeMemoryReaders, so cgroup used% and the resulting band are
+deterministic — no real /sys/fs/cgroup or psutil I/O.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.server.services.test_memory_governor_fixtures import (
+    CGROUP_LIMIT_4GB,
+    FakeMemoryReaders,
+    make_gov,
+)
+
+
+@pytest.fixture()
+def MemoryGovernor():  # noqa: N802
+    from code_indexer.server.services.memory_governor import MemoryGovernor as _MG
+
+    return _MG
+
+
+def _gov_at_used_pct(used_pct: float, MemoryGovernor):
+    """Build a governor and tick it once so its band reflects `used_pct`."""
+    limit = CGROUP_LIMIT_4GB
+    current = int(limit * used_pct / 100.0)
+    readers = FakeMemoryReaders(
+        cgroup_v2_max=str(limit), cgroup_v2_current=str(current)
+    )
+    gov = make_gov(readers, MemoryGovernor)
+    gov._tick()
+    return gov
+
+
+class TestAdmissionAllowed:
+    """admission_allowed(max_used_pct) — reactive cgroup-aware gate."""
+
+    def test_blocks_before_first_sample_failsafe(self, MemoryGovernor):
+        """No sample yet (band starts RED, _first_tick True) → never admit."""
+        readers = FakeMemoryReaders(
+            cgroup_v2_max=str(CGROUP_LIMIT_4GB),
+            cgroup_v2_current=str(CGROUP_LIMIT_4GB // 100),  # ~1%, plenty of room
+        )
+        gov = make_gov(readers, MemoryGovernor)  # not ticked yet
+        assert gov._first_tick is True
+        # Even with a very high watermark and tiny usage, fail-safe blocks.
+        assert gov.admission_allowed(99.0) is False
+
+    def test_admits_when_green_and_below_watermark(self, MemoryGovernor):
+        """GREEN band, used% below watermark → admit."""
+        gov = _gov_at_used_pct(25.0, MemoryGovernor)
+        from code_indexer.server.services.memory_governor import MemoryBand
+
+        assert gov.band == MemoryBand.GREEN
+        assert gov.admission_allowed(80.0) is True
+
+    def test_blocks_when_used_at_or_above_watermark(self, MemoryGovernor):
+        """used% >= watermark → block even though band is not RED."""
+        gov = _gov_at_used_pct(72.0, MemoryGovernor)
+        from code_indexer.server.services.memory_governor import MemoryBand
+
+        # 72% is YELLOW (>=70 <85) — not RED, so only the watermark blocks it.
+        assert gov.band == MemoryBand.YELLOW
+        assert gov.admission_allowed(70.0) is False
+        assert gov.admission_allowed(80.0) is True
+
+    def test_blocks_when_band_red_regardless_of_watermark(self, MemoryGovernor):
+        """RED band (>= red_pct) → block even if watermark is above used%."""
+        gov = _gov_at_used_pct(90.0, MemoryGovernor)
+        from code_indexer.server.services.memory_governor import MemoryBand
+
+        assert gov.band == MemoryBand.RED
+        # Watermark above the 90% usage, but RED still blocks (fail-safe).
+        assert gov.admission_allowed(95.0) is False
+
+    def test_watermark_is_percentage_of_cgroup_limit_not_host(self, MemoryGovernor):
+        """The gate uses the cgroup used% basis (self-tuning to memory.max)."""
+        # 4Gi limit, 50% used → GREEN, admit at 80, block at 40.
+        gov = _gov_at_used_pct(50.0, MemoryGovernor)
+        assert gov.admission_allowed(80.0) is True
+        assert gov.admission_allowed(40.0) is False

--- a/tests/unit/server/services/test_pod_pull_work_stealing_roundtrip_bug1424.py
+++ b/tests/unit/server/services/test_pod_pull_work_stealing_roundtrip_bug1424.py
@@ -1,0 +1,257 @@
+"""M1: pod-pull work-stealing full round-trip (PR #1424).
+
+A behavioral in-memory jobs table faithfully evaluates the REAL
+DistributedJobClaimer SQL (claim UPDATE ... RETURNING with job_types/exclude
+filters, update_progress, complete_job) against row dicts -- not a scripted
+MagicMock -- so the test exercises the actual claim/execute/complete seam and
+the dead-node reclaim -> re-claim -> re-execute path a work-stolen index op
+relies on.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from code_indexer.server.services import memory_governor as mg
+from code_indexer.server.services.distributed_job_claimer import (
+    DistributedJobClaimer,
+    _SELECT_COLS,
+)
+from code_indexer.server.services.index_job_claim_loop import IndexJobClaimLoop
+
+
+# Column order the claimer's RETURNING clause uses; parsed once so the fake row
+# tuple stays correct even if the column list is reordered.
+_COLS = [c.strip() for c in _SELECT_COLS.replace("\n", " ").split(",") if c.strip()]
+
+
+def _row_tuple(row: dict):
+    return tuple(row.get(c) for c in _COLS)
+
+
+class _ClaimerJobsTable:
+    """Faithful in-memory evaluator for the claimer statements this test drives."""
+
+    def __init__(self, rows, now):
+        self.rows = rows
+        self.now = now
+
+    def _pending_match(self, job_types, exclude_types):
+        candidates = [
+            r
+            for r in self.rows
+            if r["status"] == "pending" and r["executing_node"] is None
+        ]
+        if job_types is not None:
+            candidates = [r for r in candidates if r["operation_type"] in job_types]
+        if exclude_types is not None:
+            candidates = [
+                r for r in candidates if r["operation_type"] not in exclude_types
+            ]
+        candidates.sort(key=lambda r: r["created_at"])
+        return candidates[0] if candidates else None
+
+    def claim(self, node_id, job_types, exclude_types):
+        row = self._pending_match(job_types, exclude_types)
+        if row is None:
+            return None
+        row["status"] = "running"
+        row["executing_node"] = node_id
+        row["claimed_at"] = self.now
+        row["started_at"] = self.now
+        return _row_tuple(row)
+
+    def _owned(self, job_id, node_id):
+        for r in self.rows:
+            if r["job_id"] == job_id and r["executing_node"] == node_id:
+                return r
+        return None
+
+    def update_progress(self, job_id, node_id, progress, phase, detail):
+        r = self._owned(job_id, node_id)
+        if r is None:
+            return 0
+        r["progress"] = progress
+        if phase is not None:
+            r["current_phase"] = phase
+        if detail is not None:
+            r["phase_detail"] = detail
+        return 1
+
+    def complete(self, job_id, node_id, result_json):
+        r = self._owned(job_id, node_id)
+        if r is None:
+            return 0
+        r["status"] = "completed"
+        r["result"] = result_json
+        r["progress"] = 100
+        return 1
+
+    def fail(self, job_id, node_id, error):
+        r = self._owned(job_id, node_id)
+        if r is None:
+            return 0
+        r["status"] = "failed"
+        r["error"] = error
+        return 1
+
+    def dead_node_reclaim(self, active_nodes):
+        """Simulate JobReconciliationService resetting dead-node running rows."""
+        reclaimed = []
+        for r in self.rows:
+            if r["status"] == "running" and r["executing_node"] not in active_nodes:
+                r["status"] = "pending"
+                r["executing_node"] = None
+                r["started_at"] = None
+                r["claimed_at"] = None
+                reclaimed.append(r["job_id"])
+        return reclaimed
+
+
+def _make_pool(table: _ClaimerJobsTable):
+    cur = MagicMock()
+
+    def _execute(sql, params=()):
+        normalized = " ".join(sql.split())
+        if "SET executing_node = %s" in normalized and "RETURNING" in normalized:
+            node_id = params[0]
+            job_types = None
+            exclude_types = None
+            rest = list(params[1:])
+            if "operation_type = ANY(%s)" in normalized:
+                job_types = set(rest.pop(0))
+            if "operation_type <> ALL(%s)" in normalized:
+                exclude_types = set(rest.pop(0))
+            cur.fetchone.return_value = table.claim(node_id, job_types, exclude_types)
+        elif "SET progress" in normalized and "COALESCE" in normalized:
+            progress, phase, detail, job_id, node_id = params
+            cur.rowcount = table.update_progress(
+                job_id, node_id, progress, phase, detail
+            )
+        elif "status = 'completed'" in normalized:
+            result_json, job_id, node_id = params
+            cur.rowcount = table.complete(job_id, node_id, result_json)
+        elif "status = 'failed'" in normalized:
+            error, job_id, node_id = params
+            cur.rowcount = table.fail(job_id, node_id, error)
+        else:
+            cur.fetchone.return_value = None
+
+    cur.execute.side_effect = _execute
+
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    pool = MagicMock()
+    pool.connection.return_value.__enter__ = MagicMock(return_value=conn)
+    pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+    return pool
+
+
+def _pending_row(job_id, op, metadata, created_at):
+    return {
+        "job_id": job_id,
+        "operation_type": op,
+        "status": "pending",
+        "created_at": created_at,
+        "started_at": None,
+        "completed_at": None,
+        "result": None,
+        "error": None,
+        "progress": 0,
+        "username": "admin",
+        "is_admin": True,
+        "cancelled": False,
+        "repo_alias": metadata.get("alias", "repoA"),
+        "resolution_attempts": 0,
+        "claude_actions": None,
+        "failure_reason": None,
+        "extended_error": None,
+        "language_resolution_status": None,
+        "executing_node": None,
+        "claimed_at": None,
+        "metadata": metadata,
+        "current_phase": None,
+        "phase_detail": None,
+    }
+
+
+class TestPodPullRoundTrip:
+    def teardown_method(self):
+        mg.clear_memory_governor()
+
+    def test_pending_claimed_reconstructed_executed_completed(self):
+        now = datetime.now(timezone.utc)
+        row = _pending_row("j1", "add_golden_repo", {"alias": "repoA"}, now)
+        table = _ClaimerJobsTable([row], now)
+        claimer = DistributedJobClaimer(pool=_make_pool(table), node_id="node-1")
+
+        seen = {}
+
+        def add_executor(metadata, progress_callback):
+            seen.update(metadata)
+            progress_callback(40, phase="index", detail="indexing")
+            return {"success": True, "alias": metadata["alias"]}
+
+        loop = IndexJobClaimLoop(
+            claimer=claimer,
+            dispatch={"add_golden_repo": add_executor},
+            node_id="node-1",
+        )
+
+        assert loop._process_one_job() is True
+
+        # Reconstructed from metadata.
+        assert seen == {"alias": "repoA"}
+        # Row transitioned pending -> completed with the result + progress
+        # written mid-flight to the SHARED row.
+        assert row["status"] == "completed"
+        assert row["result"] == '{"success": true, "alias": "repoA"}'
+        assert row["current_phase"] == "index"
+        assert row["progress"] == 100  # complete_job sets 100 last
+
+    def test_leader_exclude_and_loop_include_are_disjoint(self):
+        now = datetime.now(timezone.utc)
+        row = _pending_row("j1", "add_golden_repo", {"alias": "repoA"}, now)
+        table = _ClaimerJobsTable([row], now)
+        claimer = DistributedJobClaimer(pool=_make_pool(table), node_id="leader")
+
+        # The leader worker excludes pod-pull ops: it must NOT claim this row.
+        from code_indexer.server.repositories.background_jobs import POD_PULL_OPS
+
+        claimed = claimer.claim_next_job(exclude_types=sorted(POD_PULL_OPS))
+        assert claimed is None
+        assert row["status"] == "pending"
+
+    def test_dead_node_reclaim_then_reexecute(self):
+        now = datetime.now(timezone.utc) - timedelta(hours=1)
+        row = _pending_row("j1", "add_golden_repo", {"alias": "repoA"}, now)
+        # Row was claimed by a since-dead node.
+        row["status"] = "running"
+        row["executing_node"] = "dead-node"
+        row["claimed_at"] = now
+        table = _ClaimerJobsTable([row], datetime.now(timezone.utc))
+
+        # Reconciliation resets the dead node's running row back to pending.
+        assert table.dead_node_reclaim(active_nodes=["node-2"]) == ["j1"]
+        assert row["status"] == "pending"
+        assert row["executing_node"] is None
+
+        # A live node's loop now re-claims and completes it.
+        claimer = DistributedJobClaimer(pool=_make_pool(table), node_id="node-2")
+        ran = []
+
+        def _dispatch(md, pc):
+            ran.append(md)
+            return {"ok": True}
+
+        loop = IndexJobClaimLoop(
+            claimer=claimer,
+            dispatch={"add_golden_repo": _dispatch},
+            node_id="node-2",
+        )
+        assert loop._process_one_job() is True
+        assert ran == [{"alias": "repoA"}]
+        assert row["status"] == "completed"
+        assert row["executing_node"] == "node-2"

--- a/tests/unit/server/test_sync_progress_webhook_callback.py
+++ b/tests/unit/server/test_sync_progress_webhook_callback.py
@@ -1,0 +1,49 @@
+"""build_sync_progress_webhook_callback: reusable sync progress webhook (H2).
+
+PR #1424 H2: a work-stolen sync runs on the claiming node, so its webhook (URL
+supplied by the client, carried in job metadata options.progress_webhook) must
+be rebuilt and pushed from THAT node. This shared builder is used by both the
+local sync path (inline_repos) and the executing node (lifespan pod-pull
+dispatch) so the webhook-POST logic lives in ONE place.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from code_indexer.server.app_helpers import build_sync_progress_webhook_callback
+
+# Single injected constant: a non-routable stand-in endpoint. requests.post is
+# always patched, so this value is never dialed -- it only exercises the
+# payload/routing logic.
+WEBHOOK_URL = "https://example.invalid/hook"
+
+
+class TestBuildSyncProgressWebhookCallback:
+    def test_returns_none_without_url(self):
+        assert build_sync_progress_webhook_callback(None, "repoA", "alice") is None
+        assert build_sync_progress_webhook_callback("", "repoA", "alice") is None
+
+    def test_returns_callable_that_posts_payload(self):
+        cb = build_sync_progress_webhook_callback(WEBHOOK_URL, "repoA", "alice")
+        assert callable(cb)
+
+        with patch("code_indexer.server.app_helpers.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(ok=True, status_code=200)
+            cb(42)
+
+        assert mock_post.call_count == 1
+        args, kwargs = mock_post.call_args
+        assert args[0] == WEBHOOK_URL
+        payload = kwargs["json"]
+        assert payload["repository_id"] == "repoA"
+        assert payload["progress"] == 42
+        assert payload["username"] == "alice"
+        assert "timestamp" in payload
+
+    def test_swallows_post_errors(self):
+        cb = build_sync_progress_webhook_callback(WEBHOOK_URL, "repoA", "alice")
+        with patch(
+            "code_indexer.server.app_helpers.requests.post",
+            side_effect=RuntimeError("boom"),
+        ):
+            # Must not raise -- a webhook failure never interrupts the sync.
+            cb(10)


### PR DESCRIPTION
## Summary

In cluster mode (`storage_mode=postgres`), the per-node `BackgroundJobManager` pool runs every heavy index job (`add_golden_repo`, provider index, `sync_repository`, `change_branch`) with **no resource awareness**, so bulk golden-repo indexing can fire `pool_size` concurrent HNSW + FTS + embedding builds and OOM the node. And each such job is **pinned** to the node whose API call created it, so an idle node can't help a saturated one.

This PR adds two small, composable pieces:

### 1. Memory-aware admission
A pool worker consults the cgroup-aware `MemoryGovernor` (`admission_allowed`) before starting a memory-heavy op; under pressure it **re-queues the job onto its own lane** (stays `PENDING`) and backs off instead of running it and risking an OOM. The watermark is a **percentage of the process's own cgroup limit**, so it self-tunes to any `memory.max`. Fail-open (no governor / gate disabled / cheap op). New `BackgroundJobsConfig` knobs: `job_admission_memory_gate_enabled`, `job_admission_memory_max_used_pct` (default 80), `job_admission_backoff_seconds`. A rate-limited breadcrumb makes the throttle observable.

### 2. Pod-pull work-stealing
In cluster mode a heavy op is registered `PENDING` in the shared `background_jobs` queue with its reconstruction params in the row's `metadata` JSONB, and is **not** dispatched to the local pool. A new always-on `IndexJobClaimLoop` on **every** node claims those rows via the memory-gated `DistributedJobClaimer` (`claim_next_job` gains `job_types` / `exclude_types` filters) and executes them by reconstructing from `metadata` — so any node with headroom drains the shared queue. The leader `DistributedJobWorkerService` now excludes those ops so the two claim loops target disjoint rows.

`add_golden_repo`'s worker body is extracted verbatim into a reusable `execute_add_golden_repo_work()`; the other ops reuse existing functions/methods. **No schema migration** (`metadata`/`executing_node`/`claimed_at` already exist). Solo / non-cluster paths are unchanged.

## Safety
Retry-safe: dead-node reclaim resets claimed rows to `pending`; `complete`/`fail`/`release` are ownership-scoped; each op is idempotent (`change_branch` acquires its write-lock non-blocking → fails-retryable, never deadlocks). The admission gate is guarded on `metadata` being present so a not-yet-migrated submit path falls back to the local pool.

## Validation
Exercised on a 2-node cluster: bulk golden-repo indexing that previously OOMed the node now stays **memory-safe (0 OOMs)**, and the queued backlog **drains balanced across both nodes** (the claim loop executes on each). New unit tests cover the admission gate, the claimer metadata + filters, the pod-pull submit routing, and the claim-loop dispatch/fail/release. `ruff` + `black` + `mypy` clean.